### PR TITLE
ci: close guard-completeness bypasses and gate every workflow

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,40 @@
+# Branch protection (rulesets as code)
+
+`main-branch-protection.json` is the branch-protection ruleset for `main`, kept in the repo so the required-checks policy is reviewable and version-controlled instead of living only in the GitHub UI.
+
+## Canonical required status checks
+
+Exactly four checks must pass before a PR can merge to `main`:
+
+| Check | Workflow | Rolls up |
+|-------|----------|----------|
+| `CI gate` | `ci.yml` | every fast-lane + heavy job in the core CI workflow |
+| `Python gate` | `python.yml` | the wheel matrix and its stub / smoke / nogil / freethreaded jobs |
+| `TypeScript gate` | `typescript.yml` | the napi build + test + publish jobs |
+| `Perf gate` | `perf-gate.yml` | the decode-allocations regression gate |
+
+Each of the four is an `if: always()` aggregator that depends on every job in its workflow and fails unless every dependency finished `success` or `skipped`. Requiring the four aggregators — instead of a hand-maintained list of individual job names — means two things stay true automatically:
+
+- A heavy job that legitimately skips on a path-irrelevant PR (e.g. the Python wheel matrix on a docs-only change) counts as a pass, so a conditionally-skipped check can never leave the merge gate permanently unsatisfiable.
+- A newly added job is covered the moment it lands in its workflow's aggregator `needs:` list — no ruleset edit, and no risk of a new job silently escaping the gate.
+
+Do not require the individual jobs (`fmt`, `clippy`, `Build wheel (...)`, etc.) directly. They are covered transitively by the aggregators, and pinning them by name reintroduces the skip-counts-as-unsatisfiable problem the aggregators exist to solve.
+
+## Applying it
+
+Importing or updating a ruleset is a repo-admin action on GitHub; it cannot be done from a PR. To apply this file:
+
+- GitHub UI: **Settings -> Rules -> Rulesets -> New ruleset -> Import a ruleset**, then select this JSON.
+- Or with the API:
+
+  ```bash
+  gh api -X POST repos/userFRM/ThetaDataDx/rulesets --input .github/rulesets/main-branch-protection.json
+  ```
+
+  To update an existing ruleset, `PUT repos/userFRM/ThetaDataDx/rulesets/<id>` with the same body.
+
+After applying, confirm the four contexts above are listed under the ruleset's required status checks, and that the previous single-check requirement (`CI gate` only) is replaced by all four.
+
+## Keeping this file honest
+
+The check names here must match the aggregator job `name:` values in the workflows (`CI gate`, `Python gate`, `TypeScript gate`, `Perf gate`). If an aggregator is renamed, update both the workflow and this file, then re-import.

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,42 @@
+{
+  "name": "main branch protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "CI gate" },
+          { "context": "Python gate" },
+          { "context": "TypeScript gate" },
+          { "context": "Perf gate" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
       # The cross-platform FFI builds live in the heavy lane; the fast
       # lane builds the Linux .so this gate needs and nothing more.
       - run: cargo build -p thetadatadx-ffi --release --locked
+      - run: python3 scripts/ci/check_c_abi_completeness.py --selftest
       - run: python3 scripts/ci/check_c_abi_completeness.py
 
   binding-parity:
@@ -278,6 +279,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - run: python3 scripts/ci/check_docs_consistency.py --selftest
       - run: python3 scripts/ci/check_docs_consistency.py
 
   version-sync:
@@ -289,7 +291,41 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - run: python3 scripts/ci/check_version_sync.py --selftest
       - run: python3 scripts/ci/check_version_sync.py
+
+  # Pure-Python script gates split out of the heavy `surfaces` job so they
+  # run on EVERY PR — including a docs-only PR that skips the rust-gated
+  # `surfaces` job. While they lived only in `surfaces`, a path-irrelevant
+  # PR skipped them, and the aggregate gate counts a skip as a pass, so
+  # cross-lockfile drift / endpoint-agreement regressions could merge
+  # untested. Neither needs cargo or node, so they belong in the fast lane
+  # alongside docs-consistency / version-sync.
+  lockfile-drift:
+    name: Lockfile drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      # Cross-Cargo.lock dependency-version drift on security-critical
+      # (rustls, tokio, h2, reqwest, hyper) and SDK-owned (thetadatadx)
+      # deps. A workspace bump must land in every binding lockfile or the
+      # wheel / npm package ships a stale runtime.
+      - run: python3 scripts/ci/check_lockfile_drift.py
+
+  agreement:
+    name: Endpoint agreement
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python3 scripts/ci/tests/test_check_agreement.py
 
   cargo-deny:
     name: Cargo deny
@@ -556,12 +592,12 @@ jobs:
           node-version: "20"
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
-      # Cross-Cargo.lock dependency-version drift on security-critical
-      # (rustls, tokio, h2, reqwest, hyper) and SDK-owned (thetadatadx)
-      # deps. A workspace bump must land in every binding lockfile or the
-      # wheel / npm package ships a stale runtime.
-      - run: python3 scripts/ci/check_lockfile_drift.py
-      - run: python3 scripts/ci/tests/test_check_agreement.py
+      # NOTE: `check_lockfile_drift.py` and `test_check_agreement.py` ran
+      # here historically, but they are pure-Python gates that must run on
+      # EVERY PR (a docs-only PR skips this rust-gated heavy job). They now
+      # live in the standalone `lockfile-drift` / `agreement` fast-lane
+      # jobs above, both wired into `ci-gate`. Kept out of this job to
+      # avoid running them twice.
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - run: cargo run -p thetadatadx --features config-file,__internal --bin generate_docs_site --locked -- --check
       - run: cargo check --manifest-path tools/mcp/Cargo.toml --locked
@@ -818,6 +854,8 @@ jobs:
       - no-re-framing
       - docs-consistency
       - version-sync
+      - lockfile-drift
+      - agreement
       - cargo-deny
       - lint-matrix
       - test

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -101,3 +101,49 @@ jobs:
         # tight; the floor keeps the gate meaningful if a baseline ever
         # approaches zero allocations per row.
         run: python3 scripts/ci/check_perf_gate.py --threshold 10
+
+  # ═══════════════════════════════════════════════════════════════
+  # AGGREGATOR GATE. A single roll-up status summarizing every job in
+  # this workflow, mirroring `ci.yml`'s `ci-gate`. It runs with
+  # `if: always()`, depends on every other job, and fails unless every
+  # dependency finished `success` or `skipped`. The bench job
+  # legitimately skips on a path-irrelevant PR (it counts as a pass); a
+  # real `failure` or `cancelled` fails the gate. This is the one
+  # perf-lane check branch protection should require — requiring it
+  # (instead of a per-job name) keeps a conditionally-skipped required
+  # check from leaving the merge gate permanently unsatisfiable, and a
+  # newly added job is covered the moment it appears in `needs` below.
+  # ═══════════════════════════════════════════════════════════════
+  perf-gate:
+    name: Perf gate
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - changes
+      - decode-allocations
+    steps:
+      - name: Fail unless every dependency succeeded or was skipped
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          bad = sorted(
+              name
+              for name, data in needs.items()
+              if data.get("result") not in ("success", "skipped")
+          )
+          for name in sorted(needs):
+              print(f"{name}: {needs[name].get('result')}")
+          if bad:
+              joined = ", ".join(bad)
+              sys.exit(f"Perf gate failed: {joined} did not succeed or skip")
+          print("Perf gate passed: every dependency succeeded or was skipped")
+          PY

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -455,3 +455,57 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+
+  # ═══════════════════════════════════════════════════════════════
+  # AGGREGATOR GATE. A single roll-up status summarizing every job in
+  # this workflow, mirroring `ci.yml`'s `ci-gate`. It runs with
+  # `if: always()`, depends on every other job, and fails unless every
+  # dependency finished `success` or `skipped`. A heavy job that
+  # legitimately skips on a path-irrelevant PR (the whole matrix skips
+  # when `build` skips) counts as a pass; a real `failure` or
+  # `cancelled` fails the gate. This is the one Python-lane check branch
+  # protection should require — requiring it (instead of a hand-kept
+  # list of per-job names) keeps a conditionally-skipped required check
+  # from leaving the merge gate permanently unsatisfiable, and a newly
+  # added job is covered the moment it appears in `needs` below.
+  # ═══════════════════════════════════════════════════════════════
+  python-gate:
+    name: Python gate
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - changes
+      - build
+      - stubtest
+      - fresh-install-smoke
+      - nogil-throughput
+      - compatibility
+      - freethreaded
+      - sdist
+      - publish
+    steps:
+      - name: Fail unless every dependency succeeded or was skipped
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          bad = sorted(
+              name
+              for name, data in needs.items()
+              if data.get("result") not in ("success", "skipped")
+          )
+          for name in sorted(needs):
+              print(f"{name}: {needs[name].get('result')}")
+          if bad:
+              joined = ", ".join(bad)
+              sys.exit(f"Python gate failed: {joined} did not succeed or skip")
+          print("Python gate passed: every dependency succeeded or was skipped")
+          PY

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -240,3 +240,51 @@ jobs:
             case "$pkg_version" in *-*) dist_tag=next;; esac
             npm publish --provenance --access public --tag "$dist_tag"
           fi
+
+  # ═══════════════════════════════════════════════════════════════
+  # AGGREGATOR GATE. A single roll-up status summarizing every job in
+  # this workflow, mirroring `ci.yml`'s `ci-gate`. It runs with
+  # `if: always()`, depends on every other job, and fails unless every
+  # dependency finished `success` or `skipped`. A heavy job that
+  # legitimately skips on a path-irrelevant PR counts as a pass; a real
+  # `failure` or `cancelled` fails the gate. This is the one
+  # TypeScript-lane check branch protection should require — requiring it
+  # (instead of a hand-kept list of per-job names) keeps a
+  # conditionally-skipped required check from leaving the merge gate
+  # permanently unsatisfiable, and a newly added job is covered the
+  # moment it appears in `needs` below.
+  # ═══════════════════════════════════════════════════════════════
+  typescript-gate:
+    name: TypeScript gate
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - changes
+      - build
+      - publish
+    steps:
+      - name: Fail unless every dependency succeeded or was skipped
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          bad = sorted(
+              name
+              for name, data in needs.items()
+              if data.get("result") not in ("success", "skipped")
+          )
+          for name in sorted(needs):
+              print(f"{name}: {needs[name].get('result')}")
+          if bad:
+              joined = ", ".join(bad)
+              sys.exit(f"TypeScript gate failed: {joined} did not succeed or skip")
+          print("TypeScript gate passed: every dependency succeeded or was skipped")
+          PY

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -23,14 +23,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.1"
+thetadatadx = "13.0.0-rc.5"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.1", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.5", features = ["polars"] }
 ```
 
 ## Quick start

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -44,7 +44,10 @@ def _test(name: str) -> list[list[str]]:
 # pre-pass where the gate has one, plus the production invocation with
 # the same thresholds CI uses). `all` runs them in this dict's order.
 GATES: dict[str, list[list[str]]] = {
-    "c_abi_completeness": _ci("check_c_abi_completeness"),
+    "c_abi_completeness": (
+        _ci("check_c_abi_completeness", "--selftest")
+        + _ci("check_c_abi_completeness")
+    ),
     "binding_parity": (
         _ci("check_binding_parity", "--selftest")
         + _test("test_check_binding_parity")
@@ -69,8 +72,13 @@ GATES: dict[str, list[list[str]]] = {
         + _ci("check_bench_regression", "--threshold", "25")
     ),
     "perf_gate": _ci("check_perf_gate", "--threshold", "10"),
-    "docs_consistency": _ci("check_docs_consistency"),
-    "version_sync": _ci("check_version_sync"),
+    "docs_consistency": (
+        _ci("check_docs_consistency", "--selftest")
+        + _ci("check_docs_consistency")
+    ),
+    "version_sync": (
+        _ci("check_version_sync", "--selftest") + _ci("check_version_sync")
+    ),
     "lockfile_drift": _ci("check_lockfile_drift"),
     "tier_badges": _ci("check_tier_badges"),
     "agreement": _test("test_check_agreement"),

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -413,6 +413,80 @@ def _read_source(path: pathlib.Path) -> str:
     return _strip_js_comments(path.read_text(encoding="utf-8"))
 
 
+# napi attribute argument lists can contain a callback type with its own
+# parentheses, e.g.
+#   #[napi(ts_args_type = "cb: (e: Event) => void", js_name = "setCallback")]
+# The `#[napi(` ... `)]` argument list therefore is NOT
+# parenthesis-free, so the historical `#[napi(...[^)]*...)]` collectors
+# stopped at the FIRST inner `)` (inside `(e: Event)`) and never reached
+# the trailing `js_name`, silently reading a callback-typed method as
+# ABSENT. The helper below scans the attribute argument list with a paren
+# balance counter (respecting string literals) so the full inner content
+# — across any nested `(...)` — is returned for sub-matching.
+_NAPI_ATTR_START_RE = re.compile(r"#\[\s*napi\b")
+
+
+def _iter_napi_attrs(text: str):
+    """Yield `(inner, after)` for every `#[napi ...]` attribute in `text`.
+
+    `inner` is the argument list between the `(` after `napi` and its
+    balanced closing `)` (empty string for the bare `#[napi]` form with no
+    args). `after` is the index just past the attribute's closing `]`, so a
+    caller can resume scanning for the `fn <name>` that the attribute
+    decorates. The paren/bracket walk respects `"..."` string literals
+    (with `\\` escapes), so a `)` or `]` inside a `ts_args_type` /
+    `ts_return_type` string does not terminate the span early.
+    """
+    n = len(text)
+    for m in _NAPI_ATTR_START_RE.finditer(text):
+        i = m.end()
+        # Skip whitespace between `napi` and an optional `(`.
+        j = i
+        while j < n and text[j].isspace():
+            j += 1
+        inner = ""
+        if j < n and text[j] == "(":
+            # Walk to the balanced `)`, tracking string literals.
+            depth = 0
+            k = j
+            in_str = False
+            esc = False
+            start_inner = j + 1
+            while k < n:
+                c = text[k]
+                if in_str:
+                    if esc:
+                        esc = False
+                    elif c == "\\":
+                        esc = True
+                    elif c == '"':
+                        in_str = False
+                elif c == '"':
+                    in_str = True
+                elif c == "(":
+                    depth += 1
+                elif c == ")":
+                    depth -= 1
+                    if depth == 0:
+                        inner = text[start_inner:k]
+                        k += 1
+                        break
+                k += 1
+            else:
+                # Unbalanced (malformed source) — skip this attribute.
+                continue
+            pos = k
+        else:
+            pos = j
+        # Advance to the attribute's closing `]` (also string-aware so a
+        # `]` inside a string literal in the args does not fool us; we
+        # already consumed the args, so this only spans `)]` / `]`).
+        while pos < n and text[pos] != "]":
+            pos += 1
+        after = pos + 1 if pos < n else n
+        yield inner, after
+
+
 def _read_cpp_expanded(cpp_hpp: pathlib.Path) -> str:
     """Read a C++ wrapper header, inline its `.inc` includes, and strip
     comments from the combined text.
@@ -984,11 +1058,13 @@ def _collect_typescript_setters(ts_src: pathlib.Path) -> set[str]:
         # `thetadatadx_config_set_*` C ABI surface.
         for body in _iter_impl_config_bodies(text):
             # `#[napi(js_name = "setX")]` → setter `X` (drop the `set` prefix).
-            for m in re.finditer(
-                r'#\[napi\([^)]*\bjs_name\s*=\s*"set([A-Z]\w*)"[^)]*\)\]',
-                body,
-            ):
-                setters_camel.add(m.group(1))
+            # Scan the balanced attribute arg list so a callback-typed
+            # method (`ts_args_type = "cb: (e) => void", js_name = "setX"`)
+            # is still seen — the old `[^)]*` stopped at the inner `)`.
+            for inner, _ in _iter_napi_attrs(body):
+                m = re.search(r'\bjs_name\s*=\s*"set([A-Z]\w*)"', inner)
+                if m:
+                    setters_camel.add(m.group(1))
     # Lift to snake_case for parity-row matching. Every camelCase
     # name renders to one or more snake-case candidates (the bare
     # snake form plus any compound-word alias rendering); the gate
@@ -1117,11 +1193,16 @@ def _collect_typescript_getters(ts_src: pathlib.Path) -> set[str]:
     for rs in ts_src.rglob("*.rs"):
         text = _read_source(rs)
         for body in _iter_impl_config_bodies(text):
-            for m in re.finditer(
-                r'#\[napi\([^)]*\bgetter\b[^)]*\bjs_name\s*=\s*"([a-zA-Z_]\w*)"[^)]*\)\]',
-                body,
-            ):
-                getters_camel.add(m.group(1))
+            # A getter is `#[napi(getter, js_name = "<X>")]` in either
+            # attribute order. Scan the balanced arg list and require both
+            # the `getter` flag and a `js_name` to be present, so order is
+            # irrelevant and a callback-typed arg cannot truncate the scan.
+            for inner, _ in _iter_napi_attrs(body):
+                if not re.search(r"\bgetter\b", inner):
+                    continue
+                m = re.search(r'\bjs_name\s*=\s*"([a-zA-Z_]\w*)"', inner)
+                if m:
+                    getters_camel.add(m.group(1))
     getters_snake: set[str] = set()
     for name in getters_camel:
         getters_snake.update(_camel_to_snake_with_aliases(name))
@@ -1796,13 +1877,17 @@ def _collect_typescript_class_methods(
     impl_re = re.compile(
         r"impl\s+(?:[A-Za-z_][A-Za-z0-9_]*::)*([A-Za-z_][A-Za-z0-9_]*)\s*\{"
     )
-    js_name_re = re.compile(
-        r'#\[napi\([^)]*\bjs_name\s*=\s*"([a-zA-Z_][a-zA-Z0-9_]*)"[^)]*\)\]\s*'
-        r'(?:pub\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]'
-    )
-    bare_napi_re = re.compile(
-        r'#\[napi(?:\((?:(?!js_name)[^)])*\))?\]\s*'
-        r'(?:pub\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]'
+    # The `js_name` literal inside a napi attribute arg list, and the
+    # `fn <snake>` that the attribute decorates (allowing intervening outer
+    # attributes / doc comments between the `#[napi(...)]` and the `fn`).
+    js_name_in_attr_re = re.compile(r'\bjs_name\s*=\s*"([a-zA-Z_][a-zA-Z0-9_]*)"')
+    # `.match(body, after)` anchors at `after`, so no `\A`/`^` is needed
+    # (and `\A` would WRONGLY anchor at string start, never matching when
+    # `after > 0`). Tolerates intervening outer attributes / doc comments
+    # between the `#[napi(...)]` and the decorated `fn`.
+    following_fn_re = re.compile(
+        r"(?:\s*(?:#\[[^\]]*\]|///[^\n]*|//[^\n]*))*\s*"
+        r"(?:pub\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]"
     )
     for rs in ts_src.rglob("*.rs"):
         text = _read_source(rs)
@@ -1821,14 +1906,24 @@ def _collect_typescript_class_methods(
                     depth -= 1
                 i += 1
             body = text[body_start : i - 1]
-            for m in js_name_re.finditer(body):
-                out.setdefault(class_name, set()).add(m.group(1))
-            for m in bare_napi_re.finditer(body):
-                snake = m.group(1)
-                head, *rest = snake.split("_")
-                camel = head + "".join(p.capitalize() for p in rest)
-                out.setdefault(class_name, set()).add(camel)
-                out.setdefault(class_name, set()).add(snake)
+            # Balanced-paren attribute scan: a callback-typed arg list
+            # (`ts_args_type = "cb: (e) => void", js_name = "setX"`) no
+            # longer truncates the `js_name` read at the inner `)`.
+            for inner, after in _iter_napi_attrs(body):
+                fn_m = following_fn_re.match(body, after)
+                if not fn_m:
+                    # The `#[napi(...)]` does not decorate a fn (e.g. a
+                    # struct attribute) — nothing to record from this site.
+                    continue
+                js_m = js_name_in_attr_re.search(inner)
+                if js_m:
+                    out.setdefault(class_name, set()).add(js_m.group(1))
+                else:
+                    snake = fn_m.group(1)
+                    head, *rest = snake.split("_")
+                    camel = head + "".join(p.capitalize() for p in rest)
+                    out.setdefault(class_name, set()).add(camel)
+                    out.setdefault(class_name, set()).add(snake)
     if ts_pkg_dir is not None:
         for cls, methods in _collect_ts_wrapper_class_methods(ts_pkg_dir).items():
             out.setdefault(cls, set()).update(methods)
@@ -1906,10 +2001,22 @@ def _collect_cpp_class_methods(cpp_hpp: pathlib.Path) -> dict[str, set[str]]:
     """Return `{class_name: {method, ...}}` for every C++ class.
 
     Parses each `class X { ... };` body in `thetadatadx.hpp` and collects
-    every member declaration with a `name(` shape. The first identifier
-    before the `(` is the method name. Bounded brace-counting keeps
-    nested types (e.g. lambdas inside default-arg initializers) from
-    leaking into the outer class's method set.
+    every member *declaration* with a `<return-type> name(` shape. Bounded
+    brace-counting keeps nested types (e.g. lambdas inside default-arg
+    initializers) from leaking into the outer class's method set.
+
+    A member declaration is in DECLARATION position: the method name is
+    immediately preceded by a return-type token (an identifier ending the
+    return type, or a `>` / `*` / `&` / `]` from a templated, pointer,
+    reference, or array return). A bare `name(` CALL inside another inline
+    method body — e.g. `return request(...)` in a convenience accessor, or
+    a statement-leading `helper();` — is NOT in declaration position and is
+    rejected. Counting such call sites let a method *declaration* be
+    deleted while its in-class call sites kept the name alive, so the
+    parity gate read the binding as still exposing a method it no longer
+    declared (the G11 bypass). This mirrors `_collect_cpp_setters`, which
+    already keys on the `void` / `int32_t` return type so a bare call
+    cannot satisfy it.
 
     Honors `#include "<file>.inc"` inside a class body by inlining the
     included file's contents before parsing — generator-emitted method
@@ -1923,6 +2030,54 @@ def _collect_cpp_class_methods(cpp_hpp: pathlib.Path) -> dict[str, set[str]]:
     # Limit to class bodies — struct bodies are POD-shaped value types
     # and irrelevant to the cross-binding method contract.
     class_header_re = re.compile(r"^class\s+(\w+)\s*(?::[^{]*)?\{", re.MULTILINE)
+    # A member declaration: a return-type token (`prev`), then whitespace,
+    # then the method `name(`. `prev` is captured so a control keyword that
+    # can front a CALL (`return foo(`) is rejected — a real return type is
+    # never one of those keywords. The leading return-type token is what
+    # separates `FlatFileRowList request(` (declaration) from
+    # `return request(` and the statement-leading `request(` (calls).
+    decl_re = re.compile(
+        r"(?P<prev>[A-Za-z_]\w*|[>*&\]])\s+(?P<name>[a-z_][a-z0-9_]*)\s*\(",
+    )
+    # Keywords that can precede a `name(` as a CALL or statement, never as
+    # a return type. `return foo(` is the live G11 mask; the rest guard the
+    # general class (`else if (`, `co_return bar(`, etc.).
+    _CALL_PREV_KEYWORDS = {
+        "return",
+        "co_return",
+        "co_await",
+        "if",
+        "while",
+        "for",
+        "switch",
+        "throw",
+        "catch",
+        "sizeof",
+        "new",
+        "delete",
+        "and",
+        "or",
+        "not",
+    }
+    # Method names that are themselves keywords (defensive; a declaration
+    # never names a method these).
+    _NAME_KEYWORDS = {
+        "if",
+        "while",
+        "for",
+        "switch",
+        "return",
+        "throw",
+        "catch",
+        "sizeof",
+        "operator",
+        "new",
+        "delete",
+        "static_cast",
+        "reinterpret_cast",
+        "const_cast",
+        "dynamic_cast",
+    }
     for header in class_header_re.finditer(text):
         class_name = header.group(1)
         body_start = header.end()
@@ -1936,34 +2091,16 @@ def _collect_cpp_class_methods(cpp_hpp: pathlib.Path) -> dict[str, set[str]]:
                 depth -= 1
             i += 1
         body = text[body_start : i - 1]
-        # Match member declarations + definitions. The `name(` pattern is
-        # preceded by whitespace and (optionally) qualifiers / return
-        # type tokens; the first plain identifier immediately before the
-        # opening paren is the method name.
-        for fm in re.finditer(
-            r"(?:^|\s)([a-z_][a-z0-9_]*)\s*\(",
-            body,
-            re.MULTILINE,
-        ):
-            name = fm.group(1)
-            # Filter language keywords that look like method calls.
-            if name in {
-                "if",
-                "while",
-                "for",
-                "switch",
-                "return",
-                "throw",
-                "catch",
-                "sizeof",
-                "operator",
-                "new",
-                "delete",
-                "static_cast",
-                "reinterpret_cast",
-                "const_cast",
-                "dynamic_cast",
-            }:
+        for fm in decl_re.finditer(body):
+            prev = fm.group("prev")
+            name = fm.group("name")
+            # The preceding token must be a return type, not a call-context
+            # keyword. `request` declared as `FlatFileRowList request(`
+            # passes (`prev == "FlatFileRowList"`); the `return request(`
+            # call is rejected (`prev == "return"`).
+            if prev in _CALL_PREV_KEYWORDS:
+                continue
+            if name in _NAME_KEYWORDS:
                 continue
             out.setdefault(class_name, set()).add(name)
     return out
@@ -2683,10 +2820,13 @@ def _collect_typescript_utility_functions(ts_src: pathlib.Path) -> set[str]:
     # trailing `// ...` line comment), then `pub fn <name>`. The generated
     # calculator carries a `#[allow(clippy::too_many_arguments)] // Reason:
     # ...` line between the napi attribute and the fn, so the gap tolerates
-    # further `#[...]` / `///` / `//` runs.
-    free_fn_re = re.compile(
-        r"#\[napi(?:\([^)]*\))?\]\s*"
-        r"(?:(?:#\[[^\]]*\]|//[^\n]*)\s*)*"
+    # further `#[...]` / `///` / `//` runs. The attribute arg list is
+    # consumed with the balanced-paren scanner so a callback-typed arg
+    # (`ts_args_type = "cb: (e) => void"`) cannot truncate the match.
+    # `.match(body, after)` anchors at `after`; no `\A`/`^` (which would
+    # anchor at string start and never match when `after > 0`).
+    following_fn_re = re.compile(
+        r"(?:\s*(?:#\[[^\]]*\]|///[^\n]*|//[^\n]*))*\s*"
         r"(?:pub\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]"
     )
     for rs in ts_src.rglob("*.rs"):
@@ -2716,8 +2856,10 @@ def _collect_typescript_utility_functions(ts_src: pathlib.Path) -> set[str]:
                 j += 1
             i = j
         body = "".join(cleaned)
-        for fm in free_fn_re.finditer(body):
-            out.add(fm.group(1))
+        for _inner, after in _iter_napi_attrs(body):
+            fn_m = following_fn_re.match(body, after)
+            if fn_m:
+                out.add(fn_m.group(1))
     return out
 
 

--- a/scripts/ci/check_c_abi_completeness.py
+++ b/scripts/ci/check_c_abi_completeness.py
@@ -72,38 +72,110 @@ _SO_NAMES = ("libthetadatadx_ffi.so", "libthetadatadx_ffi.dylib")
 # `nm`.
 EXTERN_RE = re.compile(r'extern\s+"C"\s+fn\s+(thetadatadx_\w+)')
 SYMBOL_RE = re.compile(r"\bthetadatadx_\w+\b")
-# A header symbol counts as DECLARED only when it appears as a function
-# declaration — the symbol name immediately followed (modulo whitespace)
-# by an opening parenthesis. A bare mention in a comment or a prose
-# wildcard like `thetadatadx_exchange_*` is NOT a declaration and must
-# not satisfy the forward `rust - header` check; counting it let a
-# genuinely-missing decl masquerade as present (the very gap the
-# `thetadatadx_exchange_` allow-list entry was a workaround for).
-HEADER_DECL_RE = re.compile(r"\b(thetadatadx_\w+)\s*\(")
-# C / C++ comment strippers. Run before the declaration scan so a
-# function name surviving only inside a comment cannot read as declared.
-# (Both directions benefit: a commented-out prototype neither satisfies
-# `rust - header` nor trips `header - rust`.) String-literal contents are
-# not stripped, which is harmless here: the scanned names are bare C
-# identifiers in declaration position, never string payloads.
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+# A header symbol counts as DECLARED only when it appears in C function
+# *declaration position*: the symbol name preceded by a return-type token
+# (an identifier, a `*`/`&` pointer-or-reference marker, a closing `>`
+# from a templated/typedef'd return, or an `extern` linkage keyword) and
+# immediately followed (modulo whitespace) by `(`. A bare mention in a
+# comment or a prose wildcard like `thetadatadx_exchange_*` is NOT a
+# declaration, and — crucially — neither is a *call site* such as
+# `const char* err = thetadatadx_last_error();` or the statement-leading
+# `thetadatadx_string_array_free(arr);` inside a C++ inline body. Counting
+# a call as a declaration let a genuinely-missing C decl masquerade as
+# present: the C++ inline wrappers (`.hpp` / `.hpp.inc`) call every C
+# symbol, so a `thetadatadx_foo(` call in a wrapper body would satisfy the
+# forward `rust - header` check even after the real prototype was deleted
+# from `thetadatadx.h`. The leading return-type requirement is what
+# separates a prototype (`int32_t thetadatadx_foo(`) from a call
+# (`= thetadatadx_foo(` / `return thetadatadx_foo(` / a bare statement).
+#
+# The token immediately before the symbol must be a return-type fragment.
+# Tokens that can only precede a *call* — `=`, `.`, `->`, `return`, `,`,
+# `(`, `&&`, `||`, `!`, `?`, `:` — are excluded via a negative lookbehind
+# group, and a statement-leading call (nothing but `;`/`{`/`}`/start before
+# the name) is excluded by requiring a preceding type token on the line.
+_DECL_PREFIX = (
+    # A return-type token: a C identifier (`void`, `int32_t`,
+    # `ThetaDataDxClient`), optionally trailed by pointer/reference markers
+    # and whitespace, or a closing `>` (a templated return), or the
+    # `extern` linkage keyword that fronts the `.h.inc` prototypes.
+    r"(?:"
+    r"(?<![A-Za-z0-9_])extern\b[^\n;{}]*?"      # `extern [linkage] <type> `
+    r"|[A-Za-z_][A-Za-z0-9_]*\s*[\*&]*\s+"       # `<ident> ` (return type)
+    r"|[\*&>]\s*"                                  # pointer / templated return
+    r")"
+)
+# Reject the obvious call-context lead-ins that the `<ident>\s+` arm could
+# otherwise match (`return thetadatadx_x(`): a declaration's return type is
+# never the `return` keyword.
+_CALL_LEAD_KEYWORDS = re.compile(r"\b(return|sizeof|case)\s*$")
+HEADER_DECL_RE = re.compile(
+    r"(?P<lead>" + _DECL_PREFIX + r")(?P<name>thetadatadx_\w+)\s*\("
+)
+# Retained for the diagnostic-only fallback path and documentation: the
+# bare `name(` shape with no decl-position guard. Not used by the
+# declaration collector, which requires decl position via HEADER_DECL_RE.
+HEADER_NAME_RE = re.compile(r"\b(thetadatadx_\w+)\s*\(")
+# C / C++ comment AND string-literal strippers. Run before the
+# declaration scan so a function name surviving only inside a comment OR a
+# string literal cannot read as declared. A bare mention in a comment
+# (`// removed thetadatadx_foo()`) and a name inside a string literal
+# (`const char* m = "call thetadatadx_foo()"`) are BOTH non-declarations;
+# counting either let a genuinely-missing prototype masquerade as present
+# (the forward `rust - header` check) and could pollute the reverse
+# `header - rust` delta. The decl-position regex already rejects most call
+# shapes, but a string payload can embed an arbitrary `<word> thetadatadx_x(`
+# fragment that mimics declaration position, so the contents must be
+# removed outright.
+#
+# Comments and string/char literals are stripped in a SINGLE alternation
+# pass: matching them together (rather than comments-then-strings) is what
+# keeps a `//` inside a string (`"http://x"`) from being mis-read as a
+# line comment, and a `"` inside a comment from opening a phantom string.
+# Each construct is replaced with a single space so adjacent tokens do not
+# fuse. Order matters inside the alternation: block comment, line comment,
+# then char, then string — the first match at each position wins.
+_STRIP_RE = re.compile(
+    r"/\*.*?\*/"                 # block comment
+    r"|//[^\n]*"                # line comment
+    r"|'(?:\\.|[^'\\])*'"      # char literal (handles '\'' and '\\')
+    r"|\"(?:\\.|[^\"\\])*\"",  # string literal (handles \" and \\)
+    re.DOTALL,
+)
 
 
 def _strip_c_comments(text: str) -> str:
-    """Remove block (`/* */`) and line (`//`) comments from C/C++ text."""
-    return _LINE_COMMENT_RE.sub("", _BLOCK_COMMENT_RE.sub("", text))
+    """Remove comments AND string/char literals from C/C++ text.
+
+    (Name kept for call-site stability; it now strips string and char
+    literals too — see `_STRIP_RE`.) A name surviving only inside a
+    comment or a string literal must not be collected as a declaration.
+    """
+    return _STRIP_RE.sub(" ", text)
 
 
 def _header_decls_from_text(text: str) -> set[str]:
     """Function-declaration symbols in one header's text.
 
-    Comments are stripped first, then `thetadatadx_<name>(` declaration
-    sites are collected. Factored out so the self-test can exercise the
-    comment-vs-declaration logic on synthetic header text.
+    Comments are stripped first, then `<return-type> thetadatadx_<name>(`
+    declaration sites are collected. A *call site* in a C++ inline body
+    (`= thetadatadx_foo(`, `return thetadatadx_foo(`, the statement-leading
+    `thetadatadx_foo(arg);`) is NOT in declaration position and is
+    rejected, so a wrapper body that calls a C symbol cannot mask a
+    deleted prototype. Factored out so the self-test can exercise the
+    comment-vs-declaration-vs-call logic on synthetic header text.
     """
     stripped = _strip_c_comments(text)
-    return {m.group(1) for m in HEADER_DECL_RE.finditer(stripped)}
+    decls: set[str] = set()
+    for m in HEADER_DECL_RE.finditer(stripped):
+        lead = m.group("lead")
+        # The `<ident>\s+` arm of the prefix would also match
+        # `return thetadatadx_x(`; a real return type is never the
+        # `return` / `sizeof` / `case` keyword. Reject those lead-ins.
+        if _CALL_LEAD_KEYWORDS.search(lead):
+            continue
+        decls.add(m.group("name"))
+    return decls
 # `nm -D --defined-only` lines look like:
 #   `0000000000123456 T thetadatadx_some_symbol_name`
 # We match the trailing identifier on `T` (text/code) entries — those
@@ -194,18 +266,48 @@ def collect_ffi_symbols() -> set[str]:
     return collect_ffi_symbols_via_regex()
 
 
-def collect_header_symbols() -> set[str]:
-    """Symbols DECLARED as functions in the shipped C/C++ headers.
+def _is_c_decl_header(path: pathlib.Path) -> bool:
+    """True for the C-ABI *declaration* headers, false for the C++
+    inline-body headers.
 
-    Comments are stripped first, then only `thetadatadx_<name>(`
+    The C `extern "C"` prototypes — the SSOT for the link contract — live
+    only in `thetadatadx.h` and the `*.h.inc` fragments it `#include`s.
+    The C++ convenience wrappers (`thetadatadx.hpp` and the `*.hpp.inc`
+    fragments) carry no prototypes; they *call* every C symbol from inline
+    bodies. Scanning a wrapper for declarations is exactly the gap C4
+    closes: a `thetadatadx_foo(` call there would otherwise count as a
+    decl and mask a prototype deleted from `thetadatadx.h`. The
+    decl-position regex already rejects those calls, but pruning the
+    wrapper files here makes the scope explicit and keeps the gate fast.
+
+    `.h.inc` ends in `.inc`, so a plain suffix check cannot tell it from
+    `.hpp.inc`; match on the compound suffix instead.
+    """
+    name = path.name
+    if name.endswith(".hpp") or name.endswith(".hpp.inc"):
+        return False
+    return name.endswith(".h") or name.endswith(".h.inc")
+
+
+def collect_header_symbols() -> set[str]:
+    """Symbols DECLARED as functions in the shipped C-ABI headers.
+
+    Only the C *declaration* headers are scanned — `thetadatadx.h` and the
+    `*.h.inc` prototype fragments. The C++ inline-body wrappers
+    (`thetadatadx.hpp` / `*.hpp.inc`) are excluded: they declare nothing
+    and merely call the C symbols, so a call there must not read as a
+    declaration (the bypass C4 closes). Within the scanned files, comments
+    are stripped first and only `<return-type> thetadatadx_<name>(`
     declaration sites are collected. A name that survives only in a
-    comment, or a `thetadatadx_foo_*` wildcard mentioned in prose, is not
-    a declaration and is intentionally not collected — so it can neither
-    satisfy the forward `rust - header` completeness check nor pollute
-    the reverse `header - rust` delta.
+    comment, a `thetadatadx_foo_*` wildcard mentioned in prose, or a call
+    site is not a declaration and is intentionally not collected — so it
+    can neither satisfy the forward `rust - header` completeness check nor
+    pollute the reverse `header - rust` delta.
     """
     out: set[str] = set()
-    for header in list(CPP_INCLUDE.rglob("*.h")) + list(CPP_INCLUDE.rglob("*.hpp")) + list(CPP_INCLUDE.rglob("*.inc")):
+    for header in sorted(CPP_INCLUDE.rglob("*")):
+        if not header.is_file() or not _is_c_decl_header(header):
+            continue
         out |= _header_decls_from_text(header.read_text(encoding="utf-8"))
     return out
 
@@ -276,7 +378,9 @@ def main() -> int:
 
 
 def _selftest() -> int:
-    """Prove a comment-only symbol mention does not count as declared.
+    """Prove a comment-only mention, a prose wildcard, and a C++ inline
+    *call site* are all rejected, while real prototypes (including
+    multi-line ones) are collected.
 
     Cases (all driven through the real `_header_decls_from_text` +
     `rust - header` / `header - rust` logic on synthetic inputs):
@@ -287,10 +391,32 @@ def _selftest() -> int:
       collected as declared.
     * Forward check: a Rust symbol set `{alpha, beta}` against that header
       must report `beta` missing — the comment mention must NOT satisfy
-      completeness (this is the gameable hole being closed).
+      completeness (this is the original gameable hole).
     * Reverse check: a header declaring `thetadatadx_delta(...)` with no
       Rust counterpart must surface `delta` as an extra — proving real
       declarations are still collected after comment stripping.
+    * Call-site rejection (the C4 bypass): a C++ inline body that *calls*
+      `thetadatadx_epsilon` three ways — assignment (`= thetadatadx_epsilon(`),
+      `return thetadatadx_epsilon(`, and the statement-leading
+      `thetadatadx_epsilon(arg);` — must collect NOTHING. A wrapper body
+      calling a C symbol must never read as that symbol's declaration, or
+      a prototype deleted from `thetadatadx.h` would still pass while the
+      `.hpp` wrapper that calls it survives.
+    * String-literal rejection (the .h/.inc string bypass): a
+      `thetadatadx_<name>(` fragment inside a C string / char literal must
+      collect NOTHING, even when the surrounding string text mimics
+      declaration position (`"use thetadatadx_x()"`). A `//`-bearing URL
+      string must not be mis-stripped as a line comment, and a char literal
+      must not swallow a following real declaration.
+    * Multi-line prototype: a declaration whose argument list wraps across
+      lines (`int32_t thetadatadx_zeta(\n  const T* a,\n  size_t n);`) must
+      still be collected — the decl-position scan must not regress the real
+      wrapped prototypes in `thetadatadx.h`.
+    * File-scope exclusion: a `.hpp` and a `.hpp.inc` wrapper file that
+      call C symbols, plus a `.h` and a `.h.inc` file that declare them,
+      run through `_is_c_decl_header` — only the `.h` / `.h.inc` files are
+      in scope, so a prototype deleted from `thetadatadx.h` is caught even
+      when the wrapper still calls it.
     """
     header_text = (
         "// thetadatadx_beta is documented here but never declared.\n"
@@ -330,6 +456,96 @@ def _selftest() -> int:
             "reverse check: a real header declaration absent from Rust was "
             "not surfaced as an extra"
         )
+
+    # Call-site rejection: a C++ inline body calling a C symbol must
+    # collect nothing. This is the C4 bypass — a wrapper call masquerading
+    # as a declaration.
+    call_body = (
+        "inline int wrap_epsilon(int a) {\n"
+        "    const int r = thetadatadx_epsilon(a);\n"
+        "    thetadatadx_epsilon(a);\n"
+        "    return thetadatadx_epsilon(a);\n"
+        "}\n"
+    )
+    call_decls = _header_decls_from_text(call_body)
+    if call_decls:
+        failures.append(
+            "call-site rejection: a C++ inline body that only CALLS "
+            f"thetadatadx_epsilon was read as declaring {sorted(call_decls)} "
+            "(a wrapper call must not count as a declaration — this is the "
+            "deleted-prototype bypass)"
+        )
+
+    # A genuinely-missing prototype whose only surviving mention is a
+    # wrapper call must read as MISSING in the forward direction.
+    rust_eps = {"thetadatadx_epsilon"}
+    if "thetadatadx_epsilon" not in (rust_eps - call_decls):
+        failures.append(
+            "forward check: a symbol present only as a wrapper call site was "
+            "treated as declared — the gate would pass a deleted prototype"
+        )
+
+    # String-literal rejection: a `thetadatadx_<name>(` fragment embedded in
+    # a C string or char literal must NOT be collected. A string payload
+    # can mimic declaration position (`"use thetadatadx_x() carefully"` puts
+    # the word `use` before the symbol), so the contents must be stripped
+    # outright before scanning. Covers a plain assignment, an initializer
+    # list, a `//`-containing URL string (which must not be mis-stripped as
+    # a line comment), and a char literal preceding a real decl (which MUST
+    # survive). This is the .h/.inc string-literal bypass.
+    string_text = (
+        'const char* msg = "call thetadatadx_strghost(x) now";\n'
+        'static const char* names[] = { "use thetadatadx_arrghost() here" };\n'
+        'const char* url = "thetadatadx_urlghost(http://x)";\n'
+        "char sep = ';';\n"
+        "void thetadatadx_strreal(int x);\n"
+    )
+    string_decls = _header_decls_from_text(string_text)
+    ghosts = {d for d in string_decls if d.endswith("ghost")}
+    if ghosts:
+        failures.append(
+            "string-literal rejection: symbols embedded only in C string "
+            f"literals were collected as declarations: {sorted(ghosts)} "
+            "(a string payload mimicking declaration position must be "
+            "stripped — this is the .h/.inc string-literal bypass)"
+        )
+    if "thetadatadx_strreal" not in string_decls:
+        failures.append(
+            "string-literal rejection: a real declaration following string / "
+            "char literals was dropped (the strip removed too much)"
+        )
+
+    # Multi-line prototype: the wrapped-arg-list declarations in
+    # thetadatadx.h must still be collected.
+    multiline_text = (
+        "int32_t thetadatadx_zeta(\n"
+        "    const ThetaDataDxClient* a,\n"
+        "    size_t n);\n"
+    )
+    if "thetadatadx_zeta" not in _header_decls_from_text(multiline_text):
+        failures.append(
+            "multi-line decl: a prototype whose argument list wraps across "
+            "lines was not collected (real wrapped prototypes in "
+            "thetadatadx.h would read as missing)"
+        )
+
+    # File-scope: only `.h` / `.h.inc` declaration headers are in scope;
+    # the `.hpp` / `.hpp.inc` C++ wrappers are excluded.
+    scope_cases = {
+        "thetadatadx.h": True,
+        "endpoint_with_options.h.inc": True,
+        "thetadatadx.hpp": False,
+        "tick_arrow_ipc.hpp.inc": False,
+    }
+    for fname, expected in scope_cases.items():
+        got = _is_c_decl_header(pathlib.Path("sdks/cpp/include") / fname)
+        if got != expected:
+            failures.append(
+                f"file-scope: _is_c_decl_header({fname!r}) returned {got}, "
+                f"expected {expected} (a C++ wrapper in scope would let a "
+                "wrapper call mask a deleted prototype; a declaration header "
+                "out of scope would blind the gate)"
+            )
 
     if failures:
         print("check_c_abi_completeness --selftest: FAILED")

--- a/scripts/ci/check_docs_consistency.py
+++ b/scripts/ci/check_docs_consistency.py
@@ -92,6 +92,17 @@ SERVER_ROUTER_FILES = (
     ROOT / "tools/server/src/flatfile_routes.rs",
 )
 
+# The server CLI is the source of truth for the documented flag defaults.
+# The `#[arg(...)]` attributes on the `struct Args` fields carry each
+# flag's default; the docs render those in a `| --flag | default | ... |`
+# Markdown table. The gate parses the `#[arg(...)]` defaults from this file
+# and asserts the doc-table rows match value-by-value, so a changed server
+# default that the docs don't reflect trips the gate (the same
+# derive-from-source pattern as `flatfile_served_matrix`). A substring
+# check ("25503" appears somewhere) could not catch a default that changed
+# to a value still mentioned elsewhere on the page.
+SERVER_MAIN_RS = ROOT / "tools/server/src/main.rs"
+
 # `.route("/v3/...")` literal. The path string may sit on the same line as
 # `.route(` or wrap onto the next, so `\s*` (which spans newlines) bridges the
 # two. Restricting the capture to `/v3/...` naturally excludes any non-served
@@ -653,6 +664,242 @@ def flatfile_served_matrix() -> dict[str, set[str]]:
     return matrix
 
 
+def _struct_body(text: str, struct_name: str) -> str | None:
+    """Return the `{ ... }` body of `struct <struct_name> { ... }`,
+    brace-balanced. Used to scope the `#[arg(...)]` scan to the CLI args
+    struct so an `#[arg]` on an unrelated type cannot leak in.
+    """
+    header = re.search(rf"struct\s+{re.escape(struct_name)}\s*\{{", text)
+    if not header:
+        return None
+    depth = 1
+    i = header.end()
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    return text[header.end() : i - 1]
+
+
+def server_arg_defaults() -> dict[str, str | None]:
+    """Derive `{--flag: default}` for every server CLI flag from the
+    `#[arg(...)]` attributes on `struct Args` in `tools/server/src/main.rs`.
+
+    The default is:
+
+    * the `default_value = "X"` string literal, verbatim;
+    * the `default_value_t = N` literal (an integer such as `25503`);
+    * for `default_value_t = <path>::Variant` (a clap `ValueEnum`), the
+      kebab/lower-cased last path segment — clap renders `LogFormat::Text`
+      as `text` with no `#[value(name=...)]` override;
+    * `None` when the field carries no `default_value*` (an `Option<T>` or
+      `bool` flag), meaning the doc-table default cell must be empty.
+
+    The flag long name is clap's snake→kebab derivation of the field name
+    (`http_port` -> `--http-port`). `value_parser = [...]` does not set a
+    default and is ignored.
+    """
+    text = SERVER_MAIN_RS.read_text()
+    body = _struct_body(text, "Args")
+    if body is None:
+        fail(f"{SERVER_MAIN_RS.relative_to(ROOT)} has no `struct Args` body")
+
+    defaults: dict[str, str | None] = {}
+    # Each field is an `#[arg(...)]` attribute followed by `<field>: <type>`.
+    # The attribute arg list can itself contain `[...]` (a
+    # `value_parser = ["production", "dev"]` allow-list) and nested `(...)`,
+    # so the inner span is read with a bracket/paren balance counter — a
+    # naive `#[arg([^\]]*)]` stops at the first `]` inside the value_parser
+    # array and drops the flag (the same inner-delimiter trap the napi
+    # parity collectors hit). After the attribute's closing `]`, the next
+    # identifier before a `:` is the field name.
+    after_field_re = re.compile(r"\s*(?:#\[[^\]]*\]\s*)*([a-z_][a-z0-9_]*)\s*:")
+    for m in re.finditer(r"#\[\s*arg\b", body):
+        i = m.end()
+        while i < len(body) and body[i].isspace():
+            i += 1
+        attr = ""
+        if i < len(body) and body[i] == "(":
+            attr, after = _balanced_paren_span(body, i)
+            if after is None:
+                continue
+        else:
+            after = i
+        # Advance past the attribute's closing `]`.
+        while after < len(body) and body[after] != "]":
+            after += 1
+        after += 1
+        fm = after_field_re.match(body, after)
+        if not fm:
+            continue
+        field = fm.group(1)
+        flag = "--" + field.replace("_", "-")
+        defaults[flag] = _arg_default_from_attr(attr)
+    if not defaults:
+        fail(
+            f"{SERVER_MAIN_RS.relative_to(ROOT)} `struct Args` parsed to no "
+            "`#[arg(...)]` flags"
+        )
+    return defaults
+
+
+def _balanced_paren_span(text: str, open_idx: int) -> tuple[str, int | None]:
+    """Given `open_idx` at a `(`, return `(inner, after)` where `inner` is
+    the balanced content up to the matching `)` and `after` is the index
+    just past that `)`. Tracks `"..."` string literals (with `\\` escapes)
+    and nested `(` / `[` so a `)` or `]` inside a string or a
+    `value_parser = [...]` array does not close the span early. Returns
+    `("", None)` if unbalanced.
+    """
+    depth = 0
+    in_str = False
+    esc = False
+    start = open_idx + 1
+    i = open_idx
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+        elif c == '"':
+            in_str = True
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start:i], i + 1
+        i += 1
+    return "", None
+
+
+def _arg_default_from_attr(attr: str) -> str | None:
+    """Extract the rendered default from one `#[arg(...)]` inner text, or
+    `None` when the attribute sets no default.
+    """
+    # `default_value = "X"` — string literal verbatim.
+    m = re.search(r'default_value\s*=\s*"([^"]*)"', attr)
+    if m:
+        return m.group(1)
+    # `default_value_t = <expr>`.
+    m = re.search(r"default_value_t\s*=\s*([^,]+)", attr)
+    if m:
+        expr = m.group(1).strip()
+        # A clap `ValueEnum` path (`logging::LogFormat::Text`) renders as
+        # the kebab/lower-cased last segment.
+        if "::" in expr:
+            variant = expr.rsplit("::", 1)[1]
+            return _value_enum_render(variant)
+        # Otherwise a literal (integer like `25503`, or `true`/`false`).
+        return expr
+    return None
+
+
+def _value_enum_render(variant: str) -> str:
+    """Render a clap `ValueEnum` PascalCase variant the way clap does by
+    default: lower-case, words separated by `-` (`OpenInterest` ->
+    `open-interest`, `Text` -> `text`). Matches clap's default
+    `to_possible_value` kebab-casing when no `#[value(name=...)]` override
+    is present.
+    """
+    out: list[str] = []
+    for i, ch in enumerate(variant):
+        if ch.isupper() and i > 0:
+            out.append("-")
+        out.append(ch.lower())
+    return "".join(out)
+
+
+# Markdown flag-table row: `| --flag[ <metavar>] | default | description |`.
+# The first cell may carry a metavar (`--creds <path>`) or pair two flags
+# (`--email / --password`); the default cell may be empty or an em-dash
+# placeholder. The parser below normalises both.
+_FLAG_ROW_RE = re.compile(
+    r"^\|\s*(?P<flags>`[^|]+?`(?:\s*/\s*`[^|]+?`)*)\s*\|"
+    r"\s*(?P<default>[^|]*?)\s*\|",
+    re.MULTILINE,
+)
+_FLAG_CELL_RE = re.compile(r"`(--[a-z][a-z0-9-]*)(?:\s+[^`]*)?`")
+
+
+def _parse_doc_flag_table(text: str) -> dict[str, str | None]:
+    """Parse a Markdown flags table into `{--flag: default-or-None}`.
+
+    Each flag in the first cell (a row may list two, `--email / --password`)
+    maps to the row's default cell. An empty cell or an em-dash / hyphen
+    placeholder (`—` / `-`) means "no default" and maps to `None`. The
+    default literal is unwrapped from surrounding backticks so it compares
+    against the raw `#[arg]` default.
+    """
+    out: dict[str, str | None] = {}
+    for m in _FLAG_ROW_RE.finditer(text):
+        flags = _FLAG_CELL_RE.findall(m.group("flags"))
+        if not flags:
+            continue
+        raw_default = m.group("default").strip()
+        # Strip backticks and treat placeholders as "no default".
+        unwrapped = raw_default.strip("`").strip()
+        default: str | None
+        if unwrapped in ("", "—", "-", "–"):
+            default = None
+        else:
+            default = unwrapped
+        for flag in flags:
+            out[flag] = default
+    return out
+
+
+def check_server_flag_defaults() -> None:
+    """Assert the server flag-default tables in the docs match the
+    `#[arg(...)]` defaults derived from `tools/server/src/main.rs`,
+    value-by-value. A substring check could not catch a default that
+    silently changed to a value still printed elsewhere on the page.
+
+    Both the server README and the docs-site server page carry the table;
+    each is checked. A doc may legitimately omit a flag from its table
+    (e.g. a terse page), so the gate asserts agreement only for the flags a
+    given table DOES document — but a documented flag whose default
+    disagrees with the source, or a documented default for a flag the
+    source says has none (and vice versa), trips.
+    """
+    source_defaults = server_arg_defaults()
+    doc_tables = (
+        ROOT / "tools/server/README.md",
+        DOCS_SITE / "server/index.md",
+    )
+    for doc in doc_tables:
+        if not doc.is_file():
+            fail(f"{doc.relative_to(ROOT)}: server flag-table doc not found")
+        documented = _parse_doc_flag_table(doc.read_text())
+        # The table must document a meaningful subset of the real flags;
+        # if it parsed to nothing, the table shape drifted and the gate is
+        # silently blind — fail loudly.
+        overlap = set(documented) & set(source_defaults)
+        if not overlap:
+            fail(
+                f"{doc.relative_to(ROOT)}: no server flags parsed from the "
+                "flag-default table (the table shape changed — the gate would "
+                "be blind to default drift)"
+            )
+        for flag in sorted(overlap):
+            want = source_defaults[flag]
+            got = documented[flag]
+            if want != got:
+                fail(
+                    f"{doc.relative_to(ROOT)} documents {flag} default as "
+                    f"{got!r}, but `tools/server/src/main.rs` `#[arg]` sets "
+                    f"{want!r}"
+                )
+
+
 def _yaml_block(text: str, header_re: str, *, after: int = 0) -> tuple[str, int]:
     """Return the indented body under the first `header_re` line at/after `after`.
 
@@ -979,8 +1226,135 @@ def check_tier_badges() -> None:
         fail("tier badge check failed (see scripts/ci/check_tier_badges.py output above)")
 
 
+def _selftest() -> int:
+    """Hermetic checks for the server flag-default derivation (G5).
+
+    Drives `server_arg_defaults`, `_parse_doc_flag_table`, and
+    `_value_enum_render` on synthetic inputs:
+
+    * The `#[arg]` parser reads string (`default_value = "x"`), integer
+      (`default_value_t = 25503`), and `ValueEnum` (`default_value_t =
+      LogFormat::Text` -> `text`) defaults, treats a flag with no default
+      as `None`, and — critically — is NOT truncated by a
+      `value_parser = ["a", "b"]` allow-list whose `]` would otherwise
+      close a naive attribute scan (the inner-delimiter bypass).
+    * The Markdown table parser maps `--flag <metavar>` and paired
+      `--a / --b` rows to their default cells, reads an em-dash / empty cell
+      as `None`, and unwraps backticked defaults.
+    * A documented default that disagrees with the source value is caught
+      value-by-value, where a substring scan would miss a default that
+      changed to a value still printed elsewhere.
+    """
+    import tempfile
+
+    global SERVER_MAIN_RS
+    failures: list[str] = []
+
+    # `_value_enum_render`.
+    if _value_enum_render("Text") != "text":
+        failures.append("value-enum: `Text` did not render to `text`")
+    if _value_enum_render("OpenInterest") != "open-interest":
+        failures.append("value-enum: `OpenInterest` did not render to `open-interest`")
+
+    synthetic_main = (
+        "struct Args {\n"
+        '    #[arg(long, default_value = "creds.txt")]\n'
+        "    creds: String,\n"
+        "    #[arg(long)]\n"
+        "    api_key: Option<String>,\n"
+        '    #[arg(long, default_value = "production", '
+        'value_parser = ["production", "dev"])]\n'
+        "    streaming_region: String,\n"
+        "    #[arg(long, default_value_t = 25503)]\n"
+        "    http_port: u16,\n"
+        "    #[arg(long, value_enum, default_value_t = logging::LogFormat::Text)]\n"
+        "    log_format: logging::LogFormat,\n"
+        "    #[arg(long)]\n"
+        "    no_streaming: bool,\n"
+        "}\n"
+    )
+    saved_main = SERVER_MAIN_RS
+    with tempfile.TemporaryDirectory() as td:
+        fake_main = Path(td) / "main.rs"
+        fake_main.write_text(synthetic_main, encoding="utf-8")
+        SERVER_MAIN_RS = fake_main
+        try:
+            derived = server_arg_defaults()
+        finally:
+            SERVER_MAIN_RS = saved_main
+
+    expected = {
+        "--creds": "creds.txt",
+        "--api-key": None,
+        "--streaming-region": "production",  # not truncated by value_parser `]`
+        "--http-port": "25503",
+        "--log-format": "text",
+        "--no-streaming": None,
+    }
+    for flag, want in expected.items():
+        got = derived.get(flag, "<<missing>>")
+        if got != want:
+            failures.append(
+                f"arg-parse: {flag} derived as {got!r}, expected {want!r}"
+            )
+
+    # Markdown table parser: metavar, paired flags, em-dash, backticks.
+    table = (
+        "| Flag | Default | Description |\n"
+        "|------|---------|-------------|\n"
+        "| `--creds <path>` | `creds.txt` | creds file |\n"
+        "| `--email` / `--password` | — | inline creds |\n"
+        "| `--http-port <port>` | `25503` | port |\n"
+        "| `--log-format <fmt>` | `text` | format |\n"
+    )
+    parsed = _parse_doc_flag_table(table)
+    table_expected = {
+        "--creds": "creds.txt",
+        "--email": None,
+        "--password": None,
+        "--http-port": "25503",
+        "--log-format": "text",
+    }
+    for flag, want in table_expected.items():
+        got = parsed.get(flag, "<<missing>>")
+        if got != want:
+            failures.append(
+                f"table-parse: {flag} parsed as {got!r}, expected {want!r}"
+            )
+
+    # Value-by-value mismatch detection: a doc default that disagrees with
+    # the source must be caught even though the stale value appears
+    # elsewhere in the page text.
+    stale_table = (
+        "Run on port 25503 by default.\n\n"
+        "| Flag | Default | Description |\n"
+        "|------|---------|-------------|\n"
+        "| `--http-port <port>` | `25503` | port |\n"
+    )
+    src = {"--http-port": "25504"}  # source moved to 25504
+    doc = _parse_doc_flag_table(stale_table)
+    mismatch = any(
+        doc.get(f) != src.get(f)
+        for f in set(doc) & set(src)
+    )
+    if not mismatch:
+        failures.append(
+            "value-by-value: a stale documented port default was not detected "
+            "as a mismatch (substring scan would have passed it)"
+        )
+
+    if failures:
+        print("check_docs_consistency --selftest: FAILED")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("check_docs_consistency --selftest: ok")
+    return 0
+
+
 def main() -> None:
     check_static_docs()
+    check_server_flag_defaults()
     check_reference_pages()
     check_llms_txt()
     check_openapi()
@@ -992,4 +1366,15 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Run the embedded self-test and exit.",
+    )
+    args = parser.parse_args()
+    if args.selftest:
+        sys.exit(_selftest())
     main()

--- a/scripts/ci/check_no_re_framing.py
+++ b/scripts/ci/check_no_re_framing.py
@@ -105,6 +105,16 @@ EXEMPT_PATH_FRAGMENTS = (
     # scanning it would flag the very guard that protects the public
     # surface.
     "/build_support_bin/",
+    # Pinned upstream / CI input data, not our publicly-rendered source.
+    # `scripts/ci/data/` holds the verbatim vendor OpenAPI snapshot
+    # (`upstream_openapi.yaml`, refreshed wholesale from
+    # `docs.thetadata.us/openapiv3.yaml`) and gate allow-lists. The vendor
+    # spec legitimately carries the vendor's own `x-java-package:
+    # net.thetadata.*` field — that is THEIR published metadata, not our
+    # provenance leak, and it is never shipped in any crate or rendered on
+    # docs.rs. This directory is the same category as `build_support_bin/`:
+    # CI input, not public prose.
+    "/scripts/ci/data/",
 )
 
 
@@ -142,6 +152,16 @@ FORBIDDEN_PATTERNS = (
     # (`Contract.java`, `CONTRACT.JAVA`): a named Java source is
     # provenance a reader could only have from decompilation.
     re.compile(r"\b\w+\.java\b", re.IGNORECASE),
+    # A dotted `net.thetadata.*` Java fully-qualified class name
+    # (`net.thetadata.types.tick.MarketValueTick`): the package path is
+    # provenance a reader could only have from the decompiled terminal,
+    # and unlike a `Contract.java` source reference it carries no `.java`
+    # suffix, so the `<identifier>.java` pattern above never sees it. Only
+    # the DOTTED form is forbidden — `net.thetadata` must be immediately
+    # followed by a `.`-separated path. The bare class name on its own
+    # (`MarketValueTick`) is a legitimate public SDK type that ships across
+    # every binding and must stay clean, so the package prefix is required.
+    re.compile(r"\bnet\.thetadata\.[\w.]+", re.IGNORECASE),
     re.compile(r"\bjavap\b", re.IGNORECASE),
     re.compile(r"decompil", re.IGNORECASE),
     # The reverse-engineering vocabulary itself, with any separator
@@ -275,6 +295,13 @@ def _selftest() -> int:
       / `RE-d`, the `reversed engineering` conjugation, an uppercase
       `.JAVA` source, and a hyphenated `jar-build` note — every one must
       be flagged.
+    * A file naming a dotted `net.thetadata.*` Java fully-qualified class
+      name (`net.thetadata.types.tick.MarketValueTick`) — must be flagged.
+      The package path has no `.java` suffix, so the `<identifier>.java`
+      pattern never saw it; the dotted-FQCN pattern closes that gap.
+    * A clean file naming only the BARE public SDK type (`MarketValueTick`,
+      `QuoteTick`) with no package prefix — must pass, proving the dotted
+      pattern does not punish the legitimate cross-binding type name.
     * A clean file that names only the allow-listed "JVM terminal" /
       "Theta Terminal" parity reference — must pass.
     * A clean file whose factual wire description shares a line with the
@@ -315,6 +342,20 @@ def _selftest() -> int:
         "/// Layout reversed engineering notes for the OHLC packet.\n"
         "/// Source: `Contract.JAVA` decompiled output.\n"
         "/// Checked against the terminal jar-build `202605221`.\n"
+    )
+    # A dotted Java fully-qualified class name from the decompiled terminal
+    # package tree. It carries no `.java` suffix, so the older
+    # `<identifier>.java` pattern never saw it. Must trip.
+    leaky_fqcn = (
+        "/// Field order mirrors net.thetadata.types.tick.MarketValueTick.\n"
+        "/// Also seen as NET.THETADATA.Types.Tick.QuoteTick in another build.\n"
+    )
+    # The bare public SDK type name on its own — no package prefix. This is
+    # a legitimate cross-binding type and must stay clean; the dotted-FQCN
+    # pattern must NOT fire on it.
+    clean_bare_type = (
+        "/// Returns a MarketValueTick with the consolidated NBBO snapshot.\n"
+        "/// The QuoteTick and TradeTick structs share the same header.\n"
     )
     clean = (
         "//! Matches the JVM terminal byte-for-byte on the wire.\n"
@@ -363,6 +404,14 @@ def _selftest() -> int:
         variants_path.parent.mkdir(parents=True, exist_ok=True)
         variants_path.write_text(leaky_variants, encoding="utf-8")
 
+        fqcn_path = root / "crates" / "thetadatadx" / "src" / "fqcn.rs"
+        fqcn_path.parent.mkdir(parents=True, exist_ok=True)
+        fqcn_path.write_text(leaky_fqcn, encoding="utf-8")
+
+        bare_type_path = root / "sdks" / "cpp" / "include" / "bare_type.hpp"
+        bare_type_path.parent.mkdir(parents=True, exist_ok=True)
+        bare_type_path.write_text(clean_bare_type, encoding="utf-8")
+
         contractions_path = root / "ffi" / "src" / "contractions.rs"
         contractions_path.parent.mkdir(parents=True, exist_ok=True)
         contractions_path.write_text(clean_contractions, encoding="utf-8")
@@ -398,6 +447,27 @@ def _selftest() -> int:
             return 1
         if any(rel.name == "vendor.rs" for (rel, _, _, _) in hits):
             print("selftest FAILED: an allow-listed parity-reference file was flagged")
+            return 1
+
+        # A dotted `net.thetadata.*` FQCN must be flagged.
+        fqcn_hits = [h for h in hits if h[0].name == "fqcn.rs"]
+        if not any("net.thetadata" in m.lower() for (_, _, m, _) in fqcn_hits):
+            print(
+                "selftest FAILED: a dotted net.thetadata.* Java FQCN was not "
+                "flagged (the package path is decompilation provenance)"
+            )
+            return 1
+        # The bare public SDK type name (no package prefix) must stay clean.
+        if any(rel.name == "bare_type.hpp" for (rel, _, _, _) in hits):
+            bad = [
+                (m, line)
+                for (rel, _, m, line) in hits
+                if rel.name == "bare_type.hpp"
+            ]
+            print(
+                "selftest FAILED: the dotted-FQCN pattern false-positived on a "
+                f"bare public type name: {bad!r}"
+            )
             return 1
 
         # Spelling-variant coverage: every new variant must surface at

--- a/scripts/ci/check_public_surface_leak.py
+++ b/scripts/ci/check_public_surface_leak.py
@@ -131,6 +131,35 @@ FORBIDDEN_PATTERNS = (
     r"Python::detach",
     r"ingest[\s_-]?ring",
     r"dispatch[\s_-]?consumer",
+    # Extended DENY set — the rest of the standing impl-IP vocabulary that
+    # describes the dispatch engine, the runtime data structures, and the
+    # async bridge. Each carries the same flexible `[\s_-]?` separator as
+    # the entries above so a reflowed or re-hyphenated rendering cannot
+    # dodge the gate.
+    r"firehose",                  # the streaming fan-out engine name
+    r"routing[\s_-]?table",       # the contract-to-consumer routing table
+    r"arc[\s_-]?swap",            # `arc_swap` / `arc-swap` hot-config cell
+    r"dashmap",                   # the concurrent map crate
+    r"rustc[\s_-]?hash",          # `rustc_hash` / `FxHashMap` hasher crate
+    r"epoll",                     # the Linux readiness primitive
+    r"kqueue",                    # the BSD/macOS readiness primitive
+    r"pyo3-async-runtimes",       # the Python async bridge crate
+    r"future_into_py",            # the pyo3 async bridge entry point
+    r"SharedProducer",            # internal ring-producer handle type
+    r"StateCell",                 # internal hot-swappable state cell type
+    # NOTE: `worker[\s_-]?pool` is deliberately NOT in this list. The
+    # async worker-thread count is a documented PUBLIC config knob
+    # (`set_worker_threads` / the `worker_threads` property on every
+    # binding); `check_binding_parity._check_public_surface_vocab` already
+    # adjudicates worker-thread vocabulary as neutral public surface (it
+    # strips the internal `tokio_` prefix and exposes `worker_threads`),
+    # with an explicit `test_surface_vocab_allows_neutral_worker_threads`
+    # asserting it stays clean. The knob's own doc comment necessarily
+    # describes its process-global threading model, so banning "worker
+    # pool" here would fire on a legitimate public-API description, not an
+    # impl-IP leak. The internal runtime crate name (`tokio`) is already
+    # banned above — that is the token that would actually leak the
+    # implementation.
 )
 
 # Each pattern is wrapped in identifier-boundary guards so a token glued
@@ -235,6 +264,13 @@ def _selftest() -> int:
       `dispatch consumer`) — every one must be flagged, proving the
       case-insensitive scan, the new phrases, and the flexible
       separators all bite.
+    * A header carrying the extended DENY set (`Firehose`, `routing table`,
+      `arc-swap`, `DashMap`, `rustc-hash`, `epoll`, `kqueue`,
+      `pyo3-async-runtimes`, `future_into_py`, `SharedProducer`,
+      `StateCell`) — every one must be flagged. A planted `firehose` in a
+      shipped `sdks/cpp/include/*.h` is the canonical bypass this closes.
+      (`worker pool` is intentionally absent — see the FORBIDDEN_PATTERNS
+      note; worker-thread vocabulary is adjudicated public surface.)
     * A shipped README (`sdks/python/README.md`) naming an internal
       runtime crate — must be flagged, proving `sdks/*/README.md` is in
       the scan set (the PyPI / npm long-description leak that previously
@@ -273,6 +309,22 @@ def _selftest() -> int:
         "/* events arrive on the ingest ring */\n"
         "/* serviced by the dispatch consumer */\n"
     )
+    # The extended DENY set, one spelling per line — the dispatch engine,
+    # the runtime data structures, and the async bridge, in mixed casing
+    # and with separator variants. Every one must be flagged.
+    extended_deny_variants = (
+        "/* events fan out through the Firehose */\n"
+        "/* keyed by the routing table */\n"
+        "/* hot config lives in an arc-swap cell */\n"
+        "/* contracts indexed in a DashMap */\n"
+        "/* hashed with rustc-hash */\n"
+        "/* readiness via epoll on Linux */\n"
+        "/* readiness via kqueue on macOS */\n"
+        "/* bridged by pyo3-async-runtimes */\n"
+        "/* the future_into_py entry point */\n"
+        "/* writes go through a SharedProducer */\n"
+        "/* swapped atomically in a StateCell */\n"
+    )
     leaky_readme = (
         "# thetadatadx (Python)\n"
         "\n"
@@ -297,6 +349,10 @@ def _selftest() -> int:
         variants = root / "sdks" / "cpp" / "include" / "variants.h"
         variants.parent.mkdir(parents=True, exist_ok=True)
         variants.write_text(case_and_separator_variants, encoding="utf-8")
+
+        extended = root / "sdks" / "cpp" / "include" / "extended.h"
+        extended.parent.mkdir(parents=True, exist_ok=True)
+        extended.write_text(extended_deny_variants, encoding="utf-8")
 
         readme = root / "sdks" / "python" / "README.md"
         readme.parent.mkdir(parents=True, exist_ok=True)
@@ -351,6 +407,35 @@ def _selftest() -> int:
             print(
                 "selftest FAILED: case/separator-variant impl-IP tokens "
                 f"slipped through: {sorted(missing)!r}"
+            )
+            return 1
+
+        # Every entry in the extended DENY set must be flagged.
+        extended_tokens = {
+            re.sub(r"[\s_-]", "", token.lower())
+            for (rel, _, token, _) in hits
+            if rel.name == "extended.h"
+        }
+        expected_extended = {
+            "firehose",
+            "routingtable",
+            "arcswap",
+            "dashmap",
+            "rustchash",
+            "epoll",
+            "kqueue",
+            # `pyo3-async-runtimes` normalises to `pyo3asyncruntimes` once
+            # the hyphens are stripped.
+            "pyo3asyncruntimes",
+            "futureintopy",
+            "sharedproducer",
+            "statecell",
+        }
+        missing_extended = expected_extended - extended_tokens
+        if missing_extended:
+            print(
+                "selftest FAILED: extended-DENY-set tokens slipped through: "
+                f"{sorted(missing_extended)!r}"
             )
             return 1
 

--- a/scripts/ci/check_version_sync.py
+++ b/scripts/ci/check_version_sync.py
@@ -40,11 +40,20 @@ import json
 import re
 import sys
 import tempfile
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 CANONICAL_CARGO = ROOT / "crates" / "thetadatadx" / "Cargo.toml"
 CMAKE_LISTS = ROOT / "sdks" / "cpp" / "CMakeLists.txt"
+# The published REST contract. Its `info.version` is the version a
+# generated client stamps into its user-agent / about strings, yet it was
+# governed by no gate: `check_version_sync` never read this file and
+# `check_docs_consistency` validates only the servers / paths / security
+# of the same YAML, never `info.version`. So the published OpenAPI spec
+# could fall a full release behind canonical undetected. The gate now
+# asserts `info.version` against the canonical version.
+OPENAPI_YAML = ROOT / "docs-site" / "docs" / "public" / "thetadatadx.yaml"
 PY_INIT = ROOT / "sdks" / "python" / "python" / "thetadatadx" / "__init__.py"
 # The published Python wheel version is NOT pinned in `pyproject.toml`
 # (it declares `dynamic = ["version"]` with `build-backend = "maturin"`);
@@ -68,6 +77,103 @@ def cargo_version(path: Path) -> str:
     if not match:
         sys.exit(f"could not parse `version` from {path}")
     return match.group(1)
+
+
+# Every workspace crate's published / advertised version must move in
+# lockstep with the canonical one. The previous gate asserted only the
+# canonical `crates/thetadatadx/Cargo.toml` and `sdks/python/Cargo.toml`
+# manifests, leaving the FFI, CLI, server, MCP, and TypeScript-binding
+# crates — plus EVERY `Cargo.lock` — unscanned. The server and MCP
+# binaries advertise their version at runtime via `CARGO_PKG_VERSION`
+# (sourced from their own manifests), and a lockfile that pins a stale
+# `thetadatadx` entry ships an aged dependency graph; both drifted
+# silently. The two helpers below discover every manifest and lockfile so
+# any `thetadatadx*` version that falls out of sync trips the gate.
+#
+# Build output and vendored trees never carry a first-party manifest, so
+# they are pruned from the walk.
+_MANIFEST_EXCLUDE_FRAGMENTS = ("/target/", "/node_modules/", "/.git/")
+
+
+def _is_excluded_manifest(path: Path) -> bool:
+    rel = "/" + path.relative_to(ROOT).as_posix()
+    return any(frag in rel for frag in _MANIFEST_EXCLUDE_FRAGMENTS)
+
+
+def cargo_manifest_package_version(path: Path) -> tuple[str, str] | None:
+    """`([package].name, [package].version)` for a Cargo manifest, or
+    `None` for a virtual manifest (a `[workspace]` root with no
+    `[package]`). Parsed with `tomllib` so a `version` under
+    `[dependencies]` is never mistaken for the package version.
+    """
+    data = tomllib.loads(path.read_text())
+    pkg = data.get("package")
+    if not isinstance(pkg, dict) or "version" not in pkg:
+        return None
+    version = pkg["version"]
+    # `version.workspace = true` inheritance renders as a dict; the
+    # thetadatadx workspace does NOT hoist `version` (each member carries
+    # its own literal), so a dict here means the manifest defers to the
+    # workspace and there is no literal to assert.
+    if not isinstance(version, str):
+        return None
+    return str(pkg.get("name", "")), version
+
+
+def cargo_manifest_mismatches(canonical: str) -> list[str]:
+    """Every first-party (`thetadatadx*`) crate manifest whose
+    `[package].version` disagrees with the canonical version.
+
+    `publish = false` crates (the binding crates, the server/MCP/CLI
+    tools) are included on purpose: the server and MCP binaries surface
+    their version at runtime through `CARGO_PKG_VERSION`, so a drifted
+    manifest there ships a wrong version string even though nothing is
+    uploaded to a registry.
+    """
+    issues: list[str] = []
+    for path in sorted(ROOT.rglob("Cargo.toml")):
+        if _is_excluded_manifest(path):
+            continue
+        parsed = cargo_manifest_package_version(path)
+        if parsed is None:
+            continue
+        name, version = parsed
+        if not name.startswith("thetadatadx"):
+            continue
+        if version != canonical:
+            issues.append(
+                f"{path.relative_to(ROOT)} [package] version (crate "
+                f"`{name}`) is {version}, expected {canonical}"
+            )
+    return issues
+
+
+def cargo_lock_mismatches(canonical: str) -> list[str]:
+    """Every `Cargo.lock` whose pinned `thetadatadx*` package entries
+    disagree with the canonical version.
+
+    A lockfile is valid TOML with a top-level `[[package]]` array; the
+    first-party crates appear there with their resolved version. A stale
+    pin here means the resolved dependency graph ships an aged crate even
+    when the manifest is correct, so every lockfile in the tree (the
+    excluded-from-workspace SDK / tool lockfiles included) is scanned.
+    """
+    issues: list[str] = []
+    for path in sorted(ROOT.rglob("Cargo.lock")):
+        if _is_excluded_manifest(path):
+            continue
+        data = tomllib.loads(path.read_text())
+        for pkg in data.get("package", []):
+            name = pkg.get("name", "")
+            if not name.startswith("thetadatadx"):
+                continue
+            version = pkg.get("version")
+            if version != canonical:
+                issues.append(
+                    f"{path.relative_to(ROOT)} pins `{name}` at {version}, "
+                    f"expected {canonical}"
+                )
+    return issues
 
 
 def package_json_version(path: Path) -> str:
@@ -99,16 +205,88 @@ def cmake_project_version(path: Path) -> str | None:
     return match.group(1)
 
 
+def openapi_info_version(path: Path) -> str | None:
+    """The `info.version` value from an OpenAPI YAML, or `None` if the
+    file or the key is absent.
+
+    Block-scoped: the spec carries other `version:` keys inside response
+    schemas (deeper-indented), so a naive first-`version:` grab would read
+    the wrong value. This walks the top-level `info:` block — from the
+    unindented `info:` line to the next top-level (column-0) key — and
+    returns the `version:` found within it. Hand-rolled in the same style
+    as `check_docs_consistency._openapi_server_urls` to keep the gate
+    dependency-light (no YAML parser).
+    """
+    if not path.is_file():
+        return None
+    in_info = False
+    for line in path.read_text().splitlines():
+        if re.match(r"^info:\s*$", line):
+            in_info = True
+            continue
+        if in_info:
+            # A new top-level key (no indentation) ends the info block.
+            if re.match(r"^\S", line):
+                break
+            m = re.match(r"\s+version:\s*(\S+)\s*$", line)
+            if m:
+                return m.group(1).strip().strip('"').strip("'")
+    return None
+
+
 # U5 closure: the same gate scans documentation pins for the
 # `thetadatadx = "<version>"` shape. Drift between the canonical Cargo
-# version and a doc pin (README.md, docs-site quickstart /
-# installation) silently aged the docs across v9 → v10 — this gate
-# now catches that case.
-DOC_PIN_PATHS = (
-    ROOT / "README.md",
-    ROOT / "docs-site" / "docs" / "articles" / "getting-started.md",
-    ROOT / "docs-site" / "docs" / "examples" / "dataframes.md",
+# version and a doc pin silently aged the docs across v9 → v10, and again
+# across the rc series: `crates/thetadatadx/README.md` ships verbatim to
+# docs.rs (it is the crate's `readme = "README.md"`) yet a hand-picked
+# three-path list never scanned it, so it pinned `13.0.0-rc.1` against a
+# canonical `13.0.0-rc.5` undetected. The gate now discovers EVERY `*.md`
+# in the tree (minus the exclusions below) so a new install snippet in any
+# Markdown file is covered the moment it lands, with no edit here.
+#
+# Excluded from the doc-pin scan, because they pin historical versions by
+# design and would false-positive against the canonical version:
+#
+#   * `CHANGELOG.md` + `docs-site/docs/changelog.md` — the changelog and
+#     its published mirror enumerate every shipped version.
+#   * `.github/release-notes/*.md` (and the whole `.github/` tree) — each
+#     release note pins the version it documents.
+#   * `docs-site/docs/migration/*.md` — migration guides pin the old→new
+#     version pair as before/after examples (`thetadatadx = "11"` → `"12"`).
+#
+# Build output, vendored deps, and VCS metadata are excluded too.
+_DOC_PIN_EXCLUDE_FRAGMENTS = (
+    "/target/",
+    "/node_modules/",
+    "/.git/",
+    "/.github/",
+    "/migration/",
 )
+_DOC_PIN_EXCLUDE_NAMES = frozenset({"CHANGELOG.md", "changelog.md"})
+
+
+def _discover_doc_pin_files() -> tuple[Path, ...]:
+    """Every `*.md` under the repo root that should carry a current pin.
+
+    Walks the tree and drops the historical-pin files (changelog, release
+    notes, migration guides) and the build/vendor/VCS trees. Sorted for
+    deterministic diagnostics.
+    """
+    out: list[Path] = []
+    for path in ROOT.rglob("*.md"):
+        rel = "/" + path.relative_to(ROOT).as_posix()
+        if any(frag in rel for frag in _DOC_PIN_EXCLUDE_FRAGMENTS):
+            continue
+        if path.name in _DOC_PIN_EXCLUDE_NAMES:
+            continue
+        out.append(path)
+    return tuple(sorted(out))
+
+
+# Retained as an override hook: when `None` (production), the doc-pin scan
+# discovers the file set via `_discover_doc_pin_files()`. The selftest sets
+# this to an explicit synthetic list to stay hermetic.
+DOC_PIN_PATHS: tuple[Path, ...] | None = None
 # Match `thetadatadx = "<VERSION>"` (Cargo.toml-ish pin) and
 # `thetadatadx = { version = "<VERSION>", ... }` (Cargo.toml feature
 # pin). Capture the FULL quoted literal — including any pre-release
@@ -162,8 +340,9 @@ def python_init_fallback_mismatches(canonical: str) -> list[str]:
 
 
 def doc_pin_mismatches(canonical: str) -> list[str]:
+    paths = DOC_PIN_PATHS if DOC_PIN_PATHS is not None else _discover_doc_pin_files()
     issues: list[str] = []
-    for path in DOC_PIN_PATHS:
+    for path in paths:
         if not path.is_file():
             continue
         for lineno, line in enumerate(path.read_text().splitlines(), start=1):
@@ -250,6 +429,29 @@ def main() -> int:
     # full (including any pre-release suffix), not merely the major.
     failures.extend(doc_pin_mismatches(canonical))
 
+    # Every first-party crate manifest and every lockfile must agree with
+    # the canonical version — the FFI / CLI / server / MCP / TS-binding
+    # crates and all `Cargo.lock` files were previously unscanned, so the
+    # server + MCP runtime `CARGO_PKG_VERSION` advertisement and the
+    # resolved dependency graph could drift undetected.
+    failures.extend(cargo_manifest_mismatches(canonical))
+    failures.extend(cargo_lock_mismatches(canonical))
+
+    # The published OpenAPI contract's `info.version` must match canonical.
+    # A generated client reads it for its about / user-agent strings, yet
+    # neither this gate nor the docs-consistency gate previously asserted
+    # it, so the published REST spec could age a full release behind.
+    openapi_version = openapi_info_version(OPENAPI_YAML)
+    if openapi_version is None:
+        failures.append(
+            f"{OPENAPI_YAML.relative_to(ROOT)}: could not read `info.version`"
+        )
+    elif openapi_version != canonical:
+        failures.append(
+            f"{OPENAPI_YAML.relative_to(ROOT)} info.version is "
+            f"{openapi_version}, expected {canonical}"
+        )
+
     # M4 closure (post-#572 audit): Python SDK `__version__` fallback
     # must be the `"unknown"` sentinel, not a numeric literal that
     # drifts silently.
@@ -282,6 +484,19 @@ def _selftest() -> int:
       crate version must compare equal. This is the published-wheel
       version that `pyproject.toml`'s `dynamic = ["version"]` + maturin
       stamps onto the PyPI upload.
+    * Doc-pin discovery (G3): against a synthetic temp ROOT, an install
+      doc (`sdks/README.md`) is discovered while a changelog, a release
+      note, and a migration guide are excluded; a stale pin in the install
+      doc is flagged and the historical-pin files never leak in.
+    * Manifest + lockfile coverage (G4): a drifted first-party crate
+      manifest (`thetadatadx-server`) and a drifted lockfile entry are
+      flagged, a third-party crate is ignored, a `[dependencies]` version
+      is not mistaken for the package version, and a virtual workspace root
+      with no `[package]` does not crash.
+    * OpenAPI info.version (G12): the block-scoped reader returns the
+      `info.version` and not a deeper-indented response-schema `version:`
+      key; a drifted value is read verbatim and a matching one compares
+      equal to canonical.
     """
     global DOC_PIN_PATHS
 
@@ -385,6 +600,179 @@ def _selftest() -> int:
         if cargo_version(matched_cargo) != canonical:
             failures.append(
                 "py-wheel: a matching Python crate version did not compare "
+                "equal to canonical"
+            )
+
+    # --- Doc-pin discovery: recursive *.md scan with exclusions ---------
+    # A synthetic repo tree: a stale pin in an arbitrary install doc must
+    # be discovered, while the same stale pin in a changelog / release-note
+    # / migration guide must be excluded (those legitimately pin history).
+    global ROOT
+    saved_root = ROOT
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ROOT = root
+        DOC_PIN_PATHS = None  # force production discovery against the temp ROOT
+        try:
+            install_doc = root / "sdks" / "README.md"
+            install_doc.parent.mkdir(parents=True, exist_ok=True)
+            install_doc.write_text('thetadatadx = "13.0.0-rc.1"\n', encoding="utf-8")
+
+            changelog = root / "CHANGELOG.md"
+            changelog.write_text('thetadatadx = "13.0.0-rc.1"\n', encoding="utf-8")
+
+            release_note = root / ".github" / "release-notes" / "v13.0.0-rc.1.md"
+            release_note.parent.mkdir(parents=True, exist_ok=True)
+            release_note.write_text('thetadatadx = "13.0.0-rc.1"\n', encoding="utf-8")
+
+            migration = root / "docs-site" / "docs" / "migration" / "v11-to-v12.md"
+            migration.parent.mkdir(parents=True, exist_ok=True)
+            migration.write_text('thetadatadx = "11"\n', encoding="utf-8")
+
+            discovered = {p.relative_to(root).as_posix() for p in _discover_doc_pin_files()}
+            if "sdks/README.md" not in discovered:
+                failures.append(
+                    "doc-pin-discovery: an install doc outside the old "
+                    "hardcoded list was not discovered (the recursive *.md "
+                    "scan regressed — this is the crate-README drift bypass)"
+                )
+            for excluded in (
+                "CHANGELOG.md",
+                ".github/release-notes/v13.0.0-rc.1.md",
+                "docs-site/docs/migration/v11-to-v12.md",
+            ):
+                if excluded in discovered:
+                    failures.append(
+                        f"doc-pin-discovery: {excluded} was scanned but must be "
+                        "excluded (it pins historical versions by design)"
+                    )
+
+            mismatches = doc_pin_mismatches(canonical)
+            if not any("sdks/README.md" in m for m in mismatches):
+                failures.append(
+                    "doc-pin-discovery: the stale pin in the discovered install "
+                    "doc was not flagged as a mismatch"
+                )
+            if any("CHANGELOG.md" in m or "migration" in m for m in mismatches):
+                failures.append(
+                    "doc-pin-discovery: a historical-pin file leaked into the "
+                    "mismatch list"
+                )
+        finally:
+            DOC_PIN_PATHS = None
+            ROOT = saved_root
+
+    # --- Manifest + lockfile coverage (G4) -----------------------------
+    # A synthetic repo with a drifted first-party manifest, a drifted
+    # lockfile entry, a third-party manifest that must be IGNORED, and a
+    # virtual workspace root with no `[package]` (must not crash).
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ROOT = root
+        try:
+            # Virtual workspace root — no `[package]`.
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["server"]\n', encoding="utf-8"
+            )
+            # First-party crate manifest, drifted.
+            srv = root / "server" / "Cargo.toml"
+            srv.parent.mkdir(parents=True, exist_ok=True)
+            srv.write_text(
+                '[package]\nname = "thetadatadx-server"\n'
+                'version = "13.0.0-rc.1"\nedition = "2021"\n\n'
+                '[dependencies]\n'
+                # A dependency `version` must NOT be mistaken for the
+                # package version — tomllib scoping proves this.
+                'serde = { version = "1.0.0" }\n',
+                encoding="utf-8",
+            )
+            # Third-party crate manifest — must be ignored (name prefix).
+            other = root / "other" / "Cargo.toml"
+            other.parent.mkdir(parents=True, exist_ok=True)
+            other.write_text(
+                '[package]\nname = "some-other-crate"\n'
+                'version = "0.1.0"\nedition = "2021"\n',
+                encoding="utf-8",
+            )
+            # Lockfile with a drifted first-party entry + an unrelated one.
+            lock = root / "Cargo.lock"
+            lock.write_text(
+                'version = 3\n\n'
+                '[[package]]\nname = "thetadatadx"\nversion = "13.0.0-rc.1"\n\n'
+                '[[package]]\nname = "serde"\nversion = "1.0.0"\n',
+                encoding="utf-8",
+            )
+
+            man_issues = cargo_manifest_mismatches(canonical)
+            if not any("thetadatadx-server" in m for m in man_issues):
+                failures.append(
+                    "manifest: a drifted first-party crate manifest "
+                    "(thetadatadx-server) was not flagged — the FFI / CLI / "
+                    "server / MCP manifests were the unscanned bypass"
+                )
+            if any("some-other-crate" in m for m in man_issues):
+                failures.append(
+                    "manifest: a third-party crate was flagged (the scan must "
+                    "be scoped to `thetadatadx*` crates)"
+                )
+
+            lock_issues = cargo_lock_mismatches(canonical)
+            if not any("thetadatadx" in m for m in lock_issues):
+                failures.append(
+                    "lockfile: a drifted first-party lock entry was not flagged "
+                    "— every Cargo.lock was previously unscanned"
+                )
+            if any("serde" in m for m in lock_issues):
+                failures.append(
+                    "lockfile: an unrelated lock entry (serde) was flagged"
+                )
+        finally:
+            ROOT = saved_root
+
+    # --- OpenAPI info.version (G12) -------------------------------------
+    # The block-scoped reader must pull the `info.version` and ignore the
+    # deeper-indented `version:` keys inside response schemas (the trap the
+    # task flagged). A drifted info.version must be detected; a matching one
+    # must compare equal.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        drift_yaml = root / "drift.yaml"
+        drift_yaml.write_text(
+            "openapi: 3.1.0\n"
+            "info:\n"
+            "  title: Theta Data v3\n"
+            "  version: 13.0.0-rc.1\n"
+            "  contact:\n"
+            "    name: x\n"
+            "paths:\n"
+            "  /v3/thing:\n"
+            "    get:\n"
+            "      responses:\n"
+            "        '200':\n"
+            "          content:\n"
+            "            application/json:\n"
+            "              schema:\n"
+            "                properties:\n"
+            "                  version:\n"
+            "                    type: string\n",
+            encoding="utf-8",
+        )
+        got = openapi_info_version(drift_yaml)
+        if got != "13.0.0-rc.1":
+            failures.append(
+                "openapi-info-version: block-scoped read returned "
+                f"{got!r}, expected '13.0.0-rc.1' (a deeper-indented "
+                "response-schema `version:` key may have been grabbed instead "
+                "of info.version)"
+            )
+        ok_yaml = root / "ok.yaml"
+        ok_yaml.write_text(
+            "info:\n  title: x\n  version: 13.0.0-rc.5\n",
+            encoding="utf-8",
+        )
+        if openapi_info_version(ok_yaml) != canonical:
+            failures.append(
+                "openapi-info-version: a matching info.version did not compare "
                 "equal to canonical"
             )
 

--- a/scripts/ci/tests/test_check_binding_parity.py
+++ b/scripts/ci/tests/test_check_binding_parity.py
@@ -1080,6 +1080,142 @@ def test_historical_families_live_rust_column_clean() -> None:
     assert stream_errors == [], f"live streaming rust column must be clean; got {stream_errors!r}"
 
 
+# ─── napi balanced-paren collector (G2) ────────────────────────────
+
+
+def test_napi_callback_typed_setter_detected(tmp: pathlib.Path) -> None:
+    """A callback-typed napi setter (`ts_args_type = "cb: (e) => void",
+    js_name = "setX"`) must be collected. The old `#[napi(...[^)]*...)]`
+    scan stopped at the `)` inside `(e)` and read it as ABSENT — the G2
+    bypass. The balanced-paren scan must see it.
+    """
+    src = (
+        "#[napi]\n"
+        "impl Config {\n"
+        '    #[napi(ts_args_type = "cb: (e: Event) => void", '
+        'js_name = "setStreamCallback")]\n'
+        "    pub fn set_stream_callback(&mut self, cb: ThreadsafeFunction)"
+        " -> napi::Result<()> { Ok(()) }\n"
+        "}\n"
+    )
+    (tmp / "config.rs").write_text(src, encoding="utf-8")
+    setters = cbp._collect_typescript_setters(tmp)
+    assert any("stream_callback" in s for s in setters), (
+        "callback-typed napi setter was not collected (the balanced-paren "
+        f"scan regressed); got {sorted(setters)!r}"
+    )
+
+
+def test_napi_callback_typed_method_detected(tmp: pathlib.Path) -> None:
+    """A callback-typed napi class method must be collected — the same
+    inner-paren bypass on the class-method collector.
+    """
+    src = (
+        "#[napi]\n"
+        "impl StreamView {\n"
+        '    #[napi(ts_args_type = "cb: (e: Event) => void", '
+        'js_name = "onEvent")]\n'
+        "    pub fn on_event(&self, cb: ThreadsafeFunction)"
+        " -> napi::Result<()> { Ok(()) }\n"
+        "}\n"
+    )
+    (tmp / "sv.rs").write_text(src, encoding="utf-8")
+    methods = cbp._collect_typescript_class_methods(tmp)
+    assert "onEvent" in methods.get("StreamView", set()), (
+        "callback-typed napi method was not collected on StreamView; got "
+        f"{sorted(methods.get('StreamView', set()))!r}"
+    )
+
+
+def test_napi_getter_order_independent(tmp: pathlib.Path) -> None:
+    """A `#[napi(js_name = "x", getter)]` (getter flag AFTER js_name) must
+    be collected — the balanced scan checks for both tokens regardless of
+    order, where the old regex required `getter` before `js_name`.
+    """
+    src = (
+        "#[napi]\n"
+        "impl Config {\n"
+        '    #[napi(js_name = "fooBar", getter)]\n'
+        "    pub fn foo_bar(&self) -> u32 { 0 }\n"
+        "}\n"
+    )
+    (tmp / "g.rs").write_text(src, encoding="utf-8")
+    getters = cbp._collect_typescript_getters(tmp)
+    assert any("foo_bar" in g for g in getters), (
+        f"order-independent getter not collected; got {sorted(getters)!r}"
+    )
+
+
+# ─── C++ method decl-position collector (G11) ──────────────────────
+
+
+def test_cpp_method_call_site_not_counted_as_decl(tmp: pathlib.Path) -> None:
+    """A C++ method called inside another inline body (`return request(...)`)
+    must NOT count as a declaration. Deleting the `request` DECLARATION
+    while leaving its call sites must make the collector drop `request` —
+    the G11 bypass (a deleted decl masked by in-class call sites).
+    """
+    with_decl = (
+        "class FlatFiles {\n"
+        "public:\n"
+        "    FlatFileRowList request(const std::string& a) const {\n"
+        "        return FlatFileRowList(do_it(a));\n"
+        "    }\n"
+        "    FlatFileRowList option_eod(const std::string& d) const {\n"
+        '        return request("OPTION");\n'
+        "    }\n"
+        "};\n"
+    )
+    decl_deleted = (
+        "class FlatFiles {\n"
+        "public:\n"
+        "    FlatFileRowList option_eod(const std::string& d) const {\n"
+        '        return request("OPTION");\n'
+        "    }\n"
+        "};\n"
+    )
+    hpp = tmp / "thetadatadx.hpp"
+
+    hpp.write_text(with_decl, encoding="utf-8")
+    methods = cbp._collect_cpp_class_methods(hpp).get("FlatFiles", set())
+    assert "request" in methods, (
+        f"declared method `request` not collected; got {sorted(methods)!r}"
+    )
+
+    hpp.write_text(decl_deleted, encoding="utf-8")
+    methods = cbp._collect_cpp_class_methods(hpp).get("FlatFiles", set())
+    assert "request" not in methods, (
+        "a deleted C++ method declaration was still reported because its "
+        "in-class call sites kept the name alive (the G11 bypass); got "
+        f"{sorted(methods)!r}"
+    )
+    # The real surviving accessor must still be collected.
+    assert "option_eod" in methods, (
+        f"a genuine method declaration was dropped; got {sorted(methods)!r}"
+    )
+
+
+def test_cpp_member_field_not_counted_as_method(tmp: pathlib.Path) -> None:
+    """A trailing-underscore member field (`handle_`) must not be collected
+    as a method — only `<return-type> name(` declarations count.
+    """
+    src = (
+        "class Foo {\n"
+        "public:\n"
+        "    int32_t value() const { return handle_; }\n"
+        "private:\n"
+        "    Handle* handle_;\n"
+        "};\n"
+    )
+    hpp = tmp / "thetadatadx.hpp"
+    hpp.write_text(src, encoding="utf-8")
+    methods = cbp._collect_cpp_class_methods(hpp).get("Foo", set())
+    assert "value" in methods, f"real method dropped; got {sorted(methods)!r}"
+    assert "handle_" not in methods, (
+        f"a member field was counted as a method; got {sorted(methods)!r}"
+    )
+
+
 # ─── Driver ────────────────────────────────────────────────────────
 
 
@@ -1126,6 +1262,32 @@ def main() -> int:
     _check("historical-base untracked orphan trips", test_historical_base_untracked_orphan_trips)
     _check("historical-base live sources clean", test_historical_base_live_sources_clean)
     _check("historical families live rust column clean", test_historical_families_live_rust_column_clean)
+    # napi balanced-paren collector (G2) + C++ decl-position collector (G11)
+    with tempfile.TemporaryDirectory() as tmp:
+        _check(
+            "napi callback-typed setter detected",
+            lambda: test_napi_callback_typed_setter_detected(pathlib.Path(tmp)),
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        _check(
+            "napi callback-typed method detected",
+            lambda: test_napi_callback_typed_method_detected(pathlib.Path(tmp)),
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        _check(
+            "napi getter order-independent",
+            lambda: test_napi_getter_order_independent(pathlib.Path(tmp)),
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        _check(
+            "cpp method call-site not counted as decl",
+            lambda: test_cpp_method_call_site_not_counted_as_decl(pathlib.Path(tmp)),
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        _check(
+            "cpp member field not counted as method",
+            lambda: test_cpp_member_field_not_counted_as_method(pathlib.Path(tmp)),
+        )
 
     if _fails:
         print(f"test_check_binding_parity: {len(_fails)} failure(s)")


### PR DESCRIPTION
Hardens the CI guards and workflow gates. Every fix below started from a crafted bypass that let real drift slip through; each is fixed and proven closed by a selftest/test case that fails on the bypass and stays clean on a correct tree. Every guard is green on `main`. Rebased onto `main` after #953 (the client-facing vocabulary gate) merged, integrating cleanly with it.

## Guard completeness

- **check_c_abi_completeness** — a C declaration deleted from `thetadatadx.h` passed two ways. (1) The declaration scan globbed the C++ inline wrappers (`*.hpp` / `*.hpp.inc`), whose bodies call every C symbol, so a `thetadatadx_foo(` call matched the prototype regex. (2) A string literal in a `.h` / `.inc` could embed a `<word> thetadatadx_x(` fragment that mimics declaration position — comments were stripped, strings were not. Fixed by scoping the scan to the C declaration headers (`.h` / `.h.inc`), requiring declaration position (a return-type / `extern` token before the symbol), and stripping string and char literals alongside comments before scanning. Verified with the compiled `.so` (nm path): deleting a real decl trips even when a `.hpp` call site survives **and** when a string literal that perfectly mimics the deleted prototype is injected.
- **check_binding_parity** — the four napi collectors used `[^)]*`, which cannot cross an inner `)`, so a callback-typed signature (`ts_args_type = "cb: (e) => void", js_name = "setCallback"`) read as absent. Replaced all four with a balanced-paren attribute scan. Separately, the C++ method collector counted any `name(` token, so a member called inside another inline body (`return request(...)`) masked a deleted declaration; anchored it to a return-type token (the `FlatFilesNamespace.request` row was the live victim). Reconciled the `setCallback` rows in `parity.toml` against the real TS surface — TS exposes `startStreaming(callback)`, not `setCallback`, so `typescript = false` is correct and unchanged.
- **check_version_sync** — the doc-pin scan covered three hand-picked files and missed `crates/thetadatadx/README.md`, which ships to docs.rs and pinned a stale pre-release (live drift, fixed here). Now discovers every `*.md` (excluding changelog / release-notes / migration guides, which pin history by design). Only one `Cargo.toml` and zero `Cargo.lock` files were scanned; now asserts every first-party `[package].version` and every lockfile `thetadatadx*` entry. Added a block-scoped `info.version` check for the published OpenAPI contract (scoped to the top-level `info:` key, not the `version:` keys nested in response schemas).
- **check_docs_consistency** — the server flag-default table was only substring-checked, so a default that changed to a value still printed elsewhere passed. Now derives each default from the `#[arg(...)]` attributes in `tools/server/src/main.rs` and asserts both doc tables value-by-value, using a balanced-paren attribute scan so a `value_parser` allow-list does not truncate it.
- **check_public_surface_leak** — extended the forbidden-token set with the rest of the standing impl-IP vocabulary (`firehose`, `routing table`, `arc-swap`, `dashmap`, `rustc-hash`, `epoll`, `kqueue`, `pyo3-async-runtimes`, `future_into_py`, `SharedProducer`, `StateCell`). Worker-thread vocabulary is intentionally excluded: the worker-thread count is a documented public knob (`set_worker_threads` / `worker_threads`), already adjudicated neutral public surface by `check_binding_parity`'s public-surface-vocab gate (with an explicit test), so banning "worker pool" would fire on a legitimate API description. The internal runtime crate (`tokio`) is already banned — that is the token that would actually leak the implementation.
- **check_no_re_framing** — a dotted `net.thetadata.*` Java FQCN passed (only `<ident>.java` was caught). Added the dotted-package pattern while leaving bare public type names (`MarketValueTick`) clean, and exempted the pinned upstream OpenAPI snapshot under `scripts/ci/data/`, which carries the vendor's own `x-java-package` field.

## Workflow enforcement

- `python.yml`, `typescript.yml`, and `perf-gate.yml` had no aggregator, so requiring only the core gate left those three workflows gating nothing. Added an `if: always()` roll-up to each (`Python gate` / `TypeScript gate` / `Perf gate`) that `needs:` every job in its file and fails on any result not in `(success, skipped)`, mirroring the core gate.
- Split the pure-script `lockfile-drift` and endpoint-`agreement` gates out of the rust-path-gated heavy job into fast-lane jobs that run on every PR, and added them to the core gate so a docs-only PR can no longer skip them.
- Wired the c-abi / docs-consistency / version-sync selftests into both the workflow and the local gate runner. These coexist with #953's client-facing vocabulary detector step in the `public-surface-leak` job, which still runs both `check_public_surface_leak` and `check_client_facing_vocab`.
- Added `.github/rulesets/main-branch-protection.json` and a doc naming the canonical required set: the four aggregators (`CI gate`, `Python gate`, `TypeScript gate`, `Perf gate`). Applying it is a repo-admin action.

## Verification

All guard selftests pass; the parity test suite is 38 → 43 cases (5 new bypass tests); every guard is clean on `main`; `actionlint` passes on all workflows. The c-abi bypasses are proven via `nm` on the built `.so`, not the regex fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjMGD5k863GuRTvGYXzaus