### PR TITLE
docs(reference): document the expiration and right wildcards from endpoint capability

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/docs_render/page.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/docs_render/page.rs
@@ -3,7 +3,7 @@
 use std::fmt::Write as _;
 
 use super::super::super::ticks::schema::Schema;
-use super::super::model::GeneratedEndpoint;
+use super::super::model::{GeneratedEndpoint, GeneratedParam};
 use super::super::sdk_helpers::{builder_params, method_params};
 use super::{lang, response};
 
@@ -108,7 +108,34 @@ fn docs_param_type(param_type: &str) -> &'static str {
     }
 }
 
+/// Note appended to the `expiration` parameter row on the endpoints whose
+/// upstream binding accepts the chain-wide wildcard. Single sentence so the
+/// per-endpoint `expiration=*` capability is documented once, from the same
+/// capability the mode taxonomy reads, instead of being hand-scattered across
+/// vendor docstrings where it silently drifted out of the parameters table.
+const EXPIRATION_WILDCARD_NOTE: &str =
+    "Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time).";
+
+/// Build the parameters-table Description cell for one parameter row, folding
+/// newlines to spaces. The `expiration` row also carries the chain-wide
+/// wildcard note when this endpoint supports it; endpoints upstream binds to
+/// `expiration_no_star` reject `*`, so they render the plain description.
+fn param_description_cell(param: &GeneratedParam, supports_expiration_wildcard: bool) -> String {
+    let base = param.description.replace('\n', " ");
+    if param.name == "expiration" && supports_expiration_wildcard {
+        format!("{base} {EXPIRATION_WILDCARD_NOTE}")
+    } else {
+        base
+    }
+}
+
 fn render_params_section(endpoint: &GeneratedEndpoint) -> String {
+    // Single source of truth for `expiration=*` support: the same pinned
+    // upstream snapshot the mode taxonomy reads, so the rendered note and the
+    // emitted wildcard test modes can never disagree.
+    let supports_expiration_wildcard =
+        super::super::modes::endpoint_supports_expiration_wildcard(&endpoint.name);
+
     let mut out = String::from("## Parameters\n\n");
     out.push_str("| Name | Type | Required | Default | Description |\n|---|---|---|---|---|\n");
     for param in method_params(endpoint)
@@ -128,7 +155,7 @@ fn render_params_section(endpoint: &GeneratedEndpoint) -> String {
             docs_param_type(&param.param_type),
             required,
             default,
-            param.description.replace('\n', " "),
+            param_description_cell(param, supports_expiration_wildcard),
         );
     }
     out.push_str(

--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -149,7 +149,7 @@ default = "*"
 
 [[param_groups.right_param.params]]
 name = "right"
-description = "Option side."
+description = "Option side. Use `both` or `*` (alias) for calls and puts."
 param_type = "Right"
 enum = "Right"
 required = false

--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -1388,7 +1388,6 @@ template = "option_snapshot_greeks"
 description = "Get all Greeks snapshot for an option contract (from ThetaData server)."
 vendor_docstring = """
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/all"
@@ -1400,7 +1399,6 @@ template = "option_snapshot_greeks"
 description = "Get first-order Greeks snapshot (delta, theta, rho) for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/first_order"
@@ -1412,7 +1410,6 @@ template = "option_snapshot_greeks"
 description = "Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/second_order"
@@ -1424,7 +1421,6 @@ template = "option_snapshot_greeks"
 description = "Get third-order Greeks snapshot (speed, color, ultima) for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/third_order"
@@ -1512,7 +1508,7 @@ description = "Fetch end-of-day Greeks history for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-- **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+- **Any ``expiration=*`` request must be made day by day.**
 """
 rest_path = "/v3/option/history/greeks/eod"
 returns = "GreeksEodTicks"

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -224,12 +224,11 @@ x-anchors:
       type: string
       enum: [call, put, both, C, P, c, p, CALL, PUT, Call, Put, "*"]
     description: >-
-      Option right. Accepts `call`, `put`, `both` (upstream ThetaData
-      vocabulary; upstream default is `both`), plus our short-forms `C`
-      (call), `P` (put), and `*` (alias for `both`) for SDK ergonomics.
-      Matching is case-insensitive. The `both` / `*` wildcard is only
-      meaningful on endpoints that also accept `strike="0"` and
-      `expiration="0"` wildcards.
+      Option side. Use `both` or `*` (alias) for calls and puts. Accepts
+      `call`, `put`, `both` (upstream ThetaData vocabulary; upstream default
+      is `both`), plus our short-forms `C` (call), `P` (put), and `*` (alias
+      for `both`) for SDK ergonomics. Matching is case-insensitive. Every
+      endpoint that exposes `right` accepts the `both` / `*` wildcard.
 
   max_dte-param: &max_dte-param
     name: max_dte

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -192,8 +192,21 @@ x-anchors:
     required: true
     schema:
       type: string
+      pattern: '^(\d{8}|\*)$'
+    description: >-
+      Option expiration date in YYYYMMDD format. Pass `*` to select all
+      expirations for the underlying (chain-wide; query one date at a time).
+
+  expiration-no-star-param: &expiration-no-star-param
+    name: expiration
+    in: query
+    required: true
+    schema:
+      type: string
       pattern: '^\d{8}$'
-    description: Option expiration date in YYYYMMDD format
+    description: >-
+      Option expiration date in YYYYMMDD format. This endpoint resolves a
+      single concrete expiration and rejects the `*` wildcard.
 
   strike-param: &strike-param
     name: strike
@@ -1175,7 +1188,7 @@ paths:
       parameters:
         - *request_type-param
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
       responses:
@@ -1232,7 +1245,7 @@ paths:
       tags: [Option / List]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
       responses:
         '200':
           description: Successful response
@@ -1335,7 +1348,7 @@ paths:
       tags: [Option / Snapshot]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *strike_range-param
@@ -1705,7 +1718,7 @@ paths:
       tags: [Option / History]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *date-optional-param
@@ -1981,7 +1994,7 @@ paths:
       tags: [Option / History Greeks]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *date-optional-param
@@ -2032,7 +2045,7 @@ paths:
       tags: [Option / History Greeks]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *date-optional-param
@@ -2083,7 +2096,7 @@ paths:
       tags: [Option / History Greeks]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *date-optional-param
@@ -2134,7 +2147,7 @@ paths:
       tags: [Option / History Greeks]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *date-optional-param
@@ -2185,7 +2198,7 @@ paths:
       tags: [Option / History Greeks]
       parameters:
         - *symbol-param
-        - *expiration-param
+        - *expiration-no-star-param
         - *strike-param
         - *right-param
         - *date-optional-param

--- a/docs-site/docs/reference/option/at-time/quote.md
+++ b/docs-site/docs/reference/option/at-time/quote.md
@@ -155,7 +155,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/at_time/quote' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `time_of_day` | string | yes | — | ET wall-clock time in HH:MM:SS.SSS (e.g. 09:30:00.000 for 9:30 AM ET; legacy 34200000 is also accepted) |

--- a/docs-site/docs/reference/option/at-time/quote.md
+++ b/docs-site/docs/reference/option/at-time/quote.md
@@ -160,7 +160,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/at_time/quote' \
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `time_of_day` | string | yes | — | ET wall-clock time in HH:MM:SS.SSS (e.g. 09:30:00.000 for 9:30 AM ET; legacy 34200000 is also accepted) |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `timeout_ms` | int | no | — | Per-request deadline in milliseconds. 0 means no deadline. |

--- a/docs-site/docs/reference/option/at-time/trade.md
+++ b/docs-site/docs/reference/option/at-time/trade.md
@@ -157,7 +157,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/at_time/trade' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `time_of_day` | string | yes | — | ET wall-clock time in HH:MM:SS.SSS (e.g. 09:30:00.000 for 9:30 AM ET; legacy 34200000 is also accepted) |

--- a/docs-site/docs/reference/option/at-time/trade.md
+++ b/docs-site/docs/reference/option/at-time/trade.md
@@ -162,7 +162,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/at_time/trade' \
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `time_of_day` | string | yes | — | ET wall-clock time in HH:MM:SS.SSS (e.g. 09:30:00.000 for 9:30 AM ET; legacy 34200000 is also accepted) |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `timeout_ms` | int | no | — | Per-request deadline in milliseconds. 0 means no deadline. |

--- a/docs-site/docs/reference/option/history/eod.md
+++ b/docs-site/docs/reference/option/history/eod.md
@@ -153,7 +153,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/eod' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |

--- a/docs-site/docs/reference/option/history/eod.md
+++ b/docs-site/docs/reference/option/history/eod.md
@@ -157,7 +157,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/eod' \
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `timeout_ms` | int | no | — | Per-request deadline in milliseconds. 0 means no deadline. |

--- a/docs-site/docs/reference/option/history/greeks/all.md
+++ b/docs-site/docs/reference/option/history/greeks/all.md
@@ -157,7 +157,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/all' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/greeks/eod.md
+++ b/docs-site/docs/reference/option/history/greeks/eod.md
@@ -13,7 +13,7 @@ Fetch end-of-day Greeks history for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-- **Set `expiration` to `*` if you want to retrieve data for every option that shares the same `symbol`. (note: Any `expiration=*` must be requested day by day)**
+- **Any `expiration=*` request must be made day by day.**
 
 <SdkTabs>
 
@@ -154,7 +154,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/eod' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |

--- a/docs-site/docs/reference/option/history/greeks/eod.md
+++ b/docs-site/docs/reference/option/history/greeks/eod.md
@@ -158,7 +158,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/eod' \
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |
 | `rate_type` | string | no | `sofr` | Risk-free-rate source used in the Greeks calculation. Accepted values: `sofr`, `treasury_m1`, `treasury_m3`, `treasury_m6`, `treasury_y1`, `treasury_y2`, `treasury_y3`, `treasury_y5`, `treasury_y7`, `treasury_y10`, `treasury_y20`, `treasury_y30`. |
 | `rate_value` | float | no | — | Interest rate as a percent (4.36 means 4.36%, matching the InterestRateTick.rate convention) used in the Greeks calculation. Applied when rate_type selects a manual rate. |

--- a/docs-site/docs/reference/option/history/greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/greeks/first-order.md
@@ -157,7 +157,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/first_order' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/greeks/implied-volatility.md
@@ -156,7 +156,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/implied_volatility' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/greeks/second-order.md
@@ -157,7 +157,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/second_order' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/greeks/third-order.md
@@ -157,7 +157,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/greeks/third_order' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/ohlc.md
+++ b/docs-site/docs/reference/option/history/ohlc.md
@@ -155,7 +155,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/ohlc' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/open-interest.md
+++ b/docs-site/docs/reference/option/history/open-interest.md
@@ -152,7 +152,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/open_interest' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `start_date` | date | no | — | Start date YYYYMMDD |

--- a/docs-site/docs/reference/option/history/open-interest.md
+++ b/docs-site/docs/reference/option/history/open-interest.md
@@ -149,7 +149,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/open_interest' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/quote.md
+++ b/docs-site/docs/reference/option/history/quote.md
@@ -153,7 +153,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/quote' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/quote.md
+++ b/docs-site/docs/reference/option/history/quote.md
@@ -156,7 +156,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/quote' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |

--- a/docs-site/docs/reference/option/history/trade-greeks/all.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/all.md
@@ -152,7 +152,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/all' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/trade-greeks/all.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/all.md
@@ -155,7 +155,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/all' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/trade-greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/first-order.md
@@ -152,7 +152,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/first_order' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/trade-greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/first-order.md
@@ -155,7 +155,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/first_order' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
@@ -154,7 +154,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/implied_volatilit
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
@@ -151,7 +151,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/implied_volatilit
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/trade-greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/second-order.md
@@ -155,7 +155,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/second_order' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/trade-greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/second-order.md
@@ -152,7 +152,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/second_order' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/trade-greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/third-order.md
@@ -155,7 +155,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/third_order' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/trade-greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/third-order.md
@@ -152,7 +152,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_greeks/third_order' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/trade-quote.md
+++ b/docs-site/docs/reference/option/history/trade-quote.md
@@ -154,7 +154,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_quote' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `exclusive` | bool | no | `false` | When true, quotes whose timestamp equals the trade timestamp are excluded; only quotes strictly before the trade are paired. |

--- a/docs-site/docs/reference/option/history/trade-quote.md
+++ b/docs-site/docs/reference/option/history/trade-quote.md
@@ -151,7 +151,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade_quote' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/history/trade.md
+++ b/docs-site/docs/reference/option/history/trade.md
@@ -153,7 +153,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade' \
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `max_dte` | int | no | — | Maximum days to expiration |

--- a/docs-site/docs/reference/option/history/trade.md
+++ b/docs-site/docs/reference/option/history/trade.md
@@ -150,7 +150,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/history/trade' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `date` | date | yes | — | Date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |

--- a/docs-site/docs/reference/option/list/dates.md
+++ b/docs-site/docs/reference/option/list/dates.md
@@ -150,7 +150,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/list/dates' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `timeout_ms` | int | no | — | Per-request deadline in milliseconds. 0 means no deadline. |
 
 ## Response

--- a/docs-site/docs/reference/option/snapshot/greeks/all.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/all.md
@@ -142,7 +142,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/all' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |
 | `rate_type` | string | no | `sofr` | Risk-free-rate source used in the Greeks calculation. Accepted values: `sofr`, `treasury_m1`, `treasury_m3`, `treasury_m6`, `treasury_y1`, `treasury_y2`, `treasury_y3`, `treasury_y5`, `treasury_y7`, `treasury_y10`, `treasury_y20`, `treasury_y30`. |
 | `rate_value` | float | no | — | Interest rate as a percent (4.36 means 4.36%, matching the InterestRateTick.rate convention) used in the Greeks calculation. Applied when rate_type selects a manual rate. |

--- a/docs-site/docs/reference/option/snapshot/greeks/all.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/all.md
@@ -12,7 +12,6 @@ description: "Get all Greeks snapshot for an option contract (from ThetaData ser
 Get all Greeks snapshot for an option contract (from ThetaData server).
 
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>
@@ -141,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/all' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/snapshot/greeks/first-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/first-order.md
@@ -142,7 +142,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/first_order' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |
 | `rate_type` | string | no | `sofr` | Risk-free-rate source used in the Greeks calculation. Accepted values: `sofr`, `treasury_m1`, `treasury_m3`, `treasury_m6`, `treasury_y1`, `treasury_y2`, `treasury_y3`, `treasury_y5`, `treasury_y7`, `treasury_y10`, `treasury_y20`, `treasury_y30`. |
 | `rate_value` | float | no | — | Interest rate as a percent (4.36 means 4.36%, matching the InterestRateTick.rate convention) used in the Greeks calculation. Applied when rate_type selects a manual rate. |

--- a/docs-site/docs/reference/option/snapshot/greeks/first-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/first-order.md
@@ -12,7 +12,6 @@ description: "Get first-order Greeks snapshot (delta, theta, rho) for an option 
 Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
 
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>
@@ -141,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/first_order' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
@@ -142,7 +142,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/implied_volatility' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
@@ -144,7 +144,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/implied_volatility' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |
 | `rate_type` | string | no | `sofr` | Risk-free-rate source used in the Greeks calculation. Accepted values: `sofr`, `treasury_m1`, `treasury_m3`, `treasury_m6`, `treasury_y1`, `treasury_y2`, `treasury_y3`, `treasury_y5`, `treasury_y7`, `treasury_y10`, `treasury_y20`, `treasury_y30`. |
 | `rate_value` | float | no | — | Interest rate as a percent (4.36 means 4.36%, matching the InterestRateTick.rate convention) used in the Greeks calculation. Applied when rate_type selects a manual rate. |

--- a/docs-site/docs/reference/option/snapshot/greeks/second-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/second-order.md
@@ -12,7 +12,6 @@ description: "Get second-order Greeks snapshot (gamma, vanna, charm) for an opti
 Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
 
 - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>
@@ -141,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/second_order' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/snapshot/greeks/second-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/second-order.md
@@ -142,7 +142,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/second_order' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |
 | `rate_type` | string | no | `sofr` | Risk-free-rate source used in the Greeks calculation. Accepted values: `sofr`, `treasury_m1`, `treasury_m3`, `treasury_m6`, `treasury_y1`, `treasury_y2`, `treasury_y3`, `treasury_y5`, `treasury_y7`, `treasury_y10`, `treasury_y20`, `treasury_y30`. |
 | `rate_value` | float | no | — | Interest rate as a percent (4.36 means 4.36%, matching the InterestRateTick.rate convention) used in the Greeks calculation. Applied when rate_type selects a manual rate. |

--- a/docs-site/docs/reference/option/snapshot/greeks/third-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/third-order.md
@@ -12,7 +12,6 @@ description: "Get third-order Greeks snapshot (speed, color, ultima) for an opti
 Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
 
 - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>
@@ -141,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/third_order' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/snapshot/greeks/third-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/third-order.md
@@ -142,7 +142,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/greeks/third_order' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |
 | `rate_type` | string | no | `sofr` | Risk-free-rate source used in the Greeks calculation. Accepted values: `sofr`, `treasury_m1`, `treasury_m3`, `treasury_m6`, `treasury_y1`, `treasury_y2`, `treasury_y3`, `treasury_y5`, `treasury_y7`, `treasury_y10`, `treasury_y20`, `treasury_y30`. |
 | `rate_value` | float | no | — | Interest rate as a percent (4.36 means 4.36%, matching the InterestRateTick.rate convention) used in the Greeks calculation. Applied when rate_type selects a manual rate. |

--- a/docs-site/docs/reference/option/snapshot/market-value.md
+++ b/docs-site/docs/reference/option/snapshot/market-value.md
@@ -138,7 +138,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/market_value' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |

--- a/docs-site/docs/reference/option/snapshot/market-value.md
+++ b/docs-site/docs/reference/option/snapshot/market-value.md
@@ -140,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/market_value' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `min_time` | string | no | — | Minimum time filter |

--- a/docs-site/docs/reference/option/snapshot/ohlc.md
+++ b/docs-site/docs/reference/option/snapshot/ohlc.md
@@ -133,7 +133,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/ohlc' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |

--- a/docs-site/docs/reference/option/snapshot/ohlc.md
+++ b/docs-site/docs/reference/option/snapshot/ohlc.md
@@ -135,7 +135,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/ohlc' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `min_time` | string | no | — | Minimum time filter |

--- a/docs-site/docs/reference/option/snapshot/open-interest.md
+++ b/docs-site/docs/reference/option/snapshot/open-interest.md
@@ -142,7 +142,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/open_interest' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `min_time` | string | no | — | Minimum time filter |

--- a/docs-site/docs/reference/option/snapshot/open-interest.md
+++ b/docs-site/docs/reference/option/snapshot/open-interest.md
@@ -140,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/open_interest' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |

--- a/docs-site/docs/reference/option/snapshot/quote.md
+++ b/docs-site/docs/reference/option/snapshot/quote.md
@@ -141,7 +141,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/quote' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |
 | `strike_range` | int | no | — | Strike range filter |
 | `min_time` | string | no | — | Minimum time filter |

--- a/docs-site/docs/reference/option/snapshot/quote.md
+++ b/docs-site/docs/reference/option/snapshot/quote.md
@@ -139,7 +139,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/quote' \
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
-| `expiration` | date | yes | — | Expiration date YYYYMMDD |
+| `expiration` | date | yes | — | Expiration date YYYYMMDD Pass `*` to select all expirations for the underlying (chain-wide; query one date at a time). |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
 | `max_dte` | int | no | — | Maximum days to expiration |

--- a/docs-site/docs/reference/option/snapshot/trade.md
+++ b/docs-site/docs/reference/option/snapshot/trade.md
@@ -140,7 +140,7 @@ curl -G 'http://127.0.0.1:25503/v3/option/snapshot/trade' \
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `expiration` | date | yes | — | Expiration date YYYYMMDD |
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
-| `right` | string | no | `both` | Option side. Accepted values: `call`, `put`, `both`. |
+| `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. |
 | `strike_range` | int | no | — | Strike range filter |
 | `min_time` | string | no | — | Minimum time filter |
 | `timeout_ms` | int | no | — | Per-request deadline in milliseconds. 0 means no deadline. |

--- a/ffi/src/endpoint_request_options.rs
+++ b/ffi/src/endpoint_request_options.rs
@@ -31,7 +31,7 @@ pub struct ThetaDataDxEndpointRequestOptions {
     pub has_exclusive: i32,
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: *const c_char,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: *const c_char,
     /// Maximum days to expiration
     pub max_dte: i32,

--- a/sdks/cpp/include/endpoint_options.hpp.inc
+++ b/sdks/cpp/include/endpoint_options.hpp.inc
@@ -34,7 +34,7 @@ struct EndpointRequestOptions {
     std::optional<bool> exclusive;
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     std::optional<std::string> strike;
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     std::optional<std::string> right;
     /// Maximum days to expiration
     std::optional<int32_t> max_dte;

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -2669,7 +2669,6 @@ class HistoricalView:
         """Get all Greeks snapshot for an option contract (from ThetaData server).
 
         - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2702,7 +2701,6 @@ class HistoricalView:
         """Get all Greeks snapshot for an option contract (from ThetaData server).
 
         - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2746,7 +2744,6 @@ class HistoricalView:
         """Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
 
         - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2779,7 +2776,6 @@ class HistoricalView:
         """Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
 
         - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2823,7 +2819,6 @@ class HistoricalView:
         """Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
 
         - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2856,7 +2851,6 @@ class HistoricalView:
         """Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
 
         - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2900,7 +2894,6 @@ class HistoricalView:
         """Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
 
         - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -2933,7 +2926,6 @@ class HistoricalView:
         """Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
 
         - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-        - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
         > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
         Defaults (upstream):
@@ -3409,7 +3401,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-        - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+        - **Any ``expiration=*`` request must be made day by day.**
 
         Defaults (upstream):
         - `strike`: `"*"`
@@ -3442,7 +3434,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-        - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+        - **Any ``expiration=*`` request must be made day by day.**
 
         Defaults (upstream):
         - `strike`: `"*"`

--- a/sdks/python/src/_generated/historical_methods.rs
+++ b/sdks/python/src/_generated/historical_methods.rs
@@ -3748,7 +3748,6 @@ impl OptionSnapshotGreeksImpliedVolatilityBuilder {
 /// Get all Greeks snapshot for an option contract (from ThetaData server).
 ///
 /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -3989,7 +3988,6 @@ impl OptionSnapshotGreeksAllBuilder {
 /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
 ///
 /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -4230,7 +4228,6 @@ impl OptionSnapshotGreeksFirstOrderBuilder {
 /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
 ///
 /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -4471,7 +4468,6 @@ impl OptionSnapshotGreeksSecondOrderBuilder {
 /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
 ///
 /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -6806,7 +6802,7 @@ impl OptionHistoryOpenInterestBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
 /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-/// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+/// - **Any ``expiration=*`` request must be made day by day.**
 ///
 /// Defaults (upstream):
 /// - `strike`: `"*"`
@@ -16733,7 +16729,6 @@ impl HistoricalView {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16805,7 +16800,6 @@ impl HistoricalView {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16915,7 +16909,6 @@ impl HistoricalView {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16987,7 +16980,6 @@ impl HistoricalView {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17097,7 +17089,6 @@ impl HistoricalView {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17169,7 +17160,6 @@ impl HistoricalView {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17279,7 +17269,6 @@ impl HistoricalView {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17351,7 +17340,6 @@ impl HistoricalView {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -18376,7 +18364,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-    /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    /// - **Any ``expiration=*`` request must be made day by day.**
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -18442,7 +18430,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-    /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    /// - **Any ``expiration=*`` request must be made day by day.**
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -4101,7 +4101,7 @@ export declare function openInterestTickToArrowIpc(rows: Array<OpenInterestTick>
 export interface OptionAtTimeQuoteOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -4125,7 +4125,7 @@ export interface OptionAtTimeQuoteOptions {
 export interface OptionAtTimeTradeOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -4157,7 +4157,7 @@ export interface OptionContract {
 export interface OptionHistoryEodOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -4181,7 +4181,7 @@ export interface OptionHistoryEodOptions {
 export interface OptionHistoryGreeksAllOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4221,7 +4221,7 @@ export interface OptionHistoryGreeksAllOptions {
 export interface OptionHistoryGreeksEodOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). */
   annualDividend?: number
@@ -4255,7 +4255,7 @@ export interface OptionHistoryGreeksEodOptions {
 export interface OptionHistoryGreeksFirstOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4295,7 +4295,7 @@ export interface OptionHistoryGreeksFirstOrderOptions {
 export interface OptionHistoryGreeksImpliedVolatilityOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4335,7 +4335,7 @@ export interface OptionHistoryGreeksImpliedVolatilityOptions {
 export interface OptionHistoryGreeksSecondOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4375,7 +4375,7 @@ export interface OptionHistoryGreeksSecondOrderOptions {
 export interface OptionHistoryGreeksThirdOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4415,7 +4415,7 @@ export interface OptionHistoryGreeksThirdOrderOptions {
 export interface OptionHistoryOhlcOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4447,7 +4447,7 @@ export interface OptionHistoryOhlcOptions {
 export interface OptionHistoryOpenInterestOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -4475,7 +4475,7 @@ export interface OptionHistoryOpenInterestOptions {
 export interface OptionHistoryQuoteOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
@@ -4509,7 +4509,7 @@ export interface OptionHistoryQuoteOptions {
 export interface OptionHistoryTradeGreeksAllOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4549,7 +4549,7 @@ export interface OptionHistoryTradeGreeksAllOptions {
 export interface OptionHistoryTradeGreeksFirstOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4589,7 +4589,7 @@ export interface OptionHistoryTradeGreeksFirstOrderOptions {
 export interface OptionHistoryTradeGreeksImpliedVolatilityOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4629,7 +4629,7 @@ export interface OptionHistoryTradeGreeksImpliedVolatilityOptions {
 export interface OptionHistoryTradeGreeksSecondOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4669,7 +4669,7 @@ export interface OptionHistoryTradeGreeksSecondOrderOptions {
 export interface OptionHistoryTradeGreeksThirdOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4709,7 +4709,7 @@ export interface OptionHistoryTradeGreeksThirdOrderOptions {
 export interface OptionHistoryTradeOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4741,7 +4741,7 @@ export interface OptionHistoryTradeOptions {
 export interface OptionHistoryTradeQuoteOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4881,7 +4881,7 @@ export interface OptionListSymbolsOptions {
 export interface OptionSnapshotGreeksAllOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). */
   annualDividend?: number
@@ -4919,7 +4919,7 @@ export interface OptionSnapshotGreeksAllOptions {
 export interface OptionSnapshotGreeksFirstOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). */
   annualDividend?: number
@@ -4957,7 +4957,7 @@ export interface OptionSnapshotGreeksFirstOrderOptions {
 export interface OptionSnapshotGreeksImpliedVolatilityOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). */
   annualDividend?: number
@@ -4995,7 +4995,7 @@ export interface OptionSnapshotGreeksImpliedVolatilityOptions {
 export interface OptionSnapshotGreeksSecondOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). */
   annualDividend?: number
@@ -5033,7 +5033,7 @@ export interface OptionSnapshotGreeksSecondOrderOptions {
 export interface OptionSnapshotGreeksThirdOrderOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). */
   annualDividend?: number
@@ -5071,7 +5071,7 @@ export interface OptionSnapshotGreeksThirdOrderOptions {
 export interface OptionSnapshotMarketValueOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -5097,7 +5097,7 @@ export interface OptionSnapshotMarketValueOptions {
 export interface OptionSnapshotOhlcOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -5123,7 +5123,7 @@ export interface OptionSnapshotOhlcOptions {
 export interface OptionSnapshotOpenInterestOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -5149,7 +5149,7 @@ export interface OptionSnapshotOpenInterestOptions {
 export interface OptionSnapshotQuoteOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Maximum days to expiration */
   maxDte?: number
@@ -5175,7 +5175,7 @@ export interface OptionSnapshotQuoteOptions {
 export interface OptionSnapshotTradeOptions {
   /** Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. */
   strike?: string
-  /** Option side. Accepted values: `call`, `put`, `both`. */
+  /** Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`. */
   right?: string
   /** Strike range filter */
   strikeRange?: number

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -1137,7 +1137,6 @@ export declare class HistoricalClient {
    * Get all Greeks snapshot for an option contract (from ThetaData server).
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1152,7 +1151,6 @@ export declare class HistoricalClient {
    * Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1167,7 +1165,6 @@ export declare class HistoricalClient {
    * Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
    *
    * - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1182,7 +1179,6 @@ export declare class HistoricalClient {
    * Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
    *
    * - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1296,7 +1292,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-   * - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+   * - **Any ``expiration=*`` request must be made day by day.**
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -1963,7 +1959,6 @@ export declare class HistoricalView {
    * Get all Greeks snapshot for an option contract (from ThetaData server).
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1978,7 +1973,6 @@ export declare class HistoricalView {
    * Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1993,7 +1987,6 @@ export declare class HistoricalView {
    * Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
    *
    * - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -2008,7 +2001,6 @@ export declare class HistoricalView {
    * Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
    *
    * - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -2122,7 +2114,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-   * - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+   * - **Any ``expiration=*`` request must be made day by day.**
    *
    * Defaults (upstream):
    * - `strike`: `"*"`

--- a/sdks/typescript/src/_generated/historical_methods.rs
+++ b/sdks/typescript/src/_generated/historical_methods.rs
@@ -329,7 +329,7 @@ pub struct OptionListContractsOptions {
 pub struct OptionSnapshotOHLCOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -353,7 +353,7 @@ pub struct OptionSnapshotOHLCOptions {
 pub struct OptionSnapshotTradeOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Strike range filter
     pub strike_range: Option<f64>,
@@ -375,7 +375,7 @@ pub struct OptionSnapshotTradeOptions {
 pub struct OptionSnapshotQuoteOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -399,7 +399,7 @@ pub struct OptionSnapshotQuoteOptions {
 pub struct OptionSnapshotOpenInterestOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -423,7 +423,7 @@ pub struct OptionSnapshotOpenInterestOptions {
 pub struct OptionSnapshotMarketValueOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -447,7 +447,7 @@ pub struct OptionSnapshotMarketValueOptions {
 pub struct OptionSnapshotGreeksImpliedVolatilityOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year).
     pub annual_dividend: Option<f64>,
@@ -483,7 +483,7 @@ pub struct OptionSnapshotGreeksImpliedVolatilityOptions {
 pub struct OptionSnapshotGreeksAllOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year).
     pub annual_dividend: Option<f64>,
@@ -519,7 +519,7 @@ pub struct OptionSnapshotGreeksAllOptions {
 pub struct OptionSnapshotGreeksFirstOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year).
     pub annual_dividend: Option<f64>,
@@ -555,7 +555,7 @@ pub struct OptionSnapshotGreeksFirstOrderOptions {
 pub struct OptionSnapshotGreeksSecondOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year).
     pub annual_dividend: Option<f64>,
@@ -591,7 +591,7 @@ pub struct OptionSnapshotGreeksSecondOrderOptions {
 pub struct OptionSnapshotGreeksThirdOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year).
     pub annual_dividend: Option<f64>,
@@ -627,7 +627,7 @@ pub struct OptionSnapshotGreeksThirdOrderOptions {
 pub struct OptionHistoryEODOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -649,7 +649,7 @@ pub struct OptionHistoryEODOptions {
 pub struct OptionHistoryOHLCOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -679,7 +679,7 @@ pub struct OptionHistoryOHLCOptions {
 pub struct OptionHistoryTradeOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -709,7 +709,7 @@ pub struct OptionHistoryTradeOptions {
 pub struct OptionHistoryQuoteOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -741,7 +741,7 @@ pub struct OptionHistoryQuoteOptions {
 pub struct OptionHistoryTradeQuoteOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -773,7 +773,7 @@ pub struct OptionHistoryTradeQuoteOptions {
 pub struct OptionHistoryOpenInterestOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -799,7 +799,7 @@ pub struct OptionHistoryOpenInterestOptions {
 pub struct OptionHistoryGreeksEODOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year).
     pub annual_dividend: Option<f64>,
@@ -831,7 +831,7 @@ pub struct OptionHistoryGreeksEODOptions {
 pub struct OptionHistoryGreeksAllOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -869,7 +869,7 @@ pub struct OptionHistoryGreeksAllOptions {
 pub struct OptionHistoryTradeGreeksAllOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -907,7 +907,7 @@ pub struct OptionHistoryTradeGreeksAllOptions {
 pub struct OptionHistoryGreeksFirstOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -945,7 +945,7 @@ pub struct OptionHistoryGreeksFirstOrderOptions {
 pub struct OptionHistoryTradeGreeksFirstOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -983,7 +983,7 @@ pub struct OptionHistoryTradeGreeksFirstOrderOptions {
 pub struct OptionHistoryGreeksSecondOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -1021,7 +1021,7 @@ pub struct OptionHistoryGreeksSecondOrderOptions {
 pub struct OptionHistoryTradeGreeksSecondOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1059,7 +1059,7 @@ pub struct OptionHistoryTradeGreeksSecondOrderOptions {
 pub struct OptionHistoryGreeksThirdOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -1097,7 +1097,7 @@ pub struct OptionHistoryGreeksThirdOrderOptions {
 pub struct OptionHistoryTradeGreeksThirdOrderOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1135,7 +1135,7 @@ pub struct OptionHistoryTradeGreeksThirdOrderOptions {
 pub struct OptionHistoryGreeksImpliedVolatilityOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
@@ -1173,7 +1173,7 @@ pub struct OptionHistoryGreeksImpliedVolatilityOptions {
 pub struct OptionHistoryTradeGreeksImpliedVolatilityOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1211,7 +1211,7 @@ pub struct OptionHistoryTradeGreeksImpliedVolatilityOptions {
 pub struct OptionAtTimeTradeOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -1233,7 +1233,7 @@ pub struct OptionAtTimeTradeOptions {
 pub struct OptionAtTimeQuoteOptions {
     /// Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection.
     pub strike: Option<String>,
-    /// Option side. Accepted values: `call`, `put`, `both`.
+    /// Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`.
     pub right: Option<String>,
     /// Maximum days to expiration
     pub max_dte: Option<f64>,
@@ -2931,7 +2931,6 @@ impl HistoricalView {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -3012,7 +3011,6 @@ impl HistoricalView {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -3093,7 +3091,6 @@ impl HistoricalView {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -3174,7 +3171,6 @@ impl HistoricalView {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -4046,7 +4042,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-    /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    /// - **Any ``expiration=*`` request must be made day by day.**
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -8330,7 +8326,6 @@ impl HistoricalClient {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8411,7 +8406,6 @@ impl HistoricalClient {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8492,7 +8486,6 @@ impl HistoricalClient {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8573,7 +8566,6 @@ impl HistoricalClient {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -9445,7 +9437,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
-    /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    /// - **Any ``expiration=*`` request must be made day by day.**
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`


### PR DESCRIPTION
## The gap

Every option endpoint's reference Parameters table rendered the same `expiration` cell — "Expiration date YYYYMMDD" — regardless of whether the endpoint accepts the chain-wide `expiration=*` wildcard, and every `right` cell listed only `call` / `put` / `both` and never named the `*` alias. The wildcard behaviour was documented only in a few hand-written vendor docstrings (rendered into the page body, not the Parameters table or the SDK request-option surfaces), so the actual capability never reached the table and drifted out of sync with the server. Example: `option/history/open_interest` accepts `expiration=*` but its table never said so.

The three contract-selector wildcards are now consistently documented: `strike=*`, `expiration=*`, and `right=*`.

## strike=* — already documented, no change

The `strike` row already carried "Use `*` for wildcard selection" on every endpoint. It is endpoint-independent, so a single template description covers it. It is unchanged here and included only so all three contract selectors are documented consistently.

## expiration=* — rendered from capability, single-source

The expiration wildcard is the only one gated by endpoint capability, so a per-endpoint signal is needed. `render_params_section` now reads `endpoint_supports_expiration_wildcard(name)` — the exact same pinned upstream snapshot (`scripts/ci/data/upstream_openapi.yaml`, via `UpstreamEndpoint::supports_expiration_wildcard`) that the mode taxonomy already reads to decide which wildcard test modes to emit. When the endpoint accepts the wildcard, the `expiration` row's Description gets the chain-wide note; when the endpoint is bound to upstream's `expiration_no_star` component, the row renders the plain description with no note. Because the rendered note and the emitted wildcard test modes read the same capability, they cannot disagree. No hardcoded endpoint list.

Scope: 22 documented, 9 excluded. The 9 endpoints upstream binds to `expiration_no_star` reject `*` and correctly keep the plain description: `option_history_ohlc`, `option_history_greeks_all` / `first_order` / `second_order` / `third_order` / `implied_volatility`, `option_list_dates`, `option_list_strikes`, `option_snapshot_trade`. Every other option endpoint that takes an `expiration` parameter (22 pages) now carries the note, verified against the upstream snapshot — the nine excluded match the `expiration_no_star` bindings exactly.

## right=* — uniform alias, one template edit propagates everywhere

Unlike expiration, the `right` alias is endpoint-uniform: the pinned upstream snapshot references a single `right` parameter (`enum: [call, put, both]`, default `both`) with no per-endpoint restriction. Extending the `right` parameter template description so it names `*` as the alias for `both` (calls and puts) lets the one edit propagate to every generated surface and the change is regenerated everywhere it appears.

## Cross-binding regeneration

The `right` template edit flows into every generated request-option surface, all regenerated from the registry (per-binding cost ≈ 0): TypeScript (`index.d.ts` plus the `historical_methods.rs` option structs), Python (`__init__.pyi` plus the generated `historical_methods.rs`), C++ (`endpoint_options.hpp.inc`), FFI (`endpoint_request_options.rs`), and the docs-site reference tables. The `strike` and `expiration` rows on those surfaces are unchanged.

`sdks/typescript/index.d.ts` is the napi-emitted type stub, so it is regenerated by the real `napi build --platform --release` followed by the contract-alias postbuild — not hand-edited — and `git diff --exit-code -- index.d.ts` is clean against the build output. Regenerating it also dropped the four redundant `option_snapshot_greeks_*` expiration-wildcard bullets and rewrote the EOD greeks caveat to "Any `expiration=*` request must be made day by day", both of which the binding source already carried but the stub had not yet picked up.

## Also in this PR

The hand-maintained OpenAPI contract (`docs-site/docs/public/thetadatadx.yaml`) is not generated from the surface, so it gets the parallel split by hand: the shared `expiration-param` anchor carries the wildcard note and a new `expiration-no-star-param` anchor (mirroring upstream's own `expiration_no_star` component) is repointed onto the nine no-star paths, and the shared `right` parameter names the `*` alias.

## Verification

- `generate_docs_site --check` (docs drift guard): generated pages match the registries.
- `cargo clippy --bin generate_docs_site` with `-D warnings`: clean.
- `upstream_openapi` capability unit tests: 9 passed.
- TypeScript `index.d.ts` sync gate: `napi build` + postbuild emitted stub, `git diff --exit-code -- index.d.ts` clean.
- `option/history/open-interest` and the other 21 wildcard pages show the expiration note; the 9 no-star pages do not; every right endpoint names the `*` alias; strike rows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)