### PR TITLE
refactor: tier-3 dedup/shrink (dual_type_columns, accumulator, endpoint_args)

### DIFF
--- a/crates/thetadatadx/build_support/endpoints/build_helpers.rs
+++ b/crates/thetadatadx/build_support/endpoints/build_helpers.rs
@@ -95,11 +95,7 @@ pub(super) fn required_getter_name(param_type: &str) -> &'static str {
         "Date" => "required_date",
         "Expiration" => "required_expiration",
         "Strike" => "required_strike",
-        "Interval" => "required_interval",
         "Right" => "required_right",
-        "Int" => "required_int32",
-        "Float" => "required_float64",
-        "Bool" => "required_bool",
         "Year" => "required_year",
         _ => "required_str",
     }

--- a/crates/thetadatadx/src/fpss/accumulator.rs
+++ b/crates/thetadatadx/src/fpss/accumulator.rs
@@ -10,6 +10,7 @@
 ///
 /// `volume` and `count` use `i64` to avoid overflow on high-volume symbols
 /// (e.g. SPY) where per-session cumulative volume can exceed `i32::MAX`.
+#[derive(Default)]
 pub(super) struct OhlcvcAccumulator {
     pub(super) open: i32,
     pub(super) high: i32,
@@ -24,21 +25,6 @@ pub(super) struct OhlcvcAccumulator {
 }
 
 impl OhlcvcAccumulator {
-    pub(super) fn new() -> Self {
-        Self {
-            open: 0,
-            high: 0,
-            low: 0,
-            close: 0,
-            volume: 0,
-            count: 0,
-            price_type: 0,
-            date: 0,
-            ms_of_day: 0,
-            initialized: false,
-        }
-    }
-
     #[allow(clippy::too_many_arguments)] // Reason: OHLCVC bar has many fields from server init message
     pub(super) fn init_from_server(
         &mut self,
@@ -86,12 +72,8 @@ impl OhlcvcAccumulator {
         // not seen, so it is folded into the current bar when initialized.
         if self.initialized && date == self.date && records_back != 0 {
             let adjusted_price = change_price_type(price, price_type, self.price_type);
-            if adjusted_price > self.high {
-                self.high = adjusted_price;
-            }
-            if adjusted_price < self.low {
-                self.low = adjusted_price;
-            }
+            self.high = self.high.max(adjusted_price);
+            self.low = self.low.min(adjusted_price);
             self.close = adjusted_price;
             return;
         }
@@ -107,12 +89,8 @@ impl OhlcvcAccumulator {
             let adjusted_price = change_price_type(price, price_type, self.price_type);
             self.volume += i64::from(size);
             self.count += 1;
-            if adjusted_price > self.high {
-                self.high = adjusted_price;
-            }
-            if adjusted_price < self.low {
-                self.low = adjusted_price;
-            }
+            self.high = self.high.max(adjusted_price);
+            self.low = self.low.min(adjusted_price);
             self.close = adjusted_price;
         } else {
             self.open = price;
@@ -194,7 +172,7 @@ mod tests {
 
     #[test]
     fn ohlcvc_accumulator_first_trade_initializes() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         assert!(!acc.initialized);
         acc.process_trade(34200000, 15025, 100, 8, 20240315, 0);
         assert!(acc.initialized);
@@ -208,7 +186,7 @@ mod tests {
 
     #[test]
     fn ohlcvc_accumulator_updates() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.process_trade(34200000, 15025, 100, 8, 20240315, 0);
         acc.process_trade(34200100, 15100, 200, 8, 20240315, 0);
         acc.process_trade(34200200, 14950, 50, 8, 20240315, 0);
@@ -222,7 +200,7 @@ mod tests {
 
     #[test]
     fn ohlcvc_accumulator_server_init_then_trade() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.init_from_server(
             34200000, 15000, 15100, 14900, 15050, 1000_i64, 10_i64, 8, 20240315,
         );
@@ -235,7 +213,7 @@ mod tests {
 
     #[test]
     fn ohlcvc_accumulator_no_overflow_on_high_volume() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.process_trade(34200000, 15025, i32::MAX, 8, 20240315, 0);
         acc.process_trade(34200100, 15100, i32::MAX, 8, 20240315, 0);
         // Would overflow i32 (2 * 2_147_483_647 = 4_294_967_294), fine in i64
@@ -255,7 +233,7 @@ mod tests {
         let count = i64::from((-2_008_126_979_i32) as u32);
         assert_eq!(volume, 2_225_611_194_i64);
         assert_eq!(count, 2_286_840_317_i64);
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.init_from_server(
             34200000, 15000, 15100, 14900, 15050, volume, count, 8, 20240315,
         );
@@ -270,7 +248,7 @@ mod tests {
     /// path, no intervening server bar or clear).
     #[test]
     fn ohlcvc_accumulator_rolls_on_date_change() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         // Day 1: two trades accumulate.
         acc.process_trade(57_600_000, 15_025, 100, 8, 20240315, 0);
         acc.process_trade(57_600_100, 15_100, 200, 8, 20240315, 0);
@@ -300,7 +278,7 @@ mod tests {
     /// low, or last.
     #[test]
     fn ohlcvc_accumulator_correction_does_not_double_count() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.process_trade(34_200_000, 15_025, 100, 8, 20240315, 0);
         acc.process_trade(34_200_100, 15_100, 200, 8, 20240315, 0);
         assert_eq!(acc.volume, 300);
@@ -331,7 +309,7 @@ mod tests {
     /// correction can never masquerade as a bar reset.
     #[test]
     fn ohlcvc_accumulator_correction_adjusts_low_without_reset() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.process_trade(34_200_000, 15_025, 100, 8, 20240315, 0);
         acc.process_trade(34_200_100, 15_100, 200, 8, 20240315, 2);
         assert_eq!(acc.open, 15_025, "correction must not reset the open");
@@ -386,7 +364,7 @@ mod tests {
     /// 71_396_865 * 10_000 wraps to +1_004_078_864 (see test above).
     #[test]
     fn ohlcvc_accumulator_rescale_matches_java_wrap() {
-        let mut acc = OhlcvcAccumulator::new();
+        let mut acc = OhlcvcAccumulator::default();
         acc.process_trade(34200000, 71_396_865, 1, 4, 20240315, 0);
         assert_eq!(acc.price_type, 4);
         assert_eq!(acc.high, 71_396_865);

--- a/crates/thetadatadx/src/fpss/decode.rs
+++ b/crates/thetadatadx/src/fpss/decode.rs
@@ -14,7 +14,6 @@ use crate::tdbe::types::enums::StreamMsgType;
 use crate::tdbe::types::price::Price;
 use metrics::Counter;
 
-use super::accumulator::OhlcvcAccumulator;
 use super::delta::{DeltaState, TickFields, OHLCVC_FIELDS, OI_FIELDS, QUOTE_FIELDS, TRADE_FIELDS};
 use super::events::{FpssEventInternal, StreamControl, StreamData};
 use super::framing;
@@ -628,10 +627,7 @@ pub fn decode_frame(
                     // being sign-extended into a negative number.
                     let volume = i64::from(buf[5] as u32);
                     let count = i64::from(buf[6] as u32);
-                    let acc = delta_state
-                        .ohlcvc
-                        .entry(contract_id)
-                        .or_insert_with(OhlcvcAccumulator::new);
+                    let acc = delta_state.ohlcvc.entry(contract_id).or_default();
                     acc.init_from_server(
                         buf[0], buf[1], buf[2], buf[3], buf[4], volume, count, buf[7], buf[8],
                     );
@@ -1255,7 +1251,7 @@ mod tests {
         // `delta_state.clear()` actually ran on the Restart arm.
         delta_state
             .ohlcvc
-            .insert(42, super::super::accumulator::OhlcvcAccumulator::new());
+            .insert(42, super::super::accumulator::OhlcvcAccumulator::default());
         assert!(delta_state.ohlcvc.contains_key(&42));
 
         let (primary, _) = decode_frame(

--- a/crates/thetadatadx/src/mdds/decode/dual_type_columns.rs
+++ b/crates/thetadatadx/src/mdds/decode/dual_type_columns.rs
@@ -10,7 +10,9 @@
 use crate::proto;
 use crate::tdbe::types::tick::{CalendarDay, OptionContract};
 
-use super::cell::{cell_type, row_price_f64, row_text};
+use super::cell::{
+    cell_type, row_contract_expiration, row_contract_right, row_date, row_price_f64, row_text,
+};
 use super::error::{observed_name, DecodeError};
 use super::headers::find_header;
 
@@ -64,40 +66,9 @@ pub fn parse_option_contracts_v3(
             let symbol = row_text(row, symbol_idx)?.unwrap_or_default();
 
             // Expiration: `Number` carries YYYYMMDD directly; `Text`
-            // carries an ISO "YYYY-MM-DD". Both pass through
-            // `is_valid_yyyymmdd` after the wire `int64` is bounds-
-            // checked against `i32`. `NullValue` -> 0.
+            // carries an ISO "YYYY-MM-DD". `NullValue` / absent column -> 0.
             let expiration = match exp_idx {
-                Some(i) => match cell_type(row, i)? {
-                    Some(proto::data_value::DataType::Number(n)) => {
-                        let n32 = match i32::try_from(*n) {
-                            Ok(v) => v,
-                            Err(_) => {
-                                return Err(DecodeError::InvalidDate { raw: n.to_string() });
-                            }
-                        };
-                        if !crate::tdbe::time::is_valid_yyyymmdd(n32) {
-                            return Err(DecodeError::InvalidDate { raw: n.to_string() });
-                        }
-                        n32
-                    }
-                    Some(proto::data_value::DataType::Text(s)) => parse_iso_date(s)?,
-                    Some(proto::data_value::DataType::NullValue(_)) => 0,
-                    None => {
-                        return Err(DecodeError::TypeMismatch {
-                            column: i,
-                            expected: "Number|Text",
-                            observed: "Unset",
-                        });
-                    }
-                    other => {
-                        return Err(DecodeError::TypeMismatch {
-                            column: i,
-                            expected: "Number|Text",
-                            observed: observed_name(other),
-                        });
-                    }
-                },
+                Some(i) => row_contract_expiration(row, i)?.unwrap_or(0),
                 None => 0,
             };
 
@@ -109,45 +80,10 @@ pub fn parse_option_contracts_v3(
             // Right: both wire encodings decode to the logical
             // character — `Number` carries the ASCII code (67 / 80),
             // `Text` carries "PUT"/"CALL"/"P"/"C". Any other value
-            // surfaces as `UnknownEnumVariant`. `NullValue` -> '\0'.
+            // surfaces as `UnknownEnumVariant`. `NullValue` / absent
+            // column -> '\0'.
             let right = match right_idx {
-                Some(i) => match cell_type(row, i)? {
-                    Some(proto::data_value::DataType::Number(n)) => match *n {
-                        67 => 'C',
-                        80 => 'P',
-                        other => {
-                            return Err(DecodeError::UnknownEnumVariant {
-                                field: "right",
-                                raw: other.to_string(),
-                            });
-                        }
-                    },
-                    Some(proto::data_value::DataType::Text(s)) => match s.as_str() {
-                        "CALL" | "C" => 'C',
-                        "PUT" | "P" => 'P',
-                        other => {
-                            return Err(DecodeError::UnknownEnumVariant {
-                                field: "right",
-                                raw: other.to_string(),
-                            });
-                        }
-                    },
-                    Some(proto::data_value::DataType::NullValue(_)) => '\0',
-                    None => {
-                        return Err(DecodeError::TypeMismatch {
-                            column: i,
-                            expected: "Number|Text",
-                            observed: "Unset",
-                        });
-                    }
-                    other => {
-                        return Err(DecodeError::TypeMismatch {
-                            column: i,
-                            expected: "Number|Text",
-                            observed: observed_name(other),
-                        });
-                    }
-                },
+                Some(i) => row_contract_right(row, i)?.unwrap_or('\0'),
                 None => '\0',
             };
 
@@ -301,42 +237,9 @@ pub fn parse_calendar_days_v3(
             // date: Number carries YYYYMMDD (bounds-checked against i32
             // then validated as a Gregorian date), Timestamp converts to
             // ET date, Text "YYYY-MM-DD" parses to YYYYMMDD. `NullValue`
-            // -> 0.
+            // / absent column -> 0.
             let date = match date_idx {
-                Some(i) => match cell_type(row, i)? {
-                    Some(proto::data_value::DataType::Number(n)) => {
-                        let n32 = match i32::try_from(*n) {
-                            Ok(v) => v,
-                            Err(_) => {
-                                return Err(DecodeError::InvalidDate { raw: n.to_string() });
-                            }
-                        };
-                        if !crate::tdbe::time::is_valid_yyyymmdd(n32) {
-                            return Err(DecodeError::InvalidDate { raw: n.to_string() });
-                        }
-                        n32
-                    }
-                    Some(proto::data_value::DataType::Timestamp(ts)) => {
-                        crate::tdbe::time::try_timestamp_to_date(ts.epoch_ms)
-                            .ok_or(DecodeError::TimestampOutOfRange { raw: ts.epoch_ms })?
-                    }
-                    Some(proto::data_value::DataType::Text(s)) => parse_iso_date(s)?,
-                    Some(proto::data_value::DataType::NullValue(_)) => 0,
-                    None => {
-                        return Err(DecodeError::TypeMismatch {
-                            column: i,
-                            expected: "Number|Timestamp|Text",
-                            observed: "Unset",
-                        });
-                    }
-                    other => {
-                        return Err(DecodeError::TypeMismatch {
-                            column: i,
-                            expected: "Number|Timestamp|Text",
-                            observed: observed_name(other),
-                        });
-                    }
-                },
+                Some(i) => row_date(row, i)?.unwrap_or(0),
                 None => 0,
             };
 

--- a/crates/thetadatadx/src/mdds/endpoint_args.rs
+++ b/crates/thetadatadx/src/mdds/endpoint_args.rs
@@ -319,13 +319,6 @@ impl EndpointArgs {
         Ok(Some(value))
     }
 
-    /// Read a required interval argument.
-    pub fn required_interval(&self, key: &str) -> Result<&str, EndpointError> {
-        let value = self.required_str(key)?;
-        validate_interval(value, key)?;
-        Ok(value)
-    }
-
     /// Read an optional interval argument.
     pub fn optional_interval(&self, key: &str) -> Result<Option<&str>, EndpointError> {
         let Some(value) = self.optional_str(key)? else {
@@ -358,23 +351,6 @@ impl EndpointArgs {
         Ok(value)
     }
 
-    /// Read a required integer argument and narrow it to `i32`.
-    pub fn required_int32(&self, key: &str) -> Result<i32, EndpointError> {
-        let raw = match self.required_value(key)? {
-            EndpointArgValue::Int(value) => *value,
-            _ => {
-                return Err(EndpointError::InvalidParams(format!(
-                    "required integer argument '{key}' must be an integer"
-                )))
-            }
-        };
-        i32::try_from(raw).map_err(|_| {
-            EndpointError::InvalidParams(format!(
-                "required integer argument '{key}' is out of range for i32: {raw}"
-            ))
-        })
-    }
-
     /// Read an optional integer argument and narrow it to `i32`.
     pub fn optional_int32(&self, key: &str) -> Result<Option<i32>, EndpointError> {
         let Some(value) = self.optional_value(key) else {
@@ -396,19 +372,6 @@ impl EndpointArgs {
         Ok(Some(narrowed))
     }
 
-    /// Read a required floating-point argument.
-    ///
-    /// Accepts both `Float` and `Int` values. `Int` is widened to `f64`.
-    pub fn required_float64(&self, key: &str) -> Result<f64, EndpointError> {
-        match self.required_value(key)? {
-            EndpointArgValue::Float(value) => Ok(*value),
-            EndpointArgValue::Int(value) => Ok(*value as f64),
-            _ => Err(EndpointError::InvalidParams(format!(
-                "required number argument '{key}' must be a number"
-            ))),
-        }
-    }
-
     /// Read an optional floating-point argument.
     ///
     /// Accepts both `Float` and `Int` values. `Int` is widened to `f64`.
@@ -419,16 +382,6 @@ impl EndpointArgs {
             Some(EndpointArgValue::Int(value)) => Ok(Some(*value as f64)),
             Some(_) => Err(EndpointError::InvalidParams(format!(
                 "optional number argument '{key}' must be a number"
-            ))),
-        }
-    }
-
-    /// Read a required boolean argument.
-    pub fn required_bool(&self, key: &str) -> Result<bool, EndpointError> {
-        match self.required_value(key)? {
-            EndpointArgValue::Bool(value) => Ok(*value),
-            _ => Err(EndpointError::InvalidParams(format!(
-                "required boolean argument '{key}' must be a boolean"
             ))),
         }
     }


### PR DESCRIPTION
Tier-3 de-bloat cuts from a deep audit. Each cut was build-verified against the full gate suite; net −174 lines (26 added, 200 removed) across 5 files.

## Changes

**1. dedup — `mdds/decode/dual_type_columns.rs` (−107 net)** — `parse_option_contracts_v3` and `parse_calendar_days_v3` inlined the exact Number/Text/Null (and Timestamp, for date) dispatch that already lives as `row_contract_expiration` / `row_contract_right` / `row_date` in `cell.rs`. Replaced the three inline blocks with calls to those canonical decoders (`.unwrap_or(0)` / `.unwrap_or('\0')` for the null→fill the v3 path wants). Behavior identical: the decoders apply the same bounds checks, ISO/ASCII parsing, and `TypeMismatch`-on-Unset policy.

**2. stdlib — `fpss/pinning.rs` (kept — skipped)** — the proposed swap to `ring::constant_time::verify_slices_are_equal` does not hold up: `ring` is **not** a direct dependency (only transitive via `rustls`; zero direct `ring` deps anywhere in the workspace), so this would add a new direct dependency for a 9-line helper. More importantly the function is `#[deprecated]` in ring 0.17.14 (it lives in `deprecated_constant_time.rs`, re-exported as `constant_time` for back-compat) with the note *"Internal function not intended for external use with no promises regarding side channels."* Calling it would trip the `deprecated` lint under `-D warnings` (forcing a banned new `#[allow]`) and downgrade a security-relevant SPKI pin compare to a function its own author makes no constant-time guarantee about. The hand-rolled `ct_eq_bytes` + its 3 tests stay.

**3. shrink — `fpss/accumulator.rs` (−42 net, incl. `decode.rs` follow-through)** — `OhlcvcAccumulator` now `#[derive(Default)]`; the all-zeros `new()` constructor is gone (its sole production caller switched to `HashMap::entry(..).or_default()`, tests use `::default()`). Hand-rolled high/low updates became `.max()` / `.min()`. Behavior identical (13 accumulator tests pass).

**4. delete — `mdds/endpoint_args.rs` + `build_support/endpoints/build_helpers.rs` (−51 net)** — removed the dead `required_int32` / `required_float64` / `required_bool` / `required_interval` getters plus the four matching arms in `required_getter_name`. Verified zero callers: every Int/Float/Bool/Interval param in `endpoint_surface.toml` is `required = false`, so they only ever route through the `optional_*` getters (untouched). Generated output references none of the deleted methods; `optional_interval`/`optional_int32`/etc. and the `_ => required_str` fallback are unchanged.

## Verification — all green

- `cargo check -p thetadatadx` (default / `__test-helpers` / `arrow,polars,frames,config-file`)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (no new `#[allow]`)
- `cargo doc --no-deps --workspace --locked`
- `cargo fmt --check`
- `cargo test -p thetadatadx --lib` — 1069 passed, 0 failed
- `check_docs_consistency.py` — ok
- `generate_sdk_surfaces --check` — no drift
- `generate_docs_site --check` — pages match registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)