### PR TITLE
refactor: dedup server + codegen helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,6 +3407,7 @@ dependencies = [
  "futures",
  "futures-core",
  "h2",
+ "heck",
  "http",
  "hyper-util",
  "libc",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-config-file = ["dep:toml", "dep:regex"]
+config-file = ["dep:toml", "dep:regex", "dep:heck"]
 # Pulls `prost-build` into the regular dep graph for the
 # `refresh_grpc_snapshot` developer binary. Strictly off for normal
 # crate builds — the build script keeps its own `prost-build` under
@@ -184,6 +184,13 @@ toml = { version = "1.1.2", optional = true }
 # `[build-dependencies]`; the binary pulls it from `[dependencies]`
 # behind the `config-file` feature gate (see `[[bin]] required-features`).
 regex = { version = "1.12.3", optional = true }
+# Case conversion for the codegen identifier emitters in the
+# `generate_sdk_surfaces` / `generate_docs_site` binaries (the shared
+# `build_support/endpoints/helpers.rs` is `#[path]`-compiled into both the
+# build script and those binaries). The build script reaches it through
+# `[build-dependencies]`; the binaries through this `config-file`-gated
+# `[dependencies]` entry, mirroring `regex`.
+heck = { version = "0.5.0", optional = true }
 
 # Lock-free ring buffer for FPSS event dispatch # VOCAB-OK: crate name in dep
 disruptor = "4.2.0" # VOCAB-OK: actual dep crate name
@@ -268,6 +275,10 @@ libc = "0.2"
 # entirely.
 prost-build = "=0.14.4"
 regex = "1.12.3"
+# Case conversion for the build-time / codegen identifier emitters
+# (snake_case / UpperCamelCase / lowerCamelCase). Standard build-time
+# crate; replaces hand-rolled per-word case folders.
+heck = "0.5.0"
 # Parses `data/{trade,quote}_conditions.toml` into the committed
 # `src/tdbe/conditions/tables_generated.rs` (see `build_support/conditions.rs`),
 # and loads the captured-response fixture sidecars for the decode-surface

--- a/crates/thetadatadx/build_support/endpoints/helpers.rs
+++ b/crates/thetadatadx/build_support/endpoints/helpers.rs
@@ -24,6 +24,8 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
+use heck::ToUpperCamelCase;
+
 use super::model::{GeneratedEndpoint, GeneratedParam};
 
 // ─────────────────────────── Render-map loader ─────────────────────────────
@@ -235,17 +237,7 @@ fn render_param_defaults_block(endpoint: &GeneratedEndpoint) -> String {
 
 /// Converts a `snake_case` identifier to `PascalCase`.
 pub(super) fn to_pascal_case(value: &str) -> String {
-    value
-        .split('_')
-        .filter(|segment| !segment.is_empty())
-        .map(|segment| {
-            let mut chars = segment.chars();
-            match chars.next() {
-                Some(first) => first.to_uppercase().to_string() + chars.as_str(),
-                None => String::new(),
-            }
-        })
-        .collect::<String>()
+    value.to_upper_camel_case()
 }
 
 // ───────────────────────── Direct (Rust) client tick map lookup ───────────

--- a/crates/thetadatadx/build_support/endpoints/render/build_out.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/build_out.rs
@@ -389,22 +389,7 @@ fn generate_endpoint_stream_dispatch_arm(out: &mut String, endpoint: &GeneratedE
     )
     .unwrap();
 
-    for param in builder_params {
-        let getter = optional_getter_name(&param.param_type);
-        writeln!(
-            out,
-            "            if let Some(value) = args.{getter}(\"{}\")? {{",
-            param.name
-        )
-        .unwrap();
-        writeln!(
-            out,
-            "                builder = builder.{}(value);",
-            param.name
-        )
-        .unwrap();
-        out.push_str("            }\n");
-    }
+    emit_optional_setters(out, &builder_params);
 
     emit_builder_deadline(out);
 
@@ -546,22 +531,7 @@ fn generate_endpoint_dispatch_arm(out: &mut String, endpoint: &GeneratedEndpoint
         )
         .unwrap();
 
-        for param in builder_params {
-            let getter = optional_getter_name(&param.param_type);
-            writeln!(
-                out,
-                "            if let Some(value) = args.{getter}(\"{}\")? {{",
-                param.name
-            )
-            .unwrap();
-            writeln!(
-                out,
-                "                builder = builder.{}(value);",
-                param.name
-            )
-            .unwrap();
-            out.push_str("            }\n");
-        }
+        emit_optional_setters(out, &builder_params);
 
         emit_builder_deadline(out);
         out.push_str("            let mut result = Vec::new();\n");
@@ -588,22 +558,7 @@ fn generate_endpoint_dispatch_arm(out: &mut String, endpoint: &GeneratedEndpoint
     )
     .unwrap();
 
-    for param in builder_params {
-        let getter = optional_getter_name(&param.param_type);
-        writeln!(
-            out,
-            "            if let Some(value) = args.{getter}(\"{}\")? {{",
-            param.name
-        )
-        .unwrap();
-        writeln!(
-            out,
-            "                builder = builder.{}(value);",
-            param.name
-        )
-        .unwrap();
-        out.push_str("            }\n");
-    }
+    emit_optional_setters(out, &builder_params);
 
     emit_builder_deadline(out);
     out.push_str("            let result = builder.await?;\n");
@@ -653,4 +608,28 @@ fn emit_required_arg(out: &mut String, _endpoint: &GeneratedEndpoint, param: &Ge
         param.name, param.name
     )
     .unwrap();
+}
+
+/// Emit the optional-parameter setter chain: for each builder param, read it
+/// from `args` via its typed optional getter and forward it onto `builder`
+/// only when present. Shared by every dispatch-arm emitter so the generated
+/// setter block reads identically across the registry, snapshot, and stream
+/// paths.
+fn emit_optional_setters(out: &mut String, builder_params: &[&GeneratedParam]) {
+    for param in builder_params {
+        let getter = optional_getter_name(&param.param_type);
+        writeln!(
+            out,
+            "            if let Some(value) = args.{getter}(\"{}\")? {{",
+            param.name
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "                builder = builder.{}(value);",
+            param.name
+        )
+        .unwrap();
+        out.push_str("            }\n");
+    }
 }

--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_helpers.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_helpers.rs
@@ -179,6 +179,32 @@ pub(super) fn render_rust_doc_block(indent: &str, doc: &str) -> String {
     out
 }
 
+/// Emit the timeout-aware await of a local `call` future: race it against
+/// `tokio::time::timeout` when `timeout_ms` is `Some`, plain `.await`
+/// otherwise. `indent` is the leading whitespace of the `if let` line; the
+/// match body nests at `indent + 4` / `indent + 8`. Shared by every list /
+/// snapshot dispatch emitter (Python and TypeScript) so the generated
+/// timeout race reads identically across surfaces.
+pub(super) fn write_timeout_call(out: &mut String, indent: &str) {
+    use std::fmt::Write as _;
+    writeln!(out, "{indent}if let Some(ms) = timeout_ms {{").unwrap();
+    writeln!(
+        out,
+        "{indent}    match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {{"
+    )
+    .unwrap();
+    writeln!(out, "{indent}        Ok(inner) => inner,").unwrap();
+    writeln!(
+        out,
+        "{indent}        Err(_) => Err(thetadatadx::Error::Timeout {{ duration_ms: ms }}),"
+    )
+    .unwrap();
+    writeln!(out, "{indent}    }}").unwrap();
+    writeln!(out, "{indent}}} else {{").unwrap();
+    writeln!(out, "{indent}    call.await").unwrap();
+    writeln!(out, "{indent}}}").unwrap();
+}
+
 // ───────────────────────── Casing ────────────────────────────────────────────
 
 /// Returns the PascalCase form of a single name segment, keeping known

--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/python.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/python.rs
@@ -44,7 +44,7 @@ use super::super::sdk_helpers::{
     builder_params, is_snapshot_endpoint, method_params, python_method_arg_decl,
     python_optional_type, python_pyclass_list_class, python_pyclass_list_converter,
     python_string_arg_type, python_vec_to_pylist_converter, render_rust_doc_block,
-    sdk_method_arg_name,
+    sdk_method_arg_name, write_timeout_call,
 };
 
 /// Emit `sdks/python/src/_generated/decode_bench.rs` — the offline decode hook.
@@ -321,16 +321,10 @@ fn render_python_endpoint_sync(endpoint: &GeneratedEndpoint) -> String {
             })
             .collect::<Vec<_>>()
             .join(", ");
-        let leading_comma_args = if positional_args.is_empty() {
-            String::new()
-        } else {
-            format!(", {positional_args}")
-        };
         let column = endpoint
             .list_column
             .as_deref()
             .expect("list endpoint must declare list_column");
-        let _ = leading_comma_args;
         out.push_str("        let values: Vec<String> = run_blocking(py, async move {\n");
         writeln!(
             out,
@@ -338,16 +332,7 @@ fn render_python_endpoint_sync(endpoint: &GeneratedEndpoint) -> String {
             endpoint.name, positional_args
         )
         .unwrap();
-        out.push_str("            if let Some(ms) = timeout_ms {\n");
-        out.push_str("                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {\n");
-        out.push_str("                    Ok(inner) => inner,\n");
-        out.push_str(
-            "                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),\n",
-        );
-        out.push_str("                }\n");
-        out.push_str("            } else {\n");
-        out.push_str("                call.await\n");
-        out.push_str("            }\n");
+        write_timeout_call(&mut out, "            ");
         out.push_str("        })?;\n");
         writeln!(
             out,
@@ -528,32 +513,17 @@ fn render_python_endpoint_async(endpoint: &GeneratedEndpoint) -> String {
             })
             .collect::<Vec<_>>()
             .join(", ");
-        let leading_comma_args = if positional_args.is_empty() {
-            String::new()
-        } else {
-            format!(", {positional_args}")
-        };
         let column = endpoint
             .list_column
             .as_deref()
             .expect("list endpoint must declare list_column");
-        let _ = leading_comma_args;
         writeln!(
             out,
             "            let call = client.historical().{}({});",
             endpoint.name, positional_args
         )
         .unwrap();
-        out.push_str("            if let Some(ms) = timeout_ms {\n");
-        out.push_str("                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {\n");
-        out.push_str("                    Ok(inner) => inner,\n");
-        out.push_str(
-            "                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),\n",
-        );
-        out.push_str("                }\n");
-        out.push_str("            } else {\n");
-        out.push_str("                call.await\n");
-        out.push_str("            }\n");
+        write_timeout_call(&mut out, "            ");
         // Wrap the returned `Vec<String>` in a typed `StringList` with
         // the semantic column name so the caller can chain `.to_polars()`
         // into a single-column frame with a sensible header. `.into_any()`
@@ -1278,11 +1248,6 @@ fn render_python_builder_constructor(endpoint: &GeneratedEndpoint) -> String {
     out.push_str("            timeout_ms: None,\n");
     out.push_str("        }\n");
     out.push_str("    }\n");
-    // The `_ = builder_params` discard is a concession to the "unused
-    // `method_params` alias" warning when `builder_params` is empty
-    // (list endpoints). Consolidating the let-binding keeps the emitter
-    // linear and avoids per-endpoint conditional code.
-    let _ = builder_params;
 
     out
 }
@@ -1305,22 +1270,6 @@ fn write_sync_list_dispatch(
         )
         .unwrap();
     }
-    let positional_args = method_params
-        .iter()
-        .map(|param| {
-            if param.param_type == "Symbols" {
-                "&refs".into()
-            } else {
-                format!("self.{}.as_str()", param.name)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    let leading_comma_args = if positional_args.is_empty() {
-        String::new()
-    } else {
-        format!(", {positional_args}")
-    };
     writeln!(out, "{indent}let client = self.client.clone();").unwrap();
     writeln!(out, "{indent}let timeout_ms = self.timeout_ms;").unwrap();
     // Rebuild the args vector inside the closure so the closure owns every
@@ -1364,36 +1313,13 @@ fn write_sync_list_dispatch(
         })
         .collect::<Vec<_>>()
         .join(", ");
-    let leading_comma_args_closure = if positional_args_closure.is_empty() {
-        String::new()
-    } else {
-        format!(", {positional_args_closure}")
-    };
-    let _ = leading_comma_args;
-    let _ = positional_args;
-    let _ = leading_comma_args_closure;
     writeln!(
         out,
         "{indent}    let call = client.historical().{}({});",
         endpoint.name, positional_args_closure
     )
     .unwrap();
-    writeln!(out, "{indent}    if let Some(ms) = timeout_ms {{").unwrap();
-    writeln!(
-        out,
-        "{indent}        match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {{"
-    )
-    .unwrap();
-    writeln!(out, "{indent}            Ok(inner) => inner,").unwrap();
-    writeln!(
-        out,
-        "{indent}            Err(_) => Err(thetadatadx::Error::Timeout {{ duration_ms: ms }}),"
-    )
-    .unwrap();
-    writeln!(out, "{indent}        }}").unwrap();
-    writeln!(out, "{indent}    }} else {{").unwrap();
-    writeln!(out, "{indent}        call.await").unwrap();
-    writeln!(out, "{indent}    }}").unwrap();
+    write_timeout_call(out, &format!("{indent}    "));
     write!(out, "{indent}}})").unwrap();
 }
 
@@ -1444,34 +1370,13 @@ fn write_async_list_dispatch(
         })
         .collect::<Vec<_>>()
         .join(", ");
-    let leading_comma_args = if positional_args.is_empty() {
-        String::new()
-    } else {
-        format!(", {positional_args}")
-    };
-    let _ = leading_comma_args;
     writeln!(
         out,
         "{indent}    let call = client.historical().{}({});",
         endpoint.name, positional_args
     )
     .unwrap();
-    writeln!(out, "{indent}    if let Some(ms) = timeout_ms {{").unwrap();
-    writeln!(
-        out,
-        "{indent}        match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {{"
-    )
-    .unwrap();
-    writeln!(out, "{indent}            Ok(inner) => inner,").unwrap();
-    writeln!(
-        out,
-        "{indent}            Err(_) => Err(thetadatadx::Error::Timeout {{ duration_ms: ms }}),"
-    )
-    .unwrap();
-    writeln!(out, "{indent}        }}").unwrap();
-    writeln!(out, "{indent}    }} else {{").unwrap();
-    writeln!(out, "{indent}        call.await").unwrap();
-    writeln!(out, "{indent}    }}").unwrap();
+    write_timeout_call(out, &format!("{indent}    "));
     // Convert the resolved `Vec<String>` into the typed `StringList` and
     // coerce up to `Py<PyAny>` to satisfy the helper's convert signature.
     writeln!(

--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
@@ -46,7 +46,7 @@ use super::super::helpers::{compose_endpoint_doc, endpoint_streams, is_streaming
 use super::super::model::GeneratedEndpoint;
 use super::super::sdk_helpers::{
     builder_params, is_time_arg, method_params, render_rust_doc_block, sdk_method_arg_name,
-    to_camel_case, to_pascal_case, ts_class_name, ts_class_vec_converter,
+    to_camel_case, to_pascal_case, ts_class_name, ts_class_vec_converter, write_timeout_call,
 };
 
 /// napi classes that carry the historical endpoint surface. Both wrap an
@@ -337,16 +337,7 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
             name = endpoint.name,
         )
         .unwrap();
-        out.push_str("            if let Some(ms) = timeout_ms {\n");
-        out.push_str("                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {\n");
-        out.push_str("                    Ok(inner) => inner,\n");
-        out.push_str(
-            "                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),\n",
-        );
-        out.push_str("                }\n");
-        out.push_str("            } else {\n");
-        out.push_str("                call.await\n");
-        out.push_str("            }\n");
+        write_timeout_call(&mut out, "            ");
         out.push_str("        })\n");
         out.push_str("        .await\n");
         out.push_str("    }\n");

--- a/crates/thetadatadx/build_support_bin/fpss_events/buffered.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/buffered.rs
@@ -8,7 +8,7 @@
 
 use std::fmt::Write as _;
 
-use super::common::{is_option, rust_field_type};
+use super::common::{control_rust_variant, is_option, rust_field_type};
 use super::schema::{sorted_control_events, sorted_event_names, EventDef, Schema};
 
 /// Emit the `BufferedEvent` enum + the `fpss_event_to_buffered` converter
@@ -177,18 +177,6 @@ fn render_control_match_arm(event_name: &str, def: &EventDef) -> String {
         out.push_str("            },\n");
     }
     out
-}
-
-/// Core `StreamControl` variant backing a schema control event. The two
-/// names coincide for every variant except `ParseError`, whose core
-/// enum variant keeps the historical `Error` spelling — the public
-/// event class is named `ParseError` so no binding ships a class that
-/// collides with the language's own error types.
-fn control_rust_variant(event_name: &str) -> &str {
-    match event_name {
-        "ParseError" => "Error",
-        other => other,
-    }
 }
 
 /// Per-variant Rust-pattern + field-assignment mapping. Keeps the

--- a/crates/thetadatadx/build_support_bin/fpss_events/common.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/common.rs
@@ -2,22 +2,25 @@
 //!
 //! Case conversion + per-language Rust type mapping for schema columns.
 
+use heck::ToSnakeCase;
+
 /// Convert a PascalCase event name to snake_case ("OpenInterest" → "open_interest")
 /// so the `kind` discriminator exposed to Python matches the wire tag the
 /// existing dict-based `next_event` emits.
 pub(super) fn snake_case(name: &str) -> String {
-    let mut out = String::with_capacity(name.len() + 2);
-    for (i, ch) in name.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if i > 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-        } else {
-            out.push(ch);
-        }
+    name.to_snake_case()
+}
+
+/// Core `StreamControl` variant backing a schema control event. The two
+/// names coincide for every variant except `ParseError`, whose core
+/// enum variant keeps the historical `Error` spelling — the public
+/// event class is named `ParseError` so no binding ships a class that
+/// collides with the language's own error types.
+pub(super) fn control_rust_variant(event_name: &str) -> &str {
+    match event_name {
+        "ParseError" => "Error",
+        other => other,
     }
-    out
 }
 
 /// Maps a schema column type to the Rust field type emitted on the Python `#[pyclass]` struct.

--- a/crates/thetadatadx/build_support_bin/fpss_events/cpp_asserts.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/cpp_asserts.rs
@@ -8,7 +8,6 @@
 
 use std::fmt::Write as _;
 
-use super::common::snake_case;
 use super::layout::{
     c_struct_offsets, c_struct_size, contract_field_offsets, contract_size, fpss_event_offsets,
     fpss_event_size,
@@ -42,7 +41,6 @@ fn render_contract_asserts(out: &mut String) {
 
 fn render_event_asserts(out: &mut String, event_name: &str, def: &EventDef) {
     let alias = format!("ThetaDataDxStream{event_name}");
-    let field = snake_case(event_name);
     if def.columns.is_empty() {
         // Empty control variants have a single `_padding` byte. Emit a
         // size-only assert; offsetof on `_padding == 0` is implicit.
@@ -71,7 +69,6 @@ fn render_event_asserts(out: &mut String, event_name: &str, def: &EventDef) {
         )
         .unwrap();
     }
-    let _ = field;
     out.push('\n');
 }
 

--- a/crates/thetadatadx/build_support_bin/fpss_events/ffi_rust.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/ffi_rust.rs
@@ -12,8 +12,8 @@
 use std::fmt::Write as _;
 
 use super::common::{
-    is_byte_buffer, is_contract, rust_ffi_scalar, rust_ffi_zero_literal, snake_case,
-    zero_const_name,
+    control_rust_variant, is_byte_buffer, is_contract, rust_ffi_scalar, rust_ffi_zero_literal,
+    snake_case, zero_const_name,
 };
 use super::layout::{
     c_struct_size, contract_align, contract_size, fpss_event_align, fpss_event_size, struct_align,
@@ -570,13 +570,7 @@ fn control_variant_mapping(event_name: &str) -> (&'static str, Vec<&'static str>
 }
 
 fn render_control_arm(out: &mut String, schema: &Schema, event_name: &str, def: &EventDef) {
-    // Core enum variant backing the schema event — the two names
-    // coincide except for `ParseError`, whose core `StreamControl`
-    // variant keeps the `Error` spelling.
-    let rust_variant = match event_name {
-        "ParseError" => "Error",
-        other => other,
-    };
+    let rust_variant = control_rust_variant(event_name);
     let (rust_pattern, field_assigns) = control_variant_mapping(event_name);
     let has_string = control_has_string(&def.columns);
     let has_bytes = control_has_byte_buffer(&def.columns);

--- a/crates/thetadatadx/build_support_bin/fpss_events/layout.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/layout.rs
@@ -150,13 +150,6 @@ pub(super) fn contract_align() -> usize {
         .unwrap_or(1)
 }
 
-/// Alignment requirement of a control-variant struct, computed from its
-/// columns. Empty-column control variants fall back to align=1 (one
-/// `_padding` byte).
-pub(super) fn control_struct_align(columns: &[ColumnDef]) -> usize {
-    struct_align(columns)
-}
-
 /// Returns the total C struct size, in bytes, of the tagged `ThetaDataDxStreamEvent` wrapper.
 pub(super) fn fpss_event_size(schema: &Schema) -> usize {
     c_layout(
@@ -209,7 +202,7 @@ fn fpss_event_fields(schema: &Schema) -> Vec<(String, CFieldLayout)> {
             snake_case(event_name),
             CFieldLayout {
                 size: c_struct_size(&def.columns),
-                align: control_struct_align(&def.columns),
+                align: struct_align(&def.columns),
             },
         ));
     }

--- a/crates/thetadatadx/build_support_bin/fpss_events/python.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/python.rs
@@ -10,7 +10,7 @@
 
 use std::fmt::Write as _;
 
-use super::common::{is_contract, python_rust_field_type, snake_case};
+use super::common::{control_rust_variant, is_contract, python_rust_field_type, snake_case};
 use super::schema::{
     sorted_control_events, sorted_data_events, sorted_event_names, ColumnDef, EventDef, Schema,
 };
@@ -408,7 +408,6 @@ fn render_control_arm(event_name: &str, def: &EventDef) -> String {
         .unwrap();
         return out;
     }
-    let has_contract = def.columns.iter().any(|c| is_contract(&c.r#type));
     let (rust_pattern, field_assigns) = control_variant_mapping(event_name);
     writeln!(
         out,
@@ -421,9 +420,6 @@ fn render_control_arm(event_name: &str, def: &EventDef) -> String {
         writeln!(out, "                    {assign},").unwrap();
     }
     out.push_str("                },\n            )\n            .map(|p| p.into_any()),\n");
-    // `has_contract` only affects how the assignment table is written;
-    // it is encoded in `control_variant_mapping` already.
-    let _ = has_contract;
     out
 }
 
@@ -440,18 +436,6 @@ fn field_rhs(column_type: &str, name: &str) -> String {
         "Contract" => format!("(**{name}).clone()"),
         // `Copy` primitives (including `Option<i32>`) — deref the binding.
         _ => format!("*{name}"),
-    }
-}
-
-/// Core `StreamControl` variant backing a schema control event. The two
-/// names coincide for every variant except `ParseError`, whose core
-/// enum variant keeps the historical `Error` spelling — the public
-/// event class is named `ParseError` so no binding ships a class that
-/// collides with the language's own error types.
-fn control_rust_variant(event_name: &str) -> &str {
-    match event_name {
-        "ParseError" => "Error",
-        other => other,
     }
 }
 

--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -3,6 +3,8 @@
 
 use std::fmt::Write as _;
 
+use heck::ToLowerCamelCase;
+
 use super::common::{generated_header, greek_result_fields, push_rust_doc_comment, ts_field_ident};
 use super::spec::{MethodKind, MethodSpec, UtilityKind, UtilitySpec};
 
@@ -325,17 +327,7 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
 }
 
 fn to_ts_camel_case(name: &str) -> String {
-    let mut parts = name.split('_');
-    let first = parts.next().unwrap_or_default();
-    let mut result = first.to_string();
-    for part in parts {
-        if !part.is_empty() {
-            let mut chars = part.chars();
-            result.push(chars.next().unwrap().to_uppercase().next().unwrap());
-            result.extend(chars);
-        }
-    }
-    result
+    name.to_lower_camel_case()
 }
 
 /// Renders the TypeScript utility functions source: the `AllGreeks` napi object and the offline utility free functions.

--- a/crates/thetadatadx/build_support_bin/ticks/cpp.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/cpp.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Write as _;
 
+use heck::ToSnakeCase;
+
 use super::idents::c_field_ident;
 use super::layout::{tick_ffi_offsets, tick_ffi_size_and_align};
 use super::schema::Schema;
@@ -54,25 +56,6 @@ pub(super) fn render_cpp_tick_layout_asserts(schema: &Schema) -> String {
     out
 }
 
-/// PascalCase → snake_case for deriving the C ABI symbol from a tick
-/// collection name (`EodTicks` → `eod_ticks`, `IndexPriceAtTimeTicks` →
-/// `index_price_at_time_ticks`). Local to the C++ emitter so it stays
-/// independent of the fpss_events `snake_case` helper.
-fn pascal_to_snake(name: &str) -> String {
-    let mut out = String::new();
-    for (i, ch) in name.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if i != 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
 /// Emit `sdks/cpp/include/tick_arrow_ipc.hpp.inc` — the C++ free functions
 /// that serialise a `std::vector<Tick>` history result to Arrow IPC bytes,
 /// mirroring the `FlatFileRowList::to_arrow_ipc()` terminal. Each wraps the
@@ -93,7 +76,7 @@ pub(super) fn render_cpp_tick_arrow_ipc(schema: &Schema) -> String {
         }
         let def = &schema.types[type_name];
         let collection = &def.render.collection;
-        let snake = pascal_to_snake(collection);
+        let snake = collection.to_snake_case();
         let c_fn = format!("thetadatadx_{snake}_to_arrow_ipc");
         writeln!(
             out,

--- a/crates/thetadatadx/build_support_bin/ticks/python_arrow.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/python_arrow.rs
@@ -141,7 +141,7 @@ fn render_python_slice_to_arrow_converters(schema: &Schema) -> String {
 /// columnar projections: `right` and `calendar_status` buffer `String`
 /// (built into `StringArray`), `bool` buffers `bool` (built into
 /// `BooleanArray`).
-fn tick_struct_field_type(column_type: &str) -> &'static str {
+pub(super) fn tick_struct_field_type(column_type: &str) -> &'static str {
     match column_type {
         "i32" | "eod_num" | "eod_date" => "i32",
         "i64" | "eod_num64" => "i64",
@@ -156,7 +156,7 @@ fn tick_struct_field_type(column_type: &str) -> &'static str {
 /// buffer. Logical columns project here: `right` chars become one-char
 /// strings (`'\0'` -> `""`), the calendar status enum becomes its
 /// vendor-vocabulary string.
-fn column_push_expr(column_type: &str, field: &str) -> String {
+pub(super) fn column_push_expr(column_type: &str, field: &str) -> String {
     match column_type {
         "right" => {
             format!("if t.{field} == '\\0' {{ String::new() }} else {{ t.{field}.to_string() }}")
@@ -339,7 +339,7 @@ fn render_python_slice_public_helper(type_name: &str) -> String {
 /// `eod_num64` (i64) are distinct on the Rust side because one is
 /// widened for volume/count; they preserve that distinction into
 /// Arrow.
-fn arrow_data_type_expr(column_type: &str) -> &'static str {
+pub(super) fn arrow_data_type_expr(column_type: &str) -> &'static str {
     match column_type {
         "i32" | "eod_num" | "eod_date" => "DataType::Int32",
         "i64" | "eod_num64" => "DataType::Int64",
@@ -354,7 +354,7 @@ fn arrow_data_type_expr(column_type: &str) -> &'static str {
 /// constructor we call when materializing a column. Parallel to
 /// `arrow_data_type_expr`; the caller wraps the result in
 /// `Arc::new(...) as ArrayRef`.
-fn arrow_array_ctor(column_type: &str) -> &'static str {
+pub(super) fn arrow_array_ctor(column_type: &str) -> &'static str {
     match column_type {
         "i32" | "eod_num" | "eod_date" => "Int32Array",
         "i64" | "eod_num64" => "Int64Array",

--- a/crates/thetadatadx/build_support_bin/ticks/rust_frames.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/rust_frames.rs
@@ -28,6 +28,9 @@
 
 use std::fmt::Write as _;
 
+use super::python_arrow::{
+    arrow_array_ctor, arrow_data_type_expr, column_push_expr, tick_struct_field_type,
+};
 use super::schema::{Schema, TickTypeDef};
 use super::sorted_type_names;
 
@@ -300,53 +303,4 @@ fn render_polars_impl(type_name: &str, def: &TickTypeDef) -> String {
     out.push_str("}\n");
 
     out
-}
-
-// ── Type-mapping helpers (mirror of python_arrow.rs) ────────────────────
-
-fn tick_struct_field_type(column_type: &str) -> &'static str {
-    match column_type {
-        "i32" | "eod_num" | "eod_date" => "i32",
-        "i64" | "eod_num64" => "i64",
-        "f64" | "price" | "eod_price" => "f64",
-        "String" | "right" | "calendar_status" => "String",
-        "bool" => "bool",
-        other => panic!("unsupported tick-struct field type '{other}'"),
-    }
-}
-
-/// Per-column push expression — mirrors
-/// `python_arrow::column_push_expr` so the Rust and Python columnar
-/// outputs project logical columns identically.
-fn column_push_expr(column_type: &str, field: &str) -> String {
-    match column_type {
-        "right" => {
-            format!("if t.{field} == '\\0' {{ String::new() }} else {{ t.{field}.to_string() }}")
-        }
-        "calendar_status" => format!("t.{field}.as_str().to_string()"),
-        "String" => format!("t.{field}.clone()"),
-        _ => format!("t.{field}"),
-    }
-}
-
-fn arrow_data_type_expr(column_type: &str) -> &'static str {
-    match column_type {
-        "i32" | "eod_num" | "eod_date" => "DataType::Int32",
-        "i64" | "eod_num64" => "DataType::Int64",
-        "f64" | "price" | "eod_price" => "DataType::Float64",
-        "String" | "right" | "calendar_status" => "DataType::Utf8",
-        "bool" => "DataType::Boolean",
-        other => panic!("unsupported Arrow data type for column type '{other}'"),
-    }
-}
-
-fn arrow_array_ctor(column_type: &str) -> &'static str {
-    match column_type {
-        "i32" | "eod_num" | "eod_date" => "Int32Array",
-        "i64" | "eod_num64" => "Int64Array",
-        "f64" | "price" | "eod_price" => "Float64Array",
-        "String" | "right" | "calendar_status" => "StringArray",
-        "bool" => "BooleanArray",
-        other => panic!("unsupported Arrow array ctor for column type '{other}'"),
-    }
 }

--- a/crates/thetadatadx/build_support_bin/ticks/schema.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/schema.rs
@@ -160,17 +160,12 @@ pub(crate) struct ColumnDef {
     pub(crate) doc: Option<String>,
 }
 
-/// Every per-language binding name a renderer needs for one tick type.
-/// Single TOML row replaces the parallel match arms previously hand-coded
-/// across `helpers.rs` and `ticks/mod.rs::pyclass_name`.
-///
-/// Underscore-prefixed fields are schema-validation-only at this seam:
-/// the per-language binding name they hold is read elsewhere (the
-/// endpoint emitters' `sdk_helpers` reparses the same TOML for FFI / C++
-/// / Python emit paths), but the per-tick emitters in this tree only
-/// reach for `collection`, the pyclass / Vec / Arrow projections, and
-/// `ts_class_vec`. Keeping the full shape here lets `deny_unknown_fields`
-/// (added at this tree's load seam) reject typos at TOML-load time.
+/// The per-language binding names the per-tick emitters in this tree read
+/// for one tick type: the pyclass / Vec / Arrow projections and the
+/// TypeScript class vec. The other binding names in the same TOML row
+/// (FFI / C++ / direct) are read by the endpoint emitters' `sdk_helpers`,
+/// which reparses the TOML independently; serde ignores the keys this
+/// struct does not name, so they are not redeclared here.
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct TickRenderDef {
     /// Wire-collection plural keying every renderer call (e.g. `"GreeksTicks"`).
@@ -178,31 +173,9 @@ pub(crate) struct TickRenderDef {
     /// `endpoint_surface.toml`. Build-time validator rejects duplicates and
     /// strays.
     pub(crate) collection: String,
-    #[serde(rename = "direct")]
-    _direct: String,
-    #[serde(rename = "parser")]
-    _parser: String,
-    #[serde(rename = "ffi_array")]
-    _ffi_array: String,
-    #[serde(rename = "ffi_output_variant")]
-    _ffi_output_variant: String,
-    #[serde(rename = "ffi_from_vec_array")]
-    _ffi_from_vec_array: String,
-    #[serde(rename = "ffi_header_return")]
-    _ffi_header_return: String,
-    #[serde(rename = "ffi_free_fn")]
-    _ffi_free_fn: String,
-    #[serde(rename = "cpp_value")]
-    _cpp_value: String,
-    #[serde(rename = "python_converter")]
-    _python_converter: String,
-    #[serde(rename = "python_columnar")]
-    _python_columnar: String,
     pub(crate) python_pyclass_list: String,
     pub(crate) python_vec_to_pylist: String,
     pub(crate) python_slice_arrow: String,
-    #[serde(rename = "ts_class")]
-    _ts_class: String,
     pub(crate) ts_class_vec: String,
     pub(crate) pyclass: String,
 }

--- a/crates/thetadatadx/build_support_bin/ticks/tdbe_structs.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/tdbe_structs.rs
@@ -22,6 +22,8 @@
 
 use std::fmt::Write as _;
 
+use heck::ToSnakeCase;
+
 use super::idents::rust_field_ident;
 use super::layout::{tick_ffi_offsets, tick_ffi_size_and_align};
 use super::schema::{Schema, TickTypeDef};
@@ -151,7 +153,7 @@ pub(super) fn render_tdbe_layout_asserts(schema: &Schema) -> String {
         }
         let def = &schema.types[type_name];
         let (size, align) = tick_ffi_size_and_align(type_name, def);
-        let snake = pascal_to_snake(type_name);
+        let snake = type_name.to_snake_case();
 
         writeln!(out, "    #[test]").unwrap();
         writeln!(out, "    fn {snake}_layout() {{").unwrap();
@@ -173,24 +175,6 @@ pub(super) fn render_tdbe_layout_asserts(schema: &Schema) -> String {
     }
 
     out.push_str("}\n");
-    out
-}
-
-/// Convert a PascalCase tick type name (`GreeksFirstOrderTick`) to the
-/// snake_case form used in test names (`greeks_first_order_tick`). Pure
-/// helper -- not exported.
-fn pascal_to_snake(name: &str) -> String {
-    let mut out = String::new();
-    for (i, ch) in name.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if i != 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-        } else {
-            out.push(ch);
-        }
-    }
     out
 }
 

--- a/crates/thetadatadx/build_support_bin/ticks/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/typescript.rs
@@ -14,6 +14,8 @@
 
 use std::fmt::Write as _;
 
+use heck::{ToLowerCamelCase, ToSnakeCase};
+
 use super::idents::rust_field_ident;
 use super::python_classes::strip_field_count_from_doc;
 use super::schema::{render_for_type, Schema, TickTypeDef};
@@ -76,8 +78,8 @@ fn render_ts_tick_arrow_ipc(type_name: &str, def: &TickTypeDef) -> Option<String
     if type_name == "OptionContract" {
         return None;
     }
-    let fn_name = format!("{}_to_arrow_ipc", to_snake_case(type_name));
-    let js_name = format!("{}ToArrowIpc", to_lower_camel(type_name));
+    let fn_name = format!("{}_to_arrow_ipc", type_name.to_snake_case());
+    let js_name = format!("{}ToArrowIpc", type_name.to_lower_camel_case());
     let mut out = String::new();
     writeln!(
         out,
@@ -216,33 +218,6 @@ fn ts_arrow_reconstruct_is_fallible(def: &TickTypeDef) -> bool {
             .columns
             .iter()
             .any(|column| matches!(column.r#type.as_str(), "right" | "calendar_status"))
-}
-
-/// PascalCase tick type name → snake_case fn-name stem (`EodTick` →
-/// `eod_tick`).
-fn to_snake_case(name: &str) -> String {
-    let mut out = String::new();
-    for (i, ch) in name.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if i != 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
-/// PascalCase tick type name → lowerCamelCase JS stem (`EodTick` →
-/// `eodTick`).
-fn to_lower_camel(name: &str) -> String {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) => first.to_ascii_lowercase().to_string() + chars.as_str(),
-        None => String::new(),
-    }
 }
 
 fn render_ts_tick_class_struct(type_name: &str, def: &TickTypeDef) -> String {

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2242,6 +2242,7 @@ dependencies = [
  "disruptor",
  "futures-core",
  "h2",
+ "heck",
  "http",
  "hyper-util",
  "libc",

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "disruptor",
  "futures-core",
  "h2",
+ "heck",
  "http",
  "hyper-util",
  "libc",

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "disruptor",
  "futures-core",
  "h2",
+ "heck",
  "http",
  "hyper-util",
  "libc",

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2273,6 +2273,7 @@ dependencies = [
  "disruptor",
  "futures-core",
  "h2",
+ "heck",
  "http",
  "hyper-util",
  "libc",

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -701,7 +701,7 @@ fn insert_contract_id_fields(row: &mut Row, expiration: i32, strike: f64, right:
 // ---------------------------------------------------------------------------
 
 /// Convert EOD ticks to ordered rows matching the JVM terminal format.
-pub fn eod_ticks_to_json(ticks: &[EodTick]) -> Vec<Row> {
+pub(crate) fn eod_ticks_to_json(ticks: &[EodTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -739,7 +739,7 @@ pub fn eod_ticks_to_json(ticks: &[EodTick]) -> Vec<Row> {
 /// `timestamp,(symbol,)open,high,low,close,volume,count` with no `vwap`
 /// column. The shared tick type carries `vwap` either way, so the snapshot
 /// shape omits it from the row rather than emitting a column the spec doesn't.
-pub fn ohlc_ticks_to_json(ticks: &[OhlcTick], shape: RowShape) -> Vec<Row> {
+pub(crate) fn ohlc_ticks_to_json(ticks: &[OhlcTick], shape: RowShape) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -775,7 +775,7 @@ pub fn ohlc_ticks_to_json(ticks: &[OhlcTick], shape: RowShape) -> Vec<Row> {
 /// execution record). The shared tick type carries every field, so the
 /// trimmed shape omits the extras rather than emitting columns the v3
 /// snapshot-trade schema doesn't list.
-pub fn trade_ticks_to_json(ticks: &[TradeTick], shape: RowShape) -> Vec<Row> {
+pub(crate) fn trade_ticks_to_json(ticks: &[TradeTick], shape: RowShape) -> Vec<Row> {
     // Only the non-option snapshot trade (stock / index) trims the extended
     // columns; option snapshot trade keeps the full execution set.
     let trim_execution_columns = shape.is_snapshot && !shape.is_option;
@@ -817,7 +817,7 @@ pub fn trade_ticks_to_json(ticks: &[TradeTick], shape: RowShape) -> Vec<Row> {
 }
 
 /// Convert quote ticks to ordered rows.
-pub fn quote_ticks_to_json(ticks: &[QuoteTick]) -> Vec<Row> {
+pub(crate) fn quote_ticks_to_json(ticks: &[QuoteTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -842,7 +842,7 @@ pub fn quote_ticks_to_json(ticks: &[QuoteTick]) -> Vec<Row> {
 }
 
 /// Convert trade+quote ticks to JSON array.
-pub fn trade_quote_ticks_to_json(ticks: &[TradeQuoteTick]) -> Vec<Row> {
+pub(crate) fn trade_quote_ticks_to_json(ticks: &[TradeQuoteTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -881,7 +881,7 @@ pub fn trade_quote_ticks_to_json(ticks: &[TradeQuoteTick]) -> Vec<Row> {
 }
 
 /// Convert open interest ticks to ordered rows.
-pub fn open_interest_ticks_to_json(ticks: &[OpenInterestTick]) -> Vec<Row> {
+pub(crate) fn open_interest_ticks_to_json(ticks: &[OpenInterestTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -906,7 +906,7 @@ pub fn open_interest_ticks_to_json(ticks: &[OpenInterestTick]) -> Vec<Row> {
 /// triple (`market_bid`, `market_ask`, `market_price`); the *index* shape
 /// publishes only `market_price` (the SIPs report an index value, not a
 /// two-sided market), so bid / ask are omitted there.
-pub fn market_value_ticks_to_json(ticks: &[MarketValueTick], shape: RowShape) -> Vec<Row> {
+pub(crate) fn market_value_ticks_to_json(ticks: &[MarketValueTick], shape: RowShape) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -935,7 +935,7 @@ pub fn market_value_ticks_to_json(ticks: &[MarketValueTick], shape: RowShape) ->
 
 /// Convert full-union Greeks ticks (`option_*_greeks_all`,
 /// `option_*_greeks_eod`) to JSON array.
-pub fn greeks_all_ticks_to_json(ticks: &[GreeksAllTick]) -> Vec<Row> {
+pub(crate) fn greeks_all_ticks_to_json(ticks: &[GreeksAllTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -987,7 +987,7 @@ pub fn greeks_all_ticks_to_json(ticks: &[GreeksAllTick]) -> Vec<Row> {
 /// -- so downstream MCP-side / REST-side consumers see the full EOD
 /// trade-quote context that the earlier routing dropped; the current schema restores the
 /// full schema.
-pub fn greeks_eod_ticks_to_json(ticks: &[GreeksEodTick]) -> Vec<Row> {
+pub(crate) fn greeks_eod_ticks_to_json(ticks: &[GreeksEodTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1044,7 +1044,7 @@ pub fn greeks_eod_ticks_to_json(ticks: &[GreeksEodTick]) -> Vec<Row> {
 
 /// Convert first-order Greeks subset ticks
 /// (`option_*_greeks_first_order`) to JSON array.
-pub fn greeks_first_order_ticks_to_json(ticks: &[GreeksFirstOrderTick]) -> Vec<Row> {
+pub(crate) fn greeks_first_order_ticks_to_json(ticks: &[GreeksFirstOrderTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1074,7 +1074,7 @@ pub fn greeks_first_order_ticks_to_json(ticks: &[GreeksFirstOrderTick]) -> Vec<R
 
 /// Convert second-order Greeks subset ticks
 /// (`option_*_greeks_second_order`) to JSON array.
-pub fn greeks_second_order_ticks_to_json(ticks: &[GreeksSecondOrderTick]) -> Vec<Row> {
+pub(crate) fn greeks_second_order_ticks_to_json(ticks: &[GreeksSecondOrderTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1104,7 +1104,7 @@ pub fn greeks_second_order_ticks_to_json(ticks: &[GreeksSecondOrderTick]) -> Vec
 /// Convert third-order Greeks subset ticks
 /// (`option_*_greeks_third_order`) to JSON array. The vendor's
 /// third-order schema does not publish `vera`, hence its absence here.
-pub fn greeks_third_order_ticks_to_json(ticks: &[GreeksThirdOrderTick]) -> Vec<Row> {
+pub(crate) fn greeks_third_order_ticks_to_json(ticks: &[GreeksThirdOrderTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1135,7 +1135,7 @@ pub fn greeks_third_order_ticks_to_json(ticks: &[GreeksThirdOrderTick]) -> Vec<R
 /// trade-side execution columns alongside every Greek the server
 /// publishes -- distinct from the interval-sampled `GreeksAllTick`
 /// JSON whose rows carry the bid/ask quote pair instead.
-pub fn trade_greeks_all_ticks_to_json(ticks: &[TradeGreeksAllTick]) -> Vec<Row> {
+pub(crate) fn trade_greeks_all_ticks_to_json(ticks: &[TradeGreeksAllTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1186,7 +1186,7 @@ pub fn trade_greeks_all_ticks_to_json(ticks: &[TradeGreeksAllTick]) -> Vec<Row> 
 
 /// Convert per-OPRA-trade first-order Greeks ticks
 /// (`option_history_trade_greeks_first_order`) to JSON array.
-pub fn trade_greeks_first_order_ticks_to_json(
+pub(crate) fn trade_greeks_first_order_ticks_to_json(
     ticks: &[TradeGreeksFirstOrderTick],
 ) -> Vec<Row> {
     ticks
@@ -1225,7 +1225,7 @@ pub fn trade_greeks_first_order_ticks_to_json(
 
 /// Convert per-OPRA-trade second-order Greeks ticks
 /// (`option_history_trade_greeks_second_order`) to JSON array.
-pub fn trade_greeks_second_order_ticks_to_json(
+pub(crate) fn trade_greeks_second_order_ticks_to_json(
     ticks: &[TradeGreeksSecondOrderTick],
 ) -> Vec<Row> {
     ticks
@@ -1264,7 +1264,7 @@ pub fn trade_greeks_second_order_ticks_to_json(
 /// Convert per-OPRA-trade third-order Greeks ticks
 /// (`option_history_trade_greeks_third_order`) to JSON array. The
 /// vendor's third-order schema does not publish `vera`.
-pub fn trade_greeks_third_order_ticks_to_json(
+pub(crate) fn trade_greeks_third_order_ticks_to_json(
     ticks: &[TradeGreeksThirdOrderTick],
 ) -> Vec<Row> {
     ticks
@@ -1303,7 +1303,7 @@ pub fn trade_greeks_third_order_ticks_to_json(
 /// (`option_history_trade_greeks_implied_volatility`) to JSON array.
 /// Carries only the single `implied_volatility` + `iv_error` pair
 /// (NOT the bid/mid/ask IV triple of the interval-sampled `IvTick`).
-pub fn trade_greeks_implied_volatility_ticks_to_json(
+pub(crate) fn trade_greeks_implied_volatility_ticks_to_json(
     ticks: &[TradeGreeksImpliedVolatilityTick],
 ) -> Vec<Row> {
     ticks
@@ -1346,7 +1346,7 @@ pub fn trade_greeks_implied_volatility_ticks_to_json(
 /// the `IvTick` type, so the snapshot shape omits the bid/mid/ask-IV columns
 /// from the row rather than emitting columns the v3 snapshot schema doesn't
 /// list.
-pub fn iv_ticks_to_json(ticks: &[IvTick], shape: RowShape) -> Vec<Row> {
+pub(crate) fn iv_ticks_to_json(ticks: &[IvTick], shape: RowShape) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1408,7 +1408,7 @@ pub fn iv_ticks_to_json(ticks: &[IvTick], shape: RowShape) -> Vec<Row> {
 }
 
 /// Convert price ticks to ordered rows.
-pub fn price_ticks_to_json(ticks: &[PriceTick]) -> Vec<Row> {
+pub(crate) fn price_ticks_to_json(ticks: &[PriceTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1429,7 +1429,7 @@ pub fn price_ticks_to_json(ticks: &[PriceTick]) -> Vec<Row> {
 /// `ms_of_day`, `price`, and `date` -- so downstream MCP-side /
 /// REST-side consumers see the per-row SIP-exchange attribution that
 /// the earlier routing dropped; the current schema restores the full schema.
-pub fn index_price_at_time_ticks_to_json(ticks: &[IndexPriceAtTimeTick]) -> Vec<Row> {
+pub(crate) fn index_price_at_time_ticks_to_json(ticks: &[IndexPriceAtTimeTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1461,7 +1461,7 @@ pub fn index_price_at_time_ticks_to_json(ticks: &[IndexPriceAtTimeTick]) -> Vec<
 /// `open` / `close` are `HH:mm:ss` clock strings on trading days and
 /// `null` on fully-closed days, so a consumer can branch on a present
 /// time vs an explicit null rather than a sentinel midnight.
-pub fn calendar_days_to_json(days: &[CalendarDay]) -> Vec<Row> {
+pub(crate) fn calendar_days_to_json(days: &[CalendarDay]) -> Vec<Row> {
     days.iter()
         .map(|d| {
             let (open, close) = if d.status.is_open() {
@@ -1488,7 +1488,7 @@ pub fn calendar_days_to_json(days: &[CalendarDay]) -> Vec<Row> {
 }
 
 /// Convert interest rate ticks to JSON array.
-pub fn interest_rate_ticks_to_json(ticks: &[InterestRateTick]) -> Vec<Row> {
+pub(crate) fn interest_rate_ticks_to_json(ticks: &[InterestRateTick]) -> Vec<Row> {
     ticks
         .iter()
         .map(|t| {
@@ -1504,7 +1504,7 @@ pub fn interest_rate_ticks_to_json(ticks: &[InterestRateTick]) -> Vec<Row> {
 }
 
 /// Convert option contracts to JSON array.
-pub fn option_contracts_to_json(contracts: &[OptionContract]) -> Vec<Row> {
+pub(crate) fn option_contracts_to_json(contracts: &[OptionContract]) -> Vec<Row> {
     contracts
         .iter()
         .map(|c| {

--- a/tools/server/src/ws/session.rs
+++ b/tools/server/src/ws/session.rs
@@ -115,18 +115,14 @@ pub(super) async fn handle_socket(mut socket: WebSocket, state: AppState) {
 ///
 /// Never sends an empty WS frame on serialization failure -- logs the
 /// error instead. The socket is left open so the client can retry the
-/// command. Callers that must close on serialize failure should inspect
-/// the return value (`false` = not sent) and propagate.
-pub(super) async fn send_response(
-    socket: &mut WebSocket,
-    resp: &sonic_rs::Value,
-    ctx: &str,
-) -> bool {
+/// command.
+pub(super) async fn send_response(socket: &mut WebSocket, resp: &sonic_rs::Value, ctx: &str) {
     match sonic_rs::to_string(resp) {
-        Ok(s) => socket.send(Message::Text(s.into())).await.is_ok(),
+        Ok(s) => {
+            let _ = socket.send(Message::Text(s.into())).await;
+        }
         Err(e) => {
             tracing::error!(error = %e, context = %ctx, "ws response serialize failed; dropping");
-            false
         }
     }
 }

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -115,14 +115,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             "text frame exceeds maximum of {WS_MAX_TEXT_BYTES} bytes (got {})",
             text.len()
         );
-        let resp = sonic_rs::json!({
-            "header": {
-                "type": "REQ_RESPONSE",
-                "response": ReqResponse::Error.as_str(),
-                "req_id": 0,
-                "error": err_msg.as_str(),
-            }
-        });
+        let resp = build_req_response(ReqResponse::Error, 0, Some(err_msg.as_str()));
         send_response(socket, &resp, "oversize_text_reply").await;
         return;
     }
@@ -131,13 +124,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
         Ok(v) => v,
         Err(_) => {
             tracing::warn!("invalid WebSocket JSON: {}", text);
-            let resp = sonic_rs::json!({
-                "header": {
-                    "type": "REQ_RESPONSE",
-                    "response": ReqResponse::Error.as_str(),
-                    "req_id": 0
-                }
-            });
+            let resp = build_req_response(ReqResponse::Error, 0, None);
             send_response(socket, &resp, "invalid_json_reply").await;
             return;
         }
@@ -229,14 +216,11 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             Some(v) => v,
             None => {
                 tracing::warn!("WS subscribe: option expiration missing or not an integer");
-                let resp = sonic_rs::json!({
-                    "header": {
-                        "type": "REQ_RESPONSE",
-                        "response": ReqResponse::Error.as_str(),
-                        "req_id": req_id,
-                        "error": "expiration must be an integer",
-                    }
-                });
+                let resp = build_req_response(
+                    ReqResponse::Error,
+                    req_id,
+                    Some("expiration must be an integer"),
+                );
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -249,14 +233,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                     "WS subscribe: option expiration out of i32 range"
                 );
                 let err_msg = format!("expiration {exp_i64} exceeds i32 range");
-                let resp = sonic_rs::json!({
-                    "header": {
-                        "type": "REQ_RESPONSE",
-                        "response": ReqResponse::Error.as_str(),
-                        "req_id": req_id,
-                        "error": err_msg.as_str(),
-                    }
-                });
+                let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -284,14 +261,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                 "'exp' out of range (expected YYYYMMDD {}..={}; got {exp})",
                 MIN_OPTION_EXP, MAX_OPTION_EXP
             );
-            let resp = sonic_rs::json!({
-                "header": {
-                    "type": "REQ_RESPONSE",
-                    "response": ReqResponse::Error.as_str(),
-                    "req_id": req_id,
-                    "error": err_msg.as_str(),
-                }
-            });
+            let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
@@ -305,14 +275,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                  reject reason: month/day decomposition is not a real \
                  Gregorian day, e.g. Feb 30 or Apr 31)"
             );
-            let resp = sonic_rs::json!({
-                "header": {
-                    "type": "REQ_RESPONSE",
-                    "response": ReqResponse::Error.as_str(),
-                    "req_id": req_id,
-                    "error": err_msg.as_str(),
-                }
-            });
+            let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
@@ -328,14 +291,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             Ok(v) => v,
             Err(err_msg) => {
                 tracing::warn!(error = %err_msg, "WS subscribe: invalid option 'strike'");
-                let resp = sonic_rs::json!({
-                    "header": {
-                        "type": "REQ_RESPONSE",
-                        "response": ReqResponse::Error.as_str(),
-                        "req_id": req_id,
-                        "error": err_msg.as_str(),
-                    }
-                });
+                let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -345,14 +301,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             Ok(sides) => sides,
             Err(err_msg) => {
                 tracing::warn!(error = %err_msg, "WS subscribe: invalid option 'right'");
-                let resp = sonic_rs::json!({
-                    "header": {
-                        "type": "REQ_RESPONSE",
-                        "response": ReqResponse::Error.as_str(),
-                        "req_id": req_id,
-                        "error": err_msg.as_str(),
-                    }
-                });
+                let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -372,14 +321,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
         Ok(subs) => subs,
         Err(err_msg) => {
             tracing::warn!(req_type = %req_type, "WS subscribe: unsupported req_type");
-            let resp = sonic_rs::json!({
-                "header": {
-                    "type": "REQ_RESPONSE",
-                    "response": ReqResponse::Error.as_str(),
-                    "req_id": req_id,
-                    "error": err_msg.as_str(),
-                }
-            });
+            let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
@@ -510,13 +452,8 @@ fn apply_bulk_trade(
 ) -> sonic_rs::Value {
     use thetadatadx::fpss::protocol::{FullSubscriptionKind, Subscription};
 
-    let st = match sec_type {
-        "OPTION" => SecType::Option,
-        "INDEX" => SecType::Index,
-        _ => SecType::Stock,
-    };
     let subscriptions = vec![Subscription::Full {
-        sec_type: st,
+        sec_type: sec_type_from_str(sec_type),
         kind: FullSubscriptionKind::Trades,
     }];
 
@@ -617,6 +554,18 @@ fn parse_right_sides(raw: Option<&str>) -> Result<Vec<bool>, String> {
     })
 }
 
+/// Resolve a client `sec_type` token to the wire [`SecType`]. Unknown
+/// values default to `Stock`, matching the wire default for a root with no
+/// security type. Options are addressed by the same `"OPTION"` token used on
+/// the per-contract path.
+fn sec_type_from_str(sec_type: &str) -> SecType {
+    match sec_type {
+        "OPTION" => SecType::Option,
+        "INDEX" => SecType::Index,
+        _ => SecType::Stock,
+    }
+}
+
 /// Build the per-contract contract for a non-option subscribe.
 ///
 /// The FPSS contract wire encoding carries a load-bearing sec_type: an
@@ -665,12 +614,10 @@ fn subscription_plan(
     };
 
     let full = |kind: FullSubscriptionKind| {
-        let st = match sec_type {
-            "OPTION" => SecType::Option,
-            "INDEX" => SecType::Index,
-            _ => SecType::Stock,
-        };
-        vec![Subscription::Full { sec_type: st, kind }]
+        vec![Subscription::Full {
+            sec_type: sec_type_from_str(sec_type),
+            kind,
+        }]
     };
 
     match req_type {


### PR DESCRIPTION
Two batches of dedup / cleanup cuts, each cross-referenced against a deep audit. Every codegen change is gated on byte-identical generated output; one audit item was reverted because reading the live source would have changed the docs.

## Commit 1 — `tools/server/src/` (server dedup)

- Replaced 9 hand-rolled `REQ_RESPONSE` error envelopes in `ws/subscribe.rs` with `build_req_response(...)` calls. Each inline `sonic_rs::json!` block emitted the byte-identical header shape the helper already produces; the two no-error (`req_id: 0`) arms map to `build_req_response(Error, 0, ..)`. Server tests covering the envelope shapes (`success_subscribe_returns_subscribed`, `validation_failure_returns_error_with_message`) confirm the wire output is unchanged.
- Extracted the duplicated `sec_type` token match (`apply_bulk_trade` + the `subscription_plan` `full` closure) into one `sec_type_from_str(&str) -> SecType`.
- `send_response` returned a `bool` all 14 callers discarded (none `let _`-bound, not `#[must_use]`). Changed the return to `()` and dropped the misleading doc lines.
- Tightened the 23 `*_to_json` tick serializers from `pub fn` to `pub(crate) fn`: binary crate, no library target, dispatched only from `build_rows` in the same module, nothing re-exports them. Visibility only.
- Skipped the borderline `FlatfilePath` extractor as instructed.

Net: 3 files, +58 / -115.

## Commit 2 — `crates/thetadatadx/build_support{,_bin}/` (codegen dedup)

Byte-identical generated output is the hard gate: `generate_sdk_surfaces --features config-file -- --check`, `generate_docs_site --features config-file,__internal -- --check`, and the `build.rs` registry regen all confirm the SDK surfaces, docs-site tree, and decode registry are unchanged.

Pure deletes (no output effect):
- Dropped the 11 dead underscore-prefixed fields from `TickRenderDef`. Serde ignores the TOML keys this struct does not name (FFI / C++ / direct names are reparsed independently by the endpoint emitters' `sdk_helpers`).
- Removed the dead compute-then-discard `let _ = x;` warning-suppressors in the SDK and FPSS-event emitters, and inlined the `control_struct_align` passthrough at its one caller.

Case-conversion dedup via `heck`:
- Replaced 7 hand-rolled folders with `heck` (`to_snake_case` / `to_upper_camel_case` / `to_lower_camel_case`). All tick / event / method names are single-cap-per-word, so heck matches the hand-rolled output byte-for-byte (proven by the regen gate).
- Kept the initialism-aware folders hand-rolled where heck would diverge: `sdk_helpers::{pascal_segment, to_pascal_case, to_camel_case}` (EOD/OHLC/IV/DTE/NBBO uppercasing), `screaming_snake_to_snake`, `napi_field_camel`, and `grpc::to_snake_case` (a unit test pins `to_snake_case("HTTPServer") == "h_t_t_p_server"`, which heck would break).
- `heck` lands in `[build-dependencies]` for the build script and in a `config-file`-gated `[dependencies]` entry for the codegen binaries, since `build_support/endpoints/helpers.rs` is `#[path]`-compiled into both.

Shared emit helpers (byte-identical emission):
- Hoisted the thrice-transcribed `control_rust_variant` into `fpss_events/common.rs`.
- Shared `python_arrow`'s 4 type-map folders into `rust_frames` via `pub(super)`.
- Collapsed the 5 timeout-race emit blocks into one `write_timeout_call` in `sdk_helpers`.
- Collapsed the 3 optional-setter emit loops into one `emit_optional_setters`.

Reverted — would change output:
- `docs_render::sample_value` stays hand-coded. It renders docs-friendly values (`trade`, `1m`, `10:30:00`) that intentionally differ from the live-validator `[test_fixtures]` (`TRADE`, `60000`, `12:00:00.000`), so reading from the loaded fixtures would change the generated docs. The audit's premise that it mirrors `[test_fixtures]` is not accurate.

Net: 21 files, +123 / -397.

## Byte-identical output confirmation

`generate_sdk_surfaces --check` and `generate_docs_site --check` both exit 0 on the final committed state, and `cargo build -p thetadatadx` regenerates the registry with no working-tree drift. No committed generated file changed.

## Gates

`cargo check -p thetadatadx` (default / `__test-helpers` / `arrow,polars,frames,config-file`), `cargo clippy --workspace --all-targets --locked -- -D warnings` (plus the codegen bins under `config-file,__internal`), `cargo doc --no-deps --workspace --locked`, `cargo fmt --check`, `cargo test -p thetadatadx --lib` (1069), the codegen bin tests (17), the grpc codegen test (1), server tests (184 + 2), `check_docs_consistency.py`, and `cargo deny check` (the new `heck` dep) all pass. No new `#[allow]`.

Combined net: -331 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)