### PR TITLE
refactor: dedup ffi credentials + lock-recovery, drop dead accessors

### DIFF
--- a/crates/thetadatadx/src/mdds/endpoint_args.rs
+++ b/crates/thetadatadx/src/mdds/endpoint_args.rs
@@ -160,21 +160,6 @@ impl EndpointArgs {
         };
     }
 
-    /// Configured per-call deadline in milliseconds.
-    ///
-    /// Returns `Some(n)` only for an explicit positive deadline
-    /// ([`DeadlineSetting::Millis`]); both [`DeadlineSetting::Unset`] and the
-    /// explicit-opt-out [`DeadlineSetting::Disabled`] return `None`. Callers
-    /// that must tell those two apart (the generated dispatch) read
-    /// [`Self::deadline_setting`] instead.
-    #[must_use]
-    pub fn timeout_ms(&self) -> Option<u64> {
-        match self.deadline {
-            DeadlineSetting::Millis(ms) => Some(ms),
-            DeadlineSetting::Unset | DeadlineSetting::Disabled => None,
-        }
-    }
-
     /// Per-call deadline state, distinguishing "unset" (fall back to the
     /// configured default) from "explicitly disabled" (run unbounded). The
     /// generated dispatch reads this to honour `with_timeout_ms(0)` as the
@@ -682,14 +667,12 @@ mod tests {
     #[test]
     fn endpoint_args_default_has_no_timeout() {
         let args = EndpointArgs::new();
-        assert_eq!(args.timeout_ms(), None);
         assert_eq!(args.deadline_setting(), DeadlineSetting::Unset);
     }
 
     #[test]
     fn with_timeout_ms_attaches_deadline() {
         let args = EndpointArgs::new().with_timeout_ms(60_000);
-        assert_eq!(args.timeout_ms(), Some(60_000));
         assert_eq!(args.deadline_setting(), DeadlineSetting::Millis(60_000));
     }
 
@@ -697,21 +680,19 @@ mod tests {
     fn clear_timeout_drops_deadline() {
         let mut args = EndpointArgs::new().with_timeout_ms(60_000);
         args.clear_timeout();
-        assert_eq!(args.timeout_ms(), None);
         // Clearing returns to "unset" — the configured default applies on
         // the next dispatch, NOT the disabled (unbounded) state.
         assert_eq!(args.deadline_setting(), DeadlineSetting::Unset);
     }
 
     /// `timeout_ms == 0` is the deadline opt-out: it records `Disabled`, a
-    /// state distinct from `Unset`. Both report `timeout_ms() == None`, but
-    /// the generated dispatch reads `deadline_setting()` to tell them apart —
-    /// `Disabled` runs the call unbounded while `Unset` falls back to the
-    /// configured `request_timeout_secs` default.
+    /// state distinct from `Unset`. The generated dispatch reads
+    /// `deadline_setting()` to tell them apart — `Disabled` runs the call
+    /// unbounded while `Unset` falls back to the configured
+    /// `request_timeout_secs` default.
     #[test]
     fn with_timeout_ms_zero_records_disabled() {
         let args = EndpointArgs::new().with_timeout_ms(0);
-        assert_eq!(args.timeout_ms(), None);
         assert_eq!(args.deadline_setting(), DeadlineSetting::Disabled);
     }
 
@@ -720,7 +701,6 @@ mod tests {
     fn set_timeout_ms_zero_records_disabled() {
         let mut args = EndpointArgs::new().with_timeout_ms(60_000);
         args.set_timeout_ms(0);
-        assert_eq!(args.timeout_ms(), None);
         assert_eq!(args.deadline_setting(), DeadlineSetting::Disabled);
     }
 
@@ -728,7 +708,6 @@ mod tests {
     #[test]
     fn with_timeout_ms_positive_value_stored() {
         let args = EndpointArgs::new().with_timeout_ms(1);
-        assert_eq!(args.timeout_ms(), Some(1));
         assert_eq!(args.deadline_setting(), DeadlineSetting::Millis(1));
     }
 

--- a/crates/thetadatadx/src/mdds/tier.rs
+++ b/crates/thetadatadx/src/mdds/tier.rs
@@ -55,30 +55,11 @@ impl SubscriptionTier {
             _ => None,
         }
     }
-
-    /// Wire-format integer for round-tripping back to the Nexus shape.
-    #[must_use]
-    pub const fn as_wire(self) -> i32 {
-        self as i32
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::SubscriptionTier;
-
-    #[test]
-    fn from_wire_round_trip() {
-        for tier in [
-            SubscriptionTier::Free,
-            SubscriptionTier::Value,
-            SubscriptionTier::Standard,
-            SubscriptionTier::Pro,
-        ] {
-            let wire = tier.as_wire();
-            assert_eq!(SubscriptionTier::from_wire(wire), Some(tier));
-        }
-    }
 
     #[test]
     fn from_wire_rejects_unknown() {
@@ -96,10 +77,16 @@ mod tests {
     }
 
     #[test]
-    fn discriminants_match_wire() {
-        assert_eq!(SubscriptionTier::Free.as_wire(), 0);
-        assert_eq!(SubscriptionTier::Value.as_wire(), 1);
-        assert_eq!(SubscriptionTier::Standard.as_wire(), 2);
-        assert_eq!(SubscriptionTier::Pro.as_wire(), 3);
+    fn from_wire_maps_known_discriminants() {
+        assert_eq!(SubscriptionTier::from_wire(0), Some(SubscriptionTier::Free));
+        assert_eq!(
+            SubscriptionTier::from_wire(1),
+            Some(SubscriptionTier::Value)
+        );
+        assert_eq!(
+            SubscriptionTier::from_wire(2),
+            Some(SubscriptionTier::Standard)
+        );
+        assert_eq!(SubscriptionTier::from_wire(3), Some(SubscriptionTier::Pro));
     }
 }

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -18,30 +18,8 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_email(
     password: *const c_char,
 ) -> *mut ThetaDataDxCredentials {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let email = match unsafe { cstr_to_str(email) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("email is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("email is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let password = match unsafe { cstr_to_str(password) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("password is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("password is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let email = require_cstr!(email, ptr::null_mut());
+        let password = require_cstr!(password, ptr::null_mut());
         let creds = thetadatadx::Credentials::new(email, password);
         Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds }))
     })
@@ -58,18 +36,7 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_api_key(
     api_key: *const c_char,
 ) -> *mut ThetaDataDxCredentials {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let api_key = match unsafe { cstr_to_str(api_key) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("api_key is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("api_key is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let api_key = require_cstr!(api_key, ptr::null_mut());
         let creds = thetadatadx::Credentials::api_key(api_key);
         Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds }))
     })
@@ -89,30 +56,8 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_api_key_with_email(
     api_key: *const c_char,
 ) -> *mut ThetaDataDxCredentials {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let email = match unsafe { cstr_to_str(email) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("email is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("email is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let api_key = match unsafe { cstr_to_str(api_key) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("api_key is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("api_key is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let email = require_cstr!(email, ptr::null_mut());
+        let api_key = require_cstr!(api_key, ptr::null_mut());
         let creds = thetadatadx::Credentials::api_key_with_email(email, api_key);
         Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds }))
     })
@@ -126,18 +71,7 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_file(
     path: *const c_char,
 ) -> *mut ThetaDataDxCredentials {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let path = match unsafe { cstr_to_str(path) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("path is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("path is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let path = require_cstr!(path, ptr::null_mut());
         match thetadatadx::Credentials::from_file(path) {
             Ok(creds) => Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds })),
             Err(e) => {
@@ -183,18 +117,7 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_env_or_file(
     path: *const c_char,
 ) -> *mut ThetaDataDxCredentials {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let path = match unsafe { cstr_to_str(path) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("path is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("path is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let path = require_cstr!(path, ptr::null_mut());
         match thetadatadx::Credentials::from_env_or_file(path) {
             Ok(creds) => Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds })),
             Err(e) => {
@@ -219,18 +142,7 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_dotenv(
     path: *const c_char,
 ) -> *mut ThetaDataDxCredentials {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let path = match unsafe { cstr_to_str(path) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("path is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("path is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let path = require_cstr!(path, ptr::null_mut());
         match thetadatadx::Credentials::from_dotenv(path) {
             Ok(creds) => Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds })),
             Err(e) => {
@@ -387,18 +299,7 @@ pub unsafe extern "C" fn thetadatadx_config_from_dotenv(
     path: *const c_char,
 ) -> *mut ThetaDataDxConfig {
     ffi_boundary!(ptr::null_mut(), {
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let path = match unsafe { cstr_to_str(path) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("path is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("path is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
-        };
+        let path = require_cstr!(path, ptr::null_mut());
         match thetadatadx::DirectConfig::from_dotenv(path) {
             Ok(config) => Box::into_raw(Box::new(ThetaDataDxConfig { inner: config })),
             Err(e) => {
@@ -1739,18 +1640,7 @@ pub unsafe extern "C" fn thetadatadx_config_set_client_type(
             set_error("config handle is null");
             return -1;
         }
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let client_type = match unsafe { cstr_to_str(client_type) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("client_type is null");
-                return -1;
-            }
-            Err(e) => {
-                set_error(&format!("client_type is not valid UTF-8: {e}"));
-                return -1;
-            }
-        };
+        let client_type = require_cstr!(client_type, -1);
         // SAFETY: config is a non-null pointer returned by
         // thetadatadx_config_production / thetadatadx_config_dev / thetadatadx_config_stage
         // and not yet freed.

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -31,11 +31,29 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicU8, Ordering as AtomicOrdering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::error::{set_error, set_error_from};
 use crate::types::{ThetaDataDxConfig, ThetaDataDxCredentials, ThetaDataDxHistoricalClient};
 use thetadatadx::DispatcherSession as FfpssDispatcherSession;
+
+/// Lock a `Mutex`, recovering the guard through poisoning rather than
+/// propagating a panic across the C ABI. A poisoned lock here means some
+/// other thread panicked while holding it; the FFI handles only own plain
+/// data (callback slots, the dispatcher state machine, drain flags), so the
+/// inner value stays usable and the consistent behaviour is to keep serving
+/// the C caller. `into_inner` returns that still-valid guard.
+trait LockRecover<T> {
+    fn lock_recover(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> LockRecover<T> for Mutex<T> {
+    #[inline]
+    fn lock_recover(&self) -> MutexGuard<'_, T> {
+        self.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
 
 // ── Callback C ABI types ──
 
@@ -609,10 +627,7 @@ pub unsafe extern "C" fn thetadatadx_client_set_callback(
         // stored registration. The dispatcher invokes the `cb` captured by
         // copy below, never reading this mutex, so holding it across
         // `start_streaming` does not deadlock the first delivered event.
-        let mut guard = handle
-            .callback
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut guard = handle.callback.lock_recover();
         // Registration is one-shot while a session is live: reject a second
         // call without disturbing the live session's stored `(callback, ctx)`.
         // Replacement is only permitted after `thetadatadx_client_stop_streaming`
@@ -938,10 +953,7 @@ pub unsafe extern "C" fn thetadatadx_client_reconnect(handle: *const ThetaDataDx
         // a prior `set_callback` — without one there is no destination
         // for the new stream's events.
         let cb = {
-            let guard = handle
-                .callback
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = handle.callback.lock_recover();
             match *guard {
                 Some(cb) => cb,
                 None => {
@@ -1693,10 +1705,7 @@ fn open_fpss<F>(
 where
     F: FnMut(&thetadatadx::fpss::StreamEvent) + Send + 'static,
 {
-    let mut guard = handle
-        .inner
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut guard = handle.inner.lock_recover();
     if guard.is_some() {
         // Belt-and-suspenders: reject_if_not_fresh should already have
         // caught this at the C ABI entry point. Keep the check so a
@@ -1721,10 +1730,7 @@ where
             // returned and the dispatcher is running.
             *guard = Some(std::sync::Arc::clone(&client_arc));
             if let Some(cb) = callback {
-                let mut cb_guard = handle
-                    .callback
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let mut cb_guard = handle.callback.lock_recover();
                 *cb_guard = Some(cb);
             }
             handle
@@ -1765,10 +1771,7 @@ where
                         client.shutdown();
                         drop(client);
                     }
-                    *handle
-                        .callback
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                    *handle.callback.lock_recover() = None;
                     set_error(&format!("failed to spawn streaming dispatcher thread: {e}"));
                     Err(())
                 }
@@ -1855,7 +1858,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_set_callback(
         // Serialise concurrent installs: `dispatcher` mutex prevents two
         // racing callers from each publishing a client into `handle.inner`
         // and orphaning one another's dispatcher.
-        let mut dispatcher_guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let mut dispatcher_guard = handle.dispatcher.lock_recover();
         if !reject_if_not_fresh(handle) {
             return -1;
         }
@@ -1912,16 +1915,13 @@ pub unsafe extern "C" fn thetadatadx_streaming_is_streaming(
         // Snapshot the one bit we need from `inner`, drop that guard, then
         // take `dispatcher` -- the two locks are never held at once here.
         let has_session = {
-            let inner_guard = handle
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let inner_guard = handle.inner.lock_recover();
             inner_guard.as_ref().is_some()
         };
         if !has_session {
             return 0;
         }
-        let session = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let session = handle.dispatcher.lock_recover();
         if let FfpssDispatcherSession::Failed { reason } = &*session {
             tracing::debug!(
                 target: "thetadatadx::ffi",
@@ -1953,10 +1953,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_is_authenticated(
         // the opposite order is the lock-order inversion that can deadlock
         // against a concurrent mutator.
         let authenticated = {
-            let inner_guard = handle
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let inner_guard = handle.inner.lock_recover();
             match inner_guard.as_ref() {
                 Some(c) => c.is_authenticated(),
                 None => return 0,
@@ -1965,7 +1962,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_is_authenticated(
         // A panicked dispatcher folds back to `!authenticated` so status
         // readers see a visible failed state instead of "authenticated with
         // no callbacks".
-        let session = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let session = handle.dispatcher.lock_recover();
         let dispatcher_failed = if let FfpssDispatcherSession::Failed { reason } = &*session {
             tracing::debug!(
                 target: "thetadatadx::ffi",
@@ -1995,10 +1992,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_active_subscriptions(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         let client = if let Some(c) = guard.as_ref() {
             c
         } else {
@@ -2036,10 +2030,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_active_full_subscriptions(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         let client = if let Some(c) = guard.as_ref() {
             c
         } else {
@@ -2079,10 +2070,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_subscribe(
         };
         // SAFETY: `handle` is a non-null `*const ThetaDataDxStreamHandle` returned by `thetadatadx_streaming_new` and not yet freed; `&*` produces a shared reference valid for the call duration.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         let client = if let Some(c) = guard.as_ref() {
             c
         } else {
@@ -2121,10 +2109,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_unsubscribe(
         };
         // SAFETY: `handle` is a non-null `*const ThetaDataDxStreamHandle` returned by `thetadatadx_streaming_new` and not yet freed; `&*` produces a shared reference valid for the call duration.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         let client = if let Some(c) = guard.as_ref() {
             c
         } else {
@@ -2187,7 +2172,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         // Serialise concurrent reconnects: `dispatcher` mutex prevents two
         // callers from each building a replacement client and racing on the
         // inner-slot publish.
-        let mut dispatcher_guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let mut dispatcher_guard = handle.dispatcher.lock_recover();
         if !reject_if_shutdown(handle) {
             return -1;
         }
@@ -2197,10 +2182,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         // make forward progress without one — `StreamingClient::connect`
         // requires an event handler at construction time.
         let cb = {
-            let guard = handle
-                .callback
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = handle.callback.lock_recover();
             match *guard {
                 Some(cb) => cb,
                 None => {
@@ -2215,10 +2197,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
 
         // 1. Save active subscriptions from the current client (if any).
         let (saved_subs, saved_full_subs) = {
-            let guard = handle
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = handle.inner.lock_recover();
             match guard.as_ref() {
                 Some(c) => (c.active_subscriptions(), c.active_full_subscriptions()),
                 None => (Vec::new(), Vec::new()),
@@ -2236,11 +2215,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         // a callback re-entering any `thetadatadx_streaming_*` API that needs
         // `handle.inner.lock()` never sees the lock held while the old
         // session tears down.
-        let taken_old = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
+        let taken_old = handle.inner.lock_recover().take();
         // Extract the old dispatcher session and RELEASE the dispatcher lock
         // before the join: the old dispatcher keeps draining ring-buffered
         // events through the user callback until it observes the shutdown, and
@@ -2253,11 +2228,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         drop(dispatcher_guard);
         let prev_drain_flag = if let Some(old) = taken_old {
             let flag = old.drained_flag();
-            handle
-                .prev_drained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(flag.clone());
+            handle.prev_drained.lock_recover().push(flag.clone());
             old.shutdown();
             drop(old);
             // Join the OLD dispatcher (lock-free) BEFORE spawning the
@@ -2314,7 +2285,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         // / `_free` could have run in the lock-free window and flipped the
         // handle terminal; re-check and bail (shutting the freshly built client)
         // rather than resurrecting a shut-down handle with a new dispatcher.
-        let mut dispatcher_guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let mut dispatcher_guard = handle.dispatcher.lock_recover();
         if handle.state.load(AtomicOrdering::Relaxed) == STREAM_STATE_SHUTDOWN {
             drop(dispatcher_guard);
             new_client.shutdown();
@@ -2338,10 +2309,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         // and never touches `handle.inner`, so the held guard does
         // NOT deadlock the dispatcher.
         let spawn_result = {
-            let mut guard = handle
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut guard = handle.inner.lock_recover();
             *guard = Some(std::sync::Arc::clone(&new_client));
 
             let dispatcher_client = std::sync::Arc::clone(&new_client);
@@ -2437,6 +2405,28 @@ fn extract_dispatcher_session(session: &mut FfpssDispatcherSession) -> FfpssDisp
     std::mem::replace(session, FfpssDispatcherSession::Idle)
 }
 
+/// Spin-poll a set of quiescence flags until every one reads `true` or the
+/// `timeout` elapses, sleeping 1 ms between polls. Returns `true` when all
+/// flags drained, `false` on timeout. `checked_add` overflow on an extreme
+/// `timeout` is treated as "effectively never" — the wait proceeds without
+/// a deadline rather than panicking. Callers own any pre-snapshot, logging,
+/// or post-drain cleanup around this barrier.
+fn await_flags(flags: &[Arc<std::sync::atomic::AtomicBool>], timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now().checked_add(timeout);
+    loop {
+        if flags
+            .iter()
+            .all(|f| f.load(std::sync::atomic::Ordering::Acquire))
+        {
+            return true;
+        }
+        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+}
+
 /// Phase 2 of teardown: join the extracted dispatcher thread with NO lock
 /// held. `handle` is taken only to RE-ACQUIRE the `dispatcher` lock on a panic
 /// join, to publish `Failed`. Defers to detach via the `prev_drained` chain
@@ -2480,11 +2470,32 @@ fn join_extracted_session(handle: &ThetaDataDxStreamHandle, session: FfpssDispat
         // now-superseded OLD session, so overwriting unconditionally would
         // clobber the new session's `JoinHandle` (orphaning its thread) and
         // falsely report a healthy live session as failed.
-        let mut guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let mut guard = handle.dispatcher.lock_recover();
         if matches!(*guard, FfpssDispatcherSession::Idle) {
             *guard = FfpssDispatcherSession::Failed { reason };
         }
     }
+}
+
+/// Tear down a live FPSS session: take the `StreamingClient` out of
+/// `handle.inner` (a different lock than `dispatcher`), record its drain
+/// flag in `prev_drained`, signal shutdown, drop it, then join the extracted
+/// dispatcher thread lock-free. Ordering the take + shutdown ahead of the
+/// join keeps a dispatcher re-entering `handle.inner` or `dispatcher` via the
+/// user callback from observing either lock held, so the join cannot
+/// deadlock. The caller must already hold no relevant lock and have flipped
+/// the handle terminal under the `dispatcher` lock before extracting
+/// `session`.
+fn retire_session(handle: &ThetaDataDxStreamHandle, session: FfpssDispatcherSession) {
+    if let Some(client) = handle.inner.lock_recover().take() {
+        handle
+            .prev_drained
+            .lock_recover()
+            .push(client.drained_flag());
+        client.shutdown();
+        drop(client);
+    }
+    join_extracted_session(handle, session);
 }
 
 /// Downcast a thread-panic payload to a human-readable string.
@@ -2516,10 +2527,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_millis_since_last_event(
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
         let value = {
-            let guard = handle
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = handle.inner.lock_recover();
             guard.as_ref().and_then(|c| c.millis_since_last_event())
         };
         match value {
@@ -2555,10 +2563,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_last_event_received_at_unix_nanos
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         guard
             .as_ref()
             .map_or(0, |c| c.last_event_received_at_unix_nanos())
@@ -2581,10 +2586,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_last_connected_addr(
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
         let addr = {
-            let guard = handle
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = handle.inner.lock_recover();
             guard.as_ref().map(|c| c.last_connected_addr())
         };
         match addr {
@@ -2616,10 +2618,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_dropped_events(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         guard.as_ref().map_or(0, |c| c.dropped_count())
     })
 }
@@ -2645,10 +2644,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_ring_occupancy(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         guard.as_ref().map_or(0, |c| c.ring_occupancy() as u64)
     })
 }
@@ -2670,10 +2666,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_ring_capacity(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         guard.as_ref().map_or(0, |c| c.ring_capacity() as u64)
     })
 }
@@ -2698,10 +2691,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_panic_count(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         guard.as_ref().map_or(0, |c| c.panic_count())
     })
 }
@@ -2728,10 +2718,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_set_slow_callback_threshold_us(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         if let Some(c) = guard.as_ref() {
             c.set_slow_callback_threshold(std::time::Duration::from_micros(threshold_us));
         }
@@ -2756,10 +2743,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_slow_callback_count(
         }
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let handle = unsafe { &*handle };
-        let guard = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = handle.inner.lock_recover();
         guard.as_ref().map_or(0, |c| c.slow_callback_count())
     })
 }
@@ -2792,7 +2776,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_shutdown(handle: *const ThetaData
         // reconnect could resurrect the handle with a new dispatcher
         // and keep firing the C callback on a handle that
         // `thetadatadx_last_error()` already reports as shut down.
-        let mut dispatcher_guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let mut dispatcher_guard = handle.dispatcher.lock_recover();
         if !reject_if_shutdown(handle) {
             // Double-shutdown -- error already set, nothing to drop.
             return;
@@ -2810,28 +2794,13 @@ pub unsafe extern "C" fn thetadatadx_streaming_shutdown(handle: *const ThetaData
             .store(STREAM_STATE_SHUTDOWN, AtomicOrdering::Relaxed);
         let session = extract_dispatcher_session(&mut dispatcher_guard);
         drop(dispatcher_guard);
-        // Take the StreamingClient Arc OUT of `handle.inner` (a different lock),
-        // then signal shutdown so a dispatcher attempting to re-enter
-        // `handle.inner` via the user callback never sees that lock held either.
-        let taken_client = handle
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        if let Some(client) = taken_client {
-            handle
-                .prev_drained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(client.drained_flag());
-            client.shutdown();
-            drop(client);
-        }
-        // Join the dispatcher with NO lock held, AFTER the producer-drop signal
-        // has propagated through the ring shutdown to the iterator, so the
-        // `for ... in &client` loop returns `Ok(None)` and the thread exits
-        // cleanly while any re-entrant status read proceeds lock-free.
-        join_extracted_session(handle, session);
+        // Take the client out of `handle.inner`, push its drain flag, signal
+        // shutdown, drop, then join lock-free — see `retire_session`. The join
+        // runs AFTER the producer-drop signal has propagated through the ring
+        // shutdown to the iterator, so the `for ... in &client` loop returns
+        // `Ok(None)` and the thread exits cleanly while any re-entrant status
+        // read proceeds lock-free.
+        retire_session(handle, session);
     })
 }
 
@@ -2875,44 +2844,21 @@ pub unsafe extern "C" fn thetadatadx_streaming_await_drain(
         // outstanding when I started", which mirrors the in-process
         // `Client::await_drain` contract.
         let initial = {
-            let guard = handle
-                .prev_drained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = handle.prev_drained.lock_recover();
             if guard.is_empty() {
                 return 0;
             }
             guard.clone()
         };
-        // `checked_add` returns `None` on an extreme `timeout_ms` (near
-        // `u64::MAX`), which we treat as "effectively never": the wait
-        // proceeds without a deadline rather than panicking on overflow.
-        let timeout = std::time::Duration::from_millis(timeout_ms);
-        let deadline = std::time::Instant::now().checked_add(timeout);
-        loop {
-            // All flags drained?
-            if initial
-                .iter()
-                .all(|f| f.load(std::sync::atomic::Ordering::Acquire))
-            {
-                // Lazy GC of the shared Vec so a long-lived handle that
-                // cycles through many sessions does not accumulate
-                // entries. Take the lock briefly; this is a clean-up
-                // path, never on the hot tick path.
-                let mut guard = handle
-                    .prev_drained
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                guard.retain(|f| !f.load(std::sync::atomic::Ordering::Acquire));
-                return 1;
-            }
-            // A `None` deadline (overflow on an extreme timeout) never fires,
-            // matching the "effectively never" contract.
-            if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
-                return 0;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(1));
+        if !await_flags(&initial, std::time::Duration::from_millis(timeout_ms)) {
+            return 0;
         }
+        // Lazy GC of the shared Vec so a long-lived handle that cycles through
+        // many sessions does not accumulate entries. Take the lock briefly;
+        // this is a clean-up path, never on the hot tick path.
+        let mut guard = handle.prev_drained.lock_recover();
+        guard.retain(|f| !f.load(std::sync::atomic::Ordering::Acquire));
+        1
     })
 }
 
@@ -2980,7 +2926,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_free(handle: *mut ThetaDataDxStre
             // for the lock-free join, so a concurrent install that later
             // acquires the lock observes SHUTDOWN and bails out before touching
             // freed memory. The drain wait further down runs lock-free.
-            let mut disp_guard = h.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+            let mut disp_guard = h.dispatcher.lock_recover();
             if h.state.load(AtomicOrdering::Relaxed) != STREAM_STATE_SHUTDOWN {
                 // Flip terminal + extract the session under the lock, then
                 // RELEASE the lock before the join: a dispatcher draining
@@ -2992,20 +2938,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_free(handle: *mut ThetaDataDxStre
                     .store(STREAM_STATE_SHUTDOWN, AtomicOrdering::Relaxed);
                 let session = extract_dispatcher_session(&mut disp_guard);
                 drop(disp_guard);
-                let taken_client = h
-                    .inner
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .take();
-                if let Some(client) = taken_client {
-                    h.prev_drained
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .push(client.drained_flag());
-                    client.shutdown();
-                    drop(client);
-                }
-                join_extracted_session(h, session);
+                retire_session(h, session);
             }
 
             // Wait for every superseded session's consumer thread to
@@ -3015,26 +2948,11 @@ pub unsafe extern "C" fn thetadatadx_streaming_free(handle: *mut ThetaDataDxStre
             // path.
             const FREE_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
             let pending: Vec<Arc<std::sync::atomic::AtomicBool>> = {
-                let guard = h
-                    .prev_drained
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let guard = h.prev_drained.lock_recover();
                 guard.clone()
             };
             if !pending.is_empty() {
-                let deadline = std::time::Instant::now() + FREE_DRAIN_TIMEOUT;
-                let drained = loop {
-                    if pending
-                        .iter()
-                        .all(|f| f.load(std::sync::atomic::Ordering::Acquire))
-                    {
-                        break true;
-                    }
-                    if std::time::Instant::now() >= deadline {
-                        break false;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(1));
-                };
+                let drained = await_flags(&pending, FREE_DRAIN_TIMEOUT);
                 if !drained {
                     tracing::error!(
                         target: "thetadatadx::ffi",
@@ -3354,7 +3272,7 @@ mod teardown_deadlock_tests {
 
     use super::{
         extract_dispatcher_session, join_extracted_session, FfiCallback, FfpssDispatcherSession,
-        StreamingConnectParams, ThetaDataDxStreamCallback, ThetaDataDxStreamEvent,
+        LockRecover, StreamingConnectParams, ThetaDataDxStreamCallback, ThetaDataDxStreamEvent,
         ThetaDataDxStreamHandle, STREAM_STATE_ACTIVE,
     };
     use std::ffi::c_void;
@@ -3410,7 +3328,7 @@ mod teardown_deadlock_tests {
                     // Re-enter the dispatcher lock, as a status reader called
                     // from the user callback would. Blocks until the worker
                     // releases the guard.
-                    let guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                    let guard = handle.dispatcher.lock_recover();
                     // With the fix the worker drops the guard before joining, so
                     // we get in only after `released` is set. With the old
                     // join-under-lock code the worker never releases before the
@@ -3427,7 +3345,7 @@ mod teardown_deadlock_tests {
 
         // Install the running session carrying the stand-in thread's handle.
         {
-            let mut guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+            let mut guard = handle.dispatcher.lock_recover();
             *guard = FfpssDispatcherSession::Running {
                 handle: dispatcher_handle,
                 on_teardown: None,
@@ -3444,7 +3362,7 @@ mod teardown_deadlock_tests {
             let attempt_gate = Arc::clone(&attempt_gate);
             std::thread::spawn(move || {
                 // Phase 1: acquire the guard and extract the session.
-                let mut guard = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                let mut guard = handle.dispatcher.lock_recover();
                 let session = extract_dispatcher_session(&mut guard);
                 // While STILL holding the guard, release the stand-in to attempt
                 // the lock. It now blocks on a lock we hold — the precise


### PR DESCRIPTION
Mechanical dedup of leftover duplication the deep audit flagged in the Rust core and FFI layer. Each cut is behavior-preserving and build-verified; nothing changes any C-ABI signature.

**dedup credentials/config cstr decode** (`ffi/src/auth.rs`, −110): ten verbatim ~11-line `match cstr_to_str(x)` null/UTF-8 blocks across the `thetadatadx_credentials_*` / `thetadatadx_config_*` wrappers now call the existing `require_cstr!` macro. The macro emits byte-identical `"<arg> is null"` / `"<arg> is not valid UTF-8: <e>"` messages and the same SAFETY note. The two sites whose error text intentionally differs from the parameter name (`url` → `nexus_url`, `host` → `historical_host`) keep their inline blocks so messages stay stable.

**lock-recovery extension method** (`ffi/src/streaming.rs`, part of −82): a one-method `LockRecover` trait collapses 43 copies of `.lock().unwrap_or_else(PoisonError::into_inner)` (rustfmt split most across four lines) to a single `.lock_recover()` per site, including the `Arc<Mutex<_>>` `inner` field via auto-deref.

**drain-barrier + teardown helpers** (`ffi/src/streaming.rs`, rest of −82): the two slice-based quiescence spin-waits fold into one `await_flags(flags, timeout) -> bool` (preserving the `checked_add` "effectively never" overflow contract); the two terminal teardown sequences fold into one `retire_session(handle, session)`. The reconnect site of each is left inline — it returns the drain flag and branches differently, so a shared helper would not preserve behavior.

**drop dead accessors** (`crates/thetadatadx/src/mdds/tier.rs` −13, `crates/thetadatadx/src/mdds/endpoint_args.rs` −21): `SubscriptionTier::as_wire` and `EndpointArgs::timeout_ms` had zero non-test callers (the live `from_wire` / `deadline_setting` cover their roles). Removed both plus their round-trip-only assertions; positive `from_wire` coverage and the deadline tri-state tests are retained.

`ChannelPool::is_empty` was left in place: it has zero call sites but exists as the `clippy::len_without_is_empty` companion to the `__test-helpers`-gated `len()`, so removing it breaks `clippy --features __test-helpers -D warnings`.

Net −226 lines. Gates green: `cargo check -p thetadatadx` (default / `__test-helpers` / `arrow,polars,frames,config-file`), FFI cdylib build, `clippy --workspace --all-targets --locked -D warnings`, `cargo doc --no-deps --workspace`, `cargo fmt --check`, `cargo test -p thetadatadx --lib` (1071) + `-p thetadatadx-ffi --lib` (91), `check_docs_consistency.py`, `generate_sdk_surfaces --check`, `generate_docs_site --check`, C-ABI completeness (342 symbols, bidirectional parity), SAFETY-comment boilerplate. No new `#[allow]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)