### PR TITLE
refactor: codegen config enum + option accessors

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/config_accessors.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/config_accessors.rs
@@ -69,6 +69,34 @@ struct Accessor {
     /// (e.g. `historical_host`) instead of a direct `path` read.
     #[serde(default)]
     getter_call: Option<String>,
+    /// `enum` only: the FFI-side enum type (`thetadatadx::`-prefixed,
+    /// e.g. `thetadatadx::StreamingFlushMode`) the int code maps to / from.
+    #[serde(default)]
+    enum_type: Option<String>,
+    /// `enum` only: the binding-side enum type (`config::`-prefixed) whose
+    /// `parse` / `as_str` the Python / TypeScript string surfaces use.
+    #[serde(default)]
+    enum_core: Option<String>,
+    /// `enum` setter only: the trailing `expected …` clause of the
+    /// `INVALID_PARAMETER` rejection message (the int-domain list spelled
+    /// with its enum-specific oxford-comma grammar).
+    #[serde(default)]
+    enum_expected: Option<String>,
+    /// `enum` / `option` setter only: the Python `ValueError` body for a
+    /// rejected value, verbatim (the per-accessor prose stays byte-stable
+    /// across bindings). `{…}` placeholders interpolate the setter param /
+    /// the matched value.
+    #[serde(default)]
+    py_err: Option<String>,
+    /// `enum` / `option` setter only: the TypeScript `invalid_parameter_err`
+    /// body for a rejected value, verbatim.
+    #[serde(default)]
+    ts_err: Option<String>,
+    /// `enum` only: the int ↔ variant ↔ lowercase-label bijection. Drives
+    /// the FFI `match` both ways and the variant arms the C++ doc and the
+    /// Python / TypeScript surfaces reference.
+    #[serde(default)]
+    variant: Vec<EnumVariant>,
     doc: String,
     cpp_doc: String,
     /// Verbatim PyO3 `#[setter]`/`#[getter]` doc block (no `///` prefix).
@@ -83,6 +111,15 @@ struct Accessor {
     /// `py_param`, but a few `*_secs` knobs spell it `ms` for back-compat.
     #[serde(default)]
     ts_param: Option<String>,
+}
+
+/// One `int` code of an `enum` accessor and its core-variant identifier.
+#[derive(Debug, Deserialize)]
+struct EnumVariant {
+    /// The wire/ABI integer code.
+    int: i32,
+    /// The variant identifier without the enum path (e.g. `Batched`).
+    rust: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -128,23 +165,97 @@ fn cpp_doc(buf: &mut String, indent: &str, text: &str) {
 /// no-ops there too).
 const LIMIT_DEFAULT: &str = "thetadatadx::ReconnectAttemptLimits::default()";
 
+/// The `ReconnectAttemptLimits` field a `policy_limit` accessor touches.
+fn limit_field(a: &Accessor) -> &str {
+    a.limit_field
+        .as_deref()
+        .expect("policy_limit needs limit_field")
+}
+
+/// `true` when this row is a setter (its symbol carries the `set_`
+/// prefix). The scalar / string carve-outs key off `kind == "set"`, but
+/// the `enum` / `option` kinds use one `kind` value for both directions,
+/// so they branch on the symbol instead.
+fn is_setter(a: &Accessor) -> bool {
+    a.symbol.contains("_config_set_")
+}
+
+/// The `policy_limit` getter read: a two-arm `match` on
+/// `<receiver>.reconnect.policy` reading `limits.<field><suffix>`, with
+/// the `Auto`-defaults fallback. `receiver` is the binding's config
+/// expression (`config.inner` / `guard`) and `limits_default` its
+/// `ReconnectAttemptLimits::default()` spelling.
+fn policy_get_match(
+    receiver: &str,
+    policy_ty: &str,
+    limits_default: &str,
+    field: &str,
+    suffix: &str,
+) -> String {
+    format!(
+        "match &{receiver}.reconnect.policy {{\n            {policy_ty}::Auto(limits) => limits.{field}{suffix},\n            _ => {limits_default}.{field}{suffix},\n        }}"
+    )
+}
+
+/// The `enum` setter int→variant decode `match` (with the typed-error
+/// `_` arm), emitted into the FFI setter body. `set_error_with_code`
+/// keeps the rejected-int path on `INVALID_PARAMETER` across every
+/// binding.
+fn ffi_enum_set_match(a: &Accessor) -> String {
+    let ty = a.enum_type.as_deref().expect("enum needs enum_type");
+    let mut arms = String::new();
+    for v in &a.variant {
+        writeln!(arms, "            {} => {ty}::{},", v.int, v.rust).unwrap();
+    }
+    let expected = a
+        .enum_expected
+        .as_deref()
+        .expect("enum setter needs enum_expected");
+    format!(
+        "let value = match {p} {{\n{arms}            other => {{\n                crate::error::set_error_with_code(\n                    &format!(\n                        \"{sym}: invalid {p} {{other}}; {expected}\"\n                    ),\n                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,\n                );\n                return -1;\n            }}\n        }};",
+        p = a.param, sym = a.symbol,
+    )
+}
+
+/// The `enum` getter variant→int decode `match`, emitted into the FFI
+/// getter body. The final arm folds to `_ => <last int>` so a
+/// `#[non_exhaustive]` core enum stays covered without an extra arm.
+fn ffi_enum_get_match(a: &Accessor) -> String {
+    let ty = a.enum_type.as_deref().expect("enum needs enum_type");
+    let mut arms = String::new();
+    let last = a.variant.len() - 1;
+    for (i, v) in a.variant.iter().enumerate() {
+        if i == last {
+            writeln!(arms, "            _ => {},", v.int).unwrap();
+        } else {
+            writeln!(arms, "            {ty}::{} => {},", v.rust, v.int).unwrap();
+        }
+    }
+    format!(
+        "let value = match {recv}.{path} {{\n{arms}        }};",
+        recv = "config.inner",
+        path = a.path,
+    )
+}
+
 /// The Rust read expression for one getter (the value written into the
 /// out-parameter), keyed by KIND. Scalar / duration reads come straight
 /// off `config.inner.<path>`; the `policy_limit` read walks
 /// `reconnect.policy` and falls back to the `Auto` defaults.
 fn ffi_get_read_expr(a: &Accessor) -> String {
     if a.shape.as_deref() == Some("policy_limit") {
-        let field = a
-            .limit_field
-            .as_deref()
-            .expect("policy_limit needs limit_field");
+        let field = limit_field(a);
         let suffix = if a.duration_unit.as_deref() == Some("secs") {
             ".as_secs()"
         } else {
             ""
         };
-        return format!(
-            "match &config.inner.reconnect.policy {{\n            thetadatadx::ReconnectPolicy::Auto(limits) => limits.{field}{suffix},\n            _ => {LIMIT_DEFAULT}.{field}{suffix},\n        }}"
+        return policy_get_match(
+            "config.inner",
+            "thetadatadx::ReconnectPolicy",
+            LIMIT_DEFAULT,
+            field,
+            suffix,
         );
     }
     match a.duration_unit.as_deref() {
@@ -170,6 +281,46 @@ pub(super) fn render_ffi_config_accessors() -> Result<String, Box<dyn std::error
         rust_doc(&mut out, &a.doc);
         out.push_str("#[no_mangle]\n");
         match (a.shape.as_deref(), a.kind.as_str()) {
+            (_, "enum") if is_setter(a) => {
+                // `i32` code → core variant. A null handle carries
+                // `ERR_CONFIG`; a rejected int carries
+                // `ERR_INVALID_PARAMETER` (unified across all four enums).
+                write!(
+                    out,
+                    "pub unsafe extern \"C\" fn {sym}(\n    config: *mut ThetaDataDxConfig,\n    {p}: {ty},\n) -> i32 {{\n    ffi_boundary!(-1, {{\n        if config.is_null() {{\n            crate::error::set_error_with_code(\n                \"{sym}: config handle is null\",\n                crate::error::THETADATADX_ERR_CONFIG,\n            );\n            return -1;\n        }}\n        {decode}\n        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.\n        let config = unsafe {{ &mut *config }};\n        config.inner.{path} = value;\n        0\n    }})\n}}\n\n",
+                    sym = a.symbol, p = a.param, ty = a.abi_type,
+                    decode = ffi_enum_set_match(a), path = a.path,
+                )?;
+            }
+            (_, "enum") => {
+                // Core variant → `i32` code. Dual null-check, then the
+                // variant `match` folded onto the canonical out-write.
+                write!(
+                    out,
+                    "pub unsafe extern \"C\" fn {sym}(\n    config: *const ThetaDataDxConfig,\n    {p}: *mut {ty},\n) -> i32 {{\n    ffi_boundary!(-1, {{\n        if config.is_null() || {p}.is_null() {{\n            set_error(\"config or out-parameter pointer is null\");\n            return -1;\n        }}\n{cfg}\n        let config = unsafe {{ &*config }};\n        {decode}\n{outs}\n        unsafe {{\n            *{p} = value;\n        }}\n        0\n    }})\n}}\n\n",
+                    sym = a.symbol, p = a.param, ty = a.abi_type,
+                    cfg = CFG_SAFETY, decode = ffi_enum_get_match(a), outs = OUT_SAFETY,
+                )?;
+            }
+            (_, "option") if is_setter(a) => {
+                // `(has_value, value)` widened ABI → `Option<T>`; the
+                // `None` sentinel survives the C boundary.
+                write!(
+                    out,
+                    "pub unsafe extern \"C\" fn {sym}(\n    config: *mut ThetaDataDxConfig,\n    has_value: bool,\n    {p}: {ty},\n) -> i32 {{\n    ffi_boundary!(-1, {{\n        if config.is_null() {{\n            set_error(\"config handle is null\");\n            return -1;\n        }}\n        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.\n        let config = unsafe {{ &mut *config }};\n        config.inner.{path} = if has_value {{ Some({p}) }} else {{ None }};\n        0\n    }})\n}}\n\n",
+                    sym = a.symbol, p = a.param, ty = a.abi_type, path = a.path,
+                )?;
+            }
+            (_, "option") => {
+                // `Option<T>` → `(has_value, value)`; `None` writes
+                // `(false, 0)`.
+                write!(
+                    out,
+                    "pub unsafe extern \"C\" fn {sym}(\n    config: *const ThetaDataDxConfig,\n    out_has_value: *mut bool,\n    {p}: *mut {ty},\n) -> i32 {{\n    ffi_boundary!(-1, {{\n        if config.is_null() || out_has_value.is_null() || {p}.is_null() {{\n            set_error(\"config or out-parameter pointer is null\");\n            return -1;\n        }}\n{cfg}\n        let config = unsafe {{ &*config }};\n        let (has_value, value) = match config.inner.{path} {{\n            Some(v) => (true, v),\n            None => (false, 0),\n        }};\n        // SAFETY: out_has_value / {p} null-checked above; caller pins the storage they point at for the call duration.\n        unsafe {{\n            *out_has_value = has_value;\n            *{p} = value;\n        }}\n        0\n    }})\n}}\n\n",
+                    sym = a.symbol, p = a.param, ty = a.abi_type, path = a.path,
+                    cfg = CFG_SAFETY,
+                )?;
+            }
             (Some("string"), "set") => {
                 // `*const c_char` → validated UTF-8 → `String`. `path`
                 // assigns the field directly; `setter_call` routes the
@@ -209,10 +360,7 @@ pub(super) fn render_ffi_config_accessors() -> Result<String, Box<dyn std::error
                     _ => a.param.clone(),
                 };
                 let body = if a.shape.as_deref() == Some("policy_limit") {
-                    let field = a
-                        .limit_field
-                        .as_deref()
-                        .expect("policy_limit needs limit_field");
+                    let field = limit_field(a);
                     format!(
                         "        let config = require_config_mut!(config);\n        if let thetadatadx::ReconnectPolicy::Auto(ref mut limits) = config.inner.reconnect.policy {{\n            limits.{field} = {rhs};\n        }}"
                     )
@@ -286,6 +434,46 @@ pub(super) fn render_cpp_config_accessors() -> Result<String, Box<dyn std::error
         out.push('\n');
         cpp_doc(&mut out, "    ", &a.cpp_doc);
         match (a.shape.as_deref(), a.kind.as_str()) {
+            (_, "enum") if is_setter(a) => {
+                // Int passthrough; the FFI rejects an out-of-domain code
+                // or null handle with a nonzero code routed through the
+                // typed error leaf.
+                write!(
+                    out,
+                    "    void {method}(int {p}) {{\n        if ({sym}(handle_.get(), {p}) != 0) {{\n            detail::throw_last_ffi_error();\n        }}\n    }}\n",
+                    method = method, p = a.param, sym = a.symbol,
+                )?;
+            }
+            (_, "enum") => {
+                // Int passthrough getter; the FFI writes the default code
+                // on a null handle.
+                write!(
+                    out,
+                    "    int {method}() const {{\n        int32_t out{{}};\n        {sym}(handle_.get(), &out);\n        return out;\n    }}\n",
+                    method = method, sym = a.symbol,
+                )?;
+            }
+            (_, "option") if is_setter(a) => {
+                // `std::optional<T>` → `(has_value, value)`; the FFI
+                // rejects a null handle through the typed error leaf.
+                let ty = cpp_type(&a.abi_type);
+                write!(
+                    out,
+                    "    void {method}(std::optional<{ty}> {p}) {{\n        const bool has_value = {p}.has_value();\n        const {ty} arg = {p}.value_or(0);\n        if ({sym}(handle_.get(), has_value, arg) != 0) {{\n            detail::throw_last_ffi_error();\n        }}\n    }}\n",
+                    method = method, ty = ty, p = a.param, sym = a.symbol,
+                )?;
+            }
+            (_, "option") => {
+                // `(has_value, value)` → `std::optional<T>`; `std::nullopt`
+                // for the `None` sentinel.
+                let ty = cpp_type(&a.abi_type);
+                let val = a.param.strip_prefix("out_").unwrap_or(&a.param);
+                write!(
+                    out,
+                    "    std::optional<{ty}> {method}() const {{\n        bool has_value = false;\n        {ty} {val} = 0;\n        if ({sym}(handle_.get(), &has_value, &{val}) != 0) {{\n            detail::throw_last_ffi_error();\n        }}\n        return has_value ? std::optional<{ty}>{{{val}}} : std::nullopt;\n    }}\n",
+                    method = method, ty = ty, val = val, sym = a.symbol,
+                )?;
+            }
             (Some("string"), "set") => {
                 // `std::string` → `const char*`; the FFI rejects a null
                 // handle or non-UTF-8 with a nonzero code routed through
@@ -340,6 +528,13 @@ fn field_name(a: &Accessor) -> &str {
         .expect("config symbol must carry the canonical set_/get_ prefix")
 }
 
+/// Embed a raw error message (carrying literal `"`) inside a Rust
+/// `format!("…")` literal: escape the double quotes; the `{…}` braces
+/// stay verbatim as format placeholders.
+fn rust_lit(raw: &str) -> String {
+    raw.replace('"', "\\\"")
+}
+
 /// The Rust scalar type each abi maps to on the PyO3 surface.
 fn py_type(abi: &str) -> &'static str {
     match abi {
@@ -381,6 +576,59 @@ pub(super) fn render_python_config_accessors() -> Result<String, Box<dyn std::er
         let field = field_name(a);
         indented_doc(&mut out, "    ", &a.py_doc);
         match (a.shape.as_deref(), a.kind.as_str()) {
+            (_, "enum") if is_setter(a) => {
+                // Lowercase string → core variant via `parse`; the same
+                // path for every enum (no inline per-enum match).
+                let param = a.py_param.as_deref().expect("setter row needs py_param");
+                let core = a.enum_core.as_deref().expect("enum needs enum_core");
+                let err = rust_lit(a.py_err.as_deref().expect("enum setter needs py_err"));
+                write!(
+                    out,
+                    "    #[setter]\n    fn set_{field}(&self, {param}: &str) -> PyResult<()> {{\n        let parsed = {core}::parse({param}).ok_or_else(|| {{\n            PyValueError::new_err(format!(\n                \"{err}\"\n            ))\n        }})?;\n{LOCK}\n        guard.{path} = parsed;\n        Ok(())\n    }}\n\n",
+                    field = field, param = param, core = core, err = err, path = a.path,
+                )?;
+            }
+            (_, "enum") => {
+                // Core variant → lowercase string via `as_str` (uniform).
+                write!(
+                    out,
+                    "    #[getter]\n    fn get_{field}(&self) -> &'static str {{\n{RLOCK}\n        guard.{path}.as_str()\n    }}\n\n",
+                    field = field, path = a.path,
+                )?;
+            }
+            (_, "option") if is_setter(a) => {
+                let param = a.py_param.as_deref().expect("setter row needs py_param");
+                match a.abi_type.as_str() {
+                    // u16 fields narrow from a Python `int`; a value outside
+                    // `0..=65535` raises `ValueError`.
+                    "u16" => {
+                        let err =
+                            rust_lit(a.py_err.as_deref().expect("option u16 setter needs py_err"));
+                        write!(
+                            out,
+                            "    #[setter]\n    fn set_{field}(&self, {param}: Option<u32>) -> PyResult<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(u16::try_from(v).map_err(|_| {{\n                PyValueError::new_err(format!(\"{err}\"))\n            }})?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
+                            field = field, param = param, err = err, path = a.path,
+                        )?;
+                    }
+                    // Wider fields take the matching `Option<T>` verbatim.
+                    other => {
+                        let ty = py_type(other);
+                        write!(
+                            out,
+                            "    #[setter]\n    fn set_{field}(&self, {param}: Option<{ty}>) {{\n{LOCK}\n        guard.{path} = {param};\n    }}\n\n",
+                            field = field, param = param, ty = ty, path = a.path,
+                        )?;
+                    }
+                }
+            }
+            (_, "option") => {
+                let ty = py_type(&a.abi_type);
+                write!(
+                    out,
+                    "    #[getter]\n    fn get_{field}(&self) -> Option<{ty}> {{\n{RLOCK}\n        guard.{path}\n    }}\n\n",
+                    field = field, ty = ty, path = a.path,
+                )?;
+            }
             (Some("string"), "set") => {
                 // `String` field assignment; `setter_call` routes the
                 // value through a `&mut self` method instead.
@@ -500,6 +748,78 @@ pub(super) fn render_typescript_config_accessors() -> Result<String, Box<dyn std
     for a in &accessors {
         let field = field_name(a);
         indented_doc(&mut out, "    ", &a.ts_doc);
+        // ── enum carve-out (lowercase string ↔ core variant via the
+        //    core enum `parse` / `as_str`; uniform across every enum) ──
+        if a.kind == "enum" {
+            if is_setter(a) {
+                let param = a.ts_param.as_deref().expect("setter row needs ts_param");
+                let set_js = format!("set{}", to_pascal_case(field));
+                let core = a.enum_core.as_deref().expect("enum needs enum_core");
+                let err = rust_lit(a.ts_err.as_deref().expect("enum setter needs ts_err"));
+                write!(
+                    out,
+                    "    #[napi(js_name = \"{set_js}\")]\n    pub fn set_{field}(&self, {param}: String) -> napi::Result<()> {{\n        let parsed = {core}::parse(&{param}).ok_or_else(|| {{\n            crate::invalid_parameter_err(format!(\n                \"{err}\"\n            ))\n        }})?;\n{LOCK}\n        guard.{path} = parsed;\n        Ok(())\n    }}\n\n",
+                    set_js = set_js, field = field, param = param, core = core, err = err, path = a.path,
+                )?;
+            } else {
+                let get_js = to_camel_case(field);
+                write!(
+                    out,
+                    "    #[napi(getter, js_name = \"{get_js}\")]\n    pub fn {field}(&self) -> napi::Result<&'static str> {{\n{RLOCK}\n        Ok(guard.{path}.as_str())\n    }}\n\n",
+                    get_js = get_js, field = field, path = a.path,
+                )?;
+            }
+            continue;
+        }
+        // ── option carve-out (`Option<T>` ↔ `T | null`; the abi switch
+        //    picks `number` vs `BigInt`, the same the scalar arm runs) ──
+        if a.kind == "option" {
+            if is_setter(a) {
+                let param = a.ts_param.as_deref().expect("setter row needs ts_param");
+                let set_js = format!("set{}", to_pascal_case(field));
+                match a.abi_type.as_str() {
+                    // u16 ports arrive as `number`; range-checked to u16.
+                    "u16" => {
+                        let err =
+                            rust_lit(a.ts_err.as_deref().expect("option u16 setter needs ts_err"));
+                        write!(
+                            out,
+                            "    #[napi(js_name = \"{set_js}\")]\n    pub fn set_{field}(&self, {param}: Option<u32>) -> napi::Result<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(u16::try_from(v).map_err(|_| {{\n                crate::invalid_parameter_err(format!(\n                    \"{err}\"\n                ))\n            }})?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
+                            set_js = set_js, field = field, param = param, err = err, path = a.path,
+                        )?;
+                    }
+                    // Wider seeds arrive as `BigInt`; decoded losslessly.
+                    "u64" => {
+                        write!(
+                            out,
+                            "    #[napi(js_name = \"{set_js}\")]\n    pub fn set_{field}(\n        &self,\n        {param}: Option<napi::bindgen_prelude::BigInt>,\n    ) -> napi::Result<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(bigint_to_u64(\"{set_js}\", &v)?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
+                            set_js = set_js, field = field, param = param, path = a.path,
+                        )?;
+                    }
+                    other => panic!("config_surface: option abi '{other}'"),
+                }
+            } else {
+                let get_js = to_camel_case(field);
+                match a.abi_type.as_str() {
+                    "u16" => {
+                        write!(
+                            out,
+                            "    #[napi(getter, js_name = \"{get_js}\")]\n    pub fn {field}(&self) -> napi::Result<Option<u32>> {{\n{RLOCK}\n        Ok(guard.{path}.map(u32::from))\n    }}\n\n",
+                            get_js = get_js, field = field, path = a.path,
+                        )?;
+                    }
+                    "u64" => {
+                        write!(
+                            out,
+                            "    #[napi(getter, js_name = \"{get_js}\")]\n    pub fn {field}(\n        &self,\n    ) -> napi::Result<Option<napi::bindgen_prelude::BigInt>> {{\n{RLOCK}\n        Ok(guard.{path}.map(napi::bindgen_prelude::BigInt::from))\n    }}\n\n",
+                            get_js = get_js, field = field, path = a.path,
+                        )?;
+                    }
+                    other => panic!("config_surface: option abi '{other}'"),
+                }
+            }
+            continue;
+        }
         // ── string carve-out (parity with the FFI `*const c_char`
         //    surface; the JS surface takes / returns a plain `string`) ──
         if a.shape.as_deref() == Some("string") {

--- a/crates/thetadatadx/config_surface.toml
+++ b/crates/thetadatadx/config_surface.toml
@@ -2061,3 +2061,575 @@ Current historical gRPC host.
 ts_doc = """
 Current historical gRPC host.
 """
+
+# ── Enum config fields (enum) ───────────────────────────────────────
+#
+# Plain string<->variant bijection enums. One [[accessor.variant]] table
+# per int code carries the FFI int <-> core-variant mapping and the
+# lowercase cross-binding label. The FFI surface speaks `i32` codes
+# (set: `match int { N => Variant, _ => typed error }`; get: `match
+# variant { Variant => N }`); C++ passes the int through; Python / TS
+# speak the lowercase string via the core enum `parse` / `as_str`. The
+# null-handle path is uniform across all four (`set_error_with_code`
+# with `THETADATADX_ERR_CONFIG`); a rejected int carries
+# `THETADATADX_ERR_INVALID_PARAMETER`.
+
+[[accessor]]
+symbol = "thetadatadx_config_set_flush_mode"
+kind = "enum"
+param = "mode"
+abi_type = "i32"
+path = "streaming.flush_mode"
+enum_type = "thetadatadx::StreamingFlushMode"
+enum_core = "config::StreamingFlushMode"
+enum_expected = "expected 0 (Batched) or 1 (Immediate)"
+py_err = 'flush_mode must be "batched" or "immediate"; got {mode:?}'
+ts_err = 'setFlushMode: mode must be "batched" or "immediate"; got {mode:?}'
+doc = """
+Set streaming flush mode on a config handle.
+
+- `mode = 0`: Batched (default) -- flush only on PING every 100ms
+- `mode = 1`: Immediate -- flush after every frame write (lowest latency)
+
+Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
+`mode` is outside the documented `{0, 1}` set or when `config` is
+null. A rejected `mode` value carries
+`thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` (the same typed
+class the Python / TypeScript bindings raise for a bad enum value);
+a null `config` carries `THETADATADX_ERR_CONFIG`.
+"""
+cpp_doc = """
+Set streaming flush mode. 0=Batched (default), 1=Immediate. Throws
+@c thetadatadx::InvalidParameterError when @p mode is outside the
+documented `{0, 1}` set (and @c thetadatadx::ThetaDataError on a null
+handle), routing through the typed leaf the FFI error code
+selects.
+"""
+py_doc = """
+Set the streaming write-flush policy.
+
+Accepts ``"batched"`` (default, flushes on the PING heartbeat,
+roughly every 100 ms — best throughput) or ``"immediate"``
+(flushes after every wire write — lowest latency, higher
+per-frame syscall cost).
+"""
+ts_doc = """
+Set the streaming write-flush policy.
+
+Accepts `"batched"` (default — flushes on the PING heartbeat,
+roughly every 100 ms — best throughput) or `"immediate"`
+(flushes after every wire write — lowest latency, higher
+per-frame syscall cost).
+"""
+py_param = "mode"
+ts_param = "mode"
+[[accessor.variant]]
+int = 0
+rust = "Batched"
+label = "batched"
+[[accessor.variant]]
+int = 1
+rust = "Immediate"
+label = "immediate"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_flush_mode"
+kind = "enum"
+param = "out_mode"
+abi_type = "i32"
+path = "streaming.flush_mode"
+enum_type = "thetadatadx::StreamingFlushMode"
+enum_core = "config::StreamingFlushMode"
+doc = """
+Read the configured streaming flush mode. Same encoding as
+`thetadatadx_config_set_flush_mode`: writes `0` (`Batched`) or `1`
+(`Immediate`) into `*out_mode`. Returns `0` on success, `-1` if
+either pointer is null.
+"""
+cpp_doc = """
+Read the current streaming flush mode. Same encoding as
+@c set_flush_mode: `0` = Batched, `1` = Immediate. Returns `0`
+(Batched) on a null handle (matching the C ABI's `-1` failure
+mapping at the boundary).
+"""
+py_doc = """
+Current streaming write-flush policy (``"batched"`` or
+``"immediate"``).
+"""
+ts_doc = """
+Current streaming write-flush policy (`"batched"` or
+`"immediate"`).
+"""
+[[accessor.variant]]
+int = 0
+rust = "Batched"
+label = "batched"
+[[accessor.variant]]
+int = 1
+rust = "Immediate"
+label = "immediate"
+
+[[accessor]]
+symbol = "thetadatadx_config_set_wait_strategy"
+kind = "enum"
+param = "mode"
+abi_type = "i32"
+path = "streaming.wait_strategy"
+enum_type = "thetadatadx::StreamingWaitStrategy"
+enum_core = "config::StreamingWaitStrategy"
+enum_expected = "expected 0 (LowLatency), 1 (Balanced), 2 (Efficient), or 3 (BusySpin)"
+py_err = 'wait_strategy must be "low_latency", "balanced", "efficient", or "busy_spin"; got {strategy:?}'
+ts_err = 'setWaitStrategy: strategy must be "low_latency", "balanced", "efficient", or "busy_spin"; got {strategy:?}'
+doc = """
+Set the streaming event-ring consumer wait strategy on a config
+handle.
+
+- `mode = 0`: LowLatency (default) — spin, yield, then a `spin_loop`
+  hint; never sleeps. Lowest latency, highest idle CPU.
+- `mode = 1`: Balanced — short spin then a brief timed park. Low idle
+  CPU, slightly higher tail latency.
+- `mode = 2`: Efficient — minimal spin then a longer timed park.
+  Lowest idle CPU.
+- `mode = 3`: BusySpin — pure spin, no yield or sleep. Absolute
+  minimum latency; pins a core while idle.
+
+Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error`
+when `mode` is outside the documented `{0, 1, 2, 3}` set (code
+`THETADATADX_ERR_INVALID_PARAMETER`) or when `config` is null (code
+`THETADATADX_ERR_CONFIG`).
+"""
+cpp_doc = """
+Set the streaming event-ring consumer wait strategy.
+0=LowLatency (default), 1=Balanced, 2=Efficient, 3=BusySpin
+(see the @c THETADATADX_WAIT_* constants). Throws
+@c thetadatadx::InvalidParameterError when @p mode is outside the
+documented `{0, 1, 2, 3}` set (and @c thetadatadx::ThetaDataError
+on a null handle).
+"""
+py_doc = """
+Set the streaming event-ring consumer wait strategy — the
+latency-vs-CPU knob applied on each ring-empty poll.
+
+Accepts ``"low_latency"`` (default, never sleeps — lowest
+latency, highest idle CPU), ``"balanced"`` (brief park — low idle
+CPU), ``"efficient"`` (longer park — lowest idle CPU), or
+``"busy_spin"`` (pure spin — pins a core). Tune the individual
+spin / yield / park counts via ``wait_spin_iters`` /
+``wait_yield_iters`` / ``wait_park_us``.
+"""
+ts_doc = """
+Set the streaming event-ring consumer wait strategy — the
+latency-vs-CPU knob applied on each ring-empty poll.
+
+Accepts `"low_latency"` (default — never sleeps, lowest latency,
+highest idle CPU), `"balanced"` (brief park — low idle CPU),
+`"efficient"` (longer park — lowest idle CPU), or `"busy_spin"`
+(pure spin — pins a core). Tune the spin / yield / park counts via
+`setWaitSpinIters` / `setWaitYieldIters` / `setWaitParkUs`.
+"""
+py_param = "strategy"
+ts_param = "strategy"
+[[accessor.variant]]
+int = 0
+rust = "LowLatency"
+label = "low_latency"
+[[accessor.variant]]
+int = 1
+rust = "Balanced"
+label = "balanced"
+[[accessor.variant]]
+int = 2
+rust = "Efficient"
+label = "efficient"
+[[accessor.variant]]
+int = 3
+rust = "BusySpin"
+label = "busy_spin"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_wait_strategy"
+kind = "enum"
+param = "out_mode"
+abi_type = "i32"
+path = "streaming.wait_strategy"
+enum_type = "thetadatadx::StreamingWaitStrategy"
+enum_core = "config::StreamingWaitStrategy"
+doc = """
+Read the configured streaming wait strategy. Same encoding as
+`thetadatadx_config_set_wait_strategy`: writes `0` (LowLatency), `1`
+(Balanced), `2` (Efficient), or `3` (BusySpin) into `*out_mode`.
+Returns `0` on success, `-1` if either pointer is null.
+"""
+cpp_doc = """
+Read the current streaming wait strategy. Same encoding as
+@c set_wait_strategy. Returns `0` (LowLatency) on a null handle.
+"""
+py_doc = """
+Current streaming wait strategy (``"low_latency"``,
+``"balanced"``, ``"efficient"``, or ``"busy_spin"``).
+"""
+ts_doc = """
+Current streaming wait strategy (`"low_latency"`, `"balanced"`,
+`"efficient"`, or `"busy_spin"`).
+"""
+[[accessor.variant]]
+int = 0
+rust = "LowLatency"
+label = "low_latency"
+[[accessor.variant]]
+int = 1
+rust = "Balanced"
+label = "balanced"
+[[accessor.variant]]
+int = 2
+rust = "Efficient"
+label = "efficient"
+[[accessor.variant]]
+int = 3
+rust = "BusySpin"
+label = "busy_spin"
+
+[[accessor]]
+symbol = "thetadatadx_config_set_reconnect_jitter"
+kind = "enum"
+param = "mode"
+abi_type = "i32"
+path = "reconnect.jitter"
+enum_type = "thetadatadx::JitterMode"
+enum_core = "config::JitterMode"
+enum_expected = "expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
+py_err = 'unknown reconnect_jitter: {mode:?} (expected "full", "equal", "decorrelated", or "none")'
+ts_err = 'setReconnectJitter: unknown mode {mode:?}; expected "full", "equal", "decorrelated", or "none"'
+doc = """
+Set the jitter strategy applied to every reconnect delay.
+
+- `mode = 0`: Full (default) — sample uniformly from `[0, delay]`.
+- `mode = 1`: Equal — `delay/2 + uniform(0, delay/2)`.
+- `mode = 2`: Decorrelated — walk relative to the previous delay.
+- `mode = 3`: None — deterministic delays (tests only).
+
+Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
+`mode` is outside the documented `{0, 1, 2, 3}` set or `config` is
+null. A rejected `mode` value carries
+`thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
+enum int surfaces the same typed class across every binding.
+"""
+cpp_doc = """
+Set the reconnect jitter mode: 0=Full (default), 1=Equal,
+2=Decorrelated, 3=None. Throws @c thetadatadx::InvalidParameterError on
+an out-of-domain mode (and @c thetadatadx::ThetaDataError on a null
+handle), routing through the typed leaf the FFI error code
+selects.
+"""
+py_doc = """
+Set the jitter strategy applied to every reconnect delay.
+Accepts ``"full"`` (default), ``"equal"``, ``"decorrelated"``,
+or ``"none"`` (case-insensitive).
+"""
+ts_doc = """
+Set the jitter strategy applied to every reconnect delay.
+Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
+`"none"` (case-insensitive).
+"""
+py_param = "mode"
+ts_param = "mode"
+[[accessor.variant]]
+int = 0
+rust = "Full"
+label = "full"
+[[accessor.variant]]
+int = 1
+rust = "Equal"
+label = "equal"
+[[accessor.variant]]
+int = 2
+rust = "Decorrelated"
+label = "decorrelated"
+[[accessor.variant]]
+int = 3
+rust = "None"
+label = "none"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_reconnect_jitter"
+kind = "enum"
+param = "out_mode"
+abi_type = "i32"
+path = "reconnect.jitter"
+enum_type = "thetadatadx::JitterMode"
+enum_core = "config::JitterMode"
+doc = """
+Read the configured reconnect jitter mode. Same encoding as
+`thetadatadx_config_set_reconnect_jitter`. Returns `0` on success, `-1` if
+either pointer is null.
+"""
+cpp_doc = """
+Current reconnect jitter mode (same encoding as the setter).
+"""
+py_doc = """
+Current reconnect jitter mode as a lowercase string.
+"""
+ts_doc = """
+Current reconnect jitter mode as a lowercase string.
+"""
+[[accessor.variant]]
+int = 0
+rust = "Full"
+label = "full"
+[[accessor.variant]]
+int = 1
+rust = "Equal"
+label = "equal"
+[[accessor.variant]]
+int = 2
+rust = "Decorrelated"
+label = "decorrelated"
+[[accessor.variant]]
+int = 3
+rust = "None"
+label = "none"
+
+[[accessor]]
+symbol = "thetadatadx_config_set_streaming_host_selection"
+kind = "enum"
+param = "policy"
+abi_type = "i32"
+path = "streaming.host_selection"
+enum_type = "thetadatadx::HostSelectionPolicy"
+enum_core = "config::HostSelectionPolicy"
+enum_expected = "expected 0 (Shuffled) or 1 (FixedOrder)"
+py_err = 'unknown streaming_host_selection: {policy:?} (expected "shuffled" or "fixed_order")'
+ts_err = 'setStreamingHostSelection: unknown policy {policy:?}; expected "shuffled" or "fixed_order"'
+doc = """
+Set the streaming host-selection policy.
+
+- `policy = 0`: Shuffled (default) — fault-domain-aware per-client
+  shuffle; a fleet spreads across hosts and consecutive failover
+  attempts cross physical machines.
+- `policy = 1`: FixedOrder — use the declared host order verbatim.
+
+Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error`
+when `policy` is outside the documented `{0, 1}` set or `config`
+is null. A rejected `policy` value carries
+`thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
+enum int surfaces the same typed class across every binding.
+"""
+cpp_doc = """
+Set the streaming host-selection policy: 0=Shuffled (default),
+1=FixedOrder. Throws @c thetadatadx::InvalidParameterError on an
+out-of-domain policy (and @c thetadatadx::ThetaDataError on a null
+handle), routing through the typed leaf the FFI error code
+selects.
+"""
+py_doc = """
+Set the streaming host-selection policy. Accepts ``"shuffled"``
+(default — fault-domain-aware per-client shuffle) or
+``"fixed_order"`` (declared order verbatim), case-insensitive.
+"""
+ts_doc = """
+Set the streaming host-selection policy. Accepts `"shuffled"`
+(default — fault-domain-aware per-client shuffle) or
+`"fixed_order"` (declared order verbatim), case-insensitive.
+"""
+py_param = "policy"
+ts_param = "policy"
+[[accessor.variant]]
+int = 0
+rust = "Shuffled"
+label = "shuffled"
+[[accessor.variant]]
+int = 1
+rust = "FixedOrder"
+label = "fixed_order"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_streaming_host_selection"
+kind = "enum"
+param = "out_policy"
+abi_type = "i32"
+path = "streaming.host_selection"
+enum_type = "thetadatadx::HostSelectionPolicy"
+enum_core = "config::HostSelectionPolicy"
+doc = """
+Read the configured streaming host-selection policy. Same encoding as
+`thetadatadx_config_set_streaming_host_selection`. Returns `0` on success, `-1`
+if either pointer is null.
+"""
+cpp_doc = """
+Current streaming host-selection policy (same encoding as the
+setter).
+"""
+py_doc = """
+Current streaming host-selection policy as a lowercase string.
+"""
+ts_doc = """
+Current streaming host-selection policy as a lowercase string.
+"""
+[[accessor.variant]]
+int = 0
+rust = "Shuffled"
+label = "shuffled"
+[[accessor.variant]]
+int = 1
+rust = "FixedOrder"
+label = "fixed_order"
+
+# ── Option config fields (option) ───────────────────────────────────
+#
+# Plain `(has_value, N)` <-> `Option<T>` accessors. The FFI carries the
+# widened `(has_value: bool, value: T)` shape that preserves the `None`
+# sentinel across C; C++ wraps it as `std::optional<T>`; Python / TS
+# expose `Optional[int]` / `T | null`. `abi_type` selects the scalar
+# decode on the JS surface (`number` for u16, `BigInt` for u64), the
+# same switch the scalar accessor already runs.
+
+[[accessor]]
+symbol = "thetadatadx_config_set_metrics_port"
+kind = "option"
+param = "port"
+abi_type = "u16"
+path = "metrics.port"
+py_err = 'metrics_port must be in 0..=65535; got {v}'
+ts_err = 'setMetricsPort: port must be in 0..=65535; got {v}'
+doc = """
+Set the Prometheus exporter port on a config handle.
+
+* `has_value = false` encodes `None`: the exporter stays disabled
+  even when the `metrics-prometheus` cargo feature is compiled in.
+  `port` is ignored.
+* `has_value = true` encodes `Some(port)`: the exporter binds an
+  HTTP listener on `0.0.0.0:<port>` whose `/metrics` endpoint
+  exposes every counter and histogram recorded through the
+  `metrics` crate.
+
+Returns `0` on success, `-1` if `config` is null.
+"""
+cpp_doc = """
+Set the Prometheus exporter port. Pass @c std::nullopt to leave
+the exporter disabled (the @c None default); pass an explicit
+@c std::uint16_t to bind an HTTP listener on @c 0.0.0.0:<port>
+when the @c metrics-prometheus feature is compiled in.
+
+Throws a @c thetadatadx::ThetaDataError leaf on a null-handle FFI failure,
+routing through the typed class the FFI error code selects.
+"""
+py_doc = """
+Set the Prometheus exporter port. ``None`` (the default) keeps
+the exporter disabled; an ``int`` binds an HTTP listener whose
+``/metrics`` endpoint exposes every counter and histogram.
+
+Raises ``ValueError`` if the value is outside the ``u16`` range
+(``0..=65535``).
+"""
+ts_doc = """
+Set the Prometheus exporter port. Pass `null` or `undefined`
+to leave the exporter disabled (the default); pass a
+`number` to bind an HTTP listener on `0.0.0.0:<port>` when the
+`metrics-prometheus` feature is compiled in.
+
+Rejects values outside the `0..=65535` port range.
+"""
+py_param = "port"
+ts_param = "port"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_metrics_port"
+kind = "option"
+param = "out_port"
+abi_type = "u16"
+path = "metrics.port"
+doc = """
+Read the current `metrics.port` setting.
+
+* `*out_has_value = false` → the config holds `None` (exporter
+  disabled). `*out_port` is left as `0`.
+* `*out_has_value = true` → the config holds `Some(*out_port)`.
+
+Returns `0` on success, `-1` if any pointer is null.
+"""
+cpp_doc = """
+Read the current @c metrics.port setting. Returns
+@c std::nullopt for the disabled sentinel; returns the wrapped
+@c std::uint16_t when an explicit port is set.
+
+Throws a @c thetadatadx::ThetaDataError leaf on a null-handle FFI failure,
+routing through the typed class the FFI error code selects.
+"""
+py_doc = """
+Current ``metrics.port`` setting. ``None`` means the exporter is
+disabled; an ``int`` is the bound port.
+"""
+ts_doc = """
+Current `metrics.port` setting. `null` means the exporter is
+disabled; a `number` is the bound port.
+"""
+
+[[accessor]]
+symbol = "thetadatadx_config_set_streaming_host_shuffle_seed"
+kind = "option"
+param = "seed"
+abi_type = "u64"
+path = "streaming.host_shuffle_seed"
+doc = """
+Set the streaming host-shuffle seed using the `(has_value, seed)`
+widened ABI shape that preserves the `None` sentinel across the C
+boundary.
+
+* `has_value = false` → `None` (default): every client derives a
+  fresh per-instance seed, so a fleet shuffles independently.
+  `seed` is ignored.
+* `has_value = true` → `Some(seed)`: the shuffled order becomes
+  deterministic — useful for fleet sharding and tests.
+
+Ignored under the `FixedOrder` host-selection policy. Returns `0`
+on success, `-1` if `config` is null.
+"""
+cpp_doc = """
+Set the streaming host-shuffle seed using the (has_value, seed)
+shape. has_value=false derives a fresh per-client seed;
+has_value=true makes the shuffled order deterministic.
+"""
+py_doc = """
+Set the streaming host-shuffle seed. ``None`` (default) derives a
+fresh per-client seed so a fleet shuffles independently; an
+explicit value makes the shuffled order deterministic — useful
+for fleet sharding and tests. Ignored under ``"fixed_order"``.
+"""
+ts_doc = """
+Set the streaming host-shuffle seed. `null` (default) derives a
+fresh per-client seed so a fleet shuffles independently; an
+explicit `bigint` makes the shuffled order deterministic —
+useful for fleet sharding and tests. Ignored under
+`"fixed_order"`.
+"""
+py_param = "seed"
+ts_param = "seed"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_streaming_host_shuffle_seed"
+kind = "option"
+param = "out_seed"
+abi_type = "u64"
+path = "streaming.host_shuffle_seed"
+doc = """
+Read the current streaming host-shuffle seed. Same `(has_value, seed)`
+ABI as `thetadatadx_config_set_streaming_host_shuffle_seed`:
+
+* `*out_has_value = false` → `None` (per-client entropy). `*out_seed` is left `0`.
+* `*out_has_value = true` → `Some(*out_seed)`.
+
+Returns `0` on success, `-1` if any pointer is null.
+"""
+cpp_doc = """
+Read the streaming host-shuffle seed back. Returns @c std::nullopt for
+the per-client-entropy sentinel (no pinned seed); returns the
+wrapped seed when the shuffled order is deterministic.
+"""
+py_doc = """
+Current ``streaming.host_shuffle_seed`` value (``None`` = per-client
+entropy).
+"""
+ts_doc = """
+Current `streaming.host_shuffle_seed` value (`null` = per-client
+entropy).
+"""

--- a/crates/thetadatadx/src/config/fpss.rs
+++ b/crates/thetadatadx/src/config/fpss.rs
@@ -12,6 +12,29 @@ pub enum StreamingFlushMode {
     Immediate,
 }
 
+impl StreamingFlushMode {
+    /// Canonical lowercase string for this mode, matching the
+    /// cross-binding encoding.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Batched => "batched",
+            Self::Immediate => "immediate",
+        }
+    }
+
+    /// Parse the cross-binding string encoding (case-insensitive).
+    /// Returns `None` for unrecognised input.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "batched" => Some(Self::Batched),
+            "immediate" => Some(Self::Immediate),
+            _ => None,
+        }
+    }
+}
+
 /// How the streaming client orders the configured streaming hosts for the
 /// initial connect and every reconnect.
 ///

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -321,83 +321,6 @@ pub unsafe extern "C" fn thetadatadx_config_free(config: *mut ThetaDataDxConfig)
     })
 }
 
-/// Set streaming flush mode on a config handle.
-///
-/// - `mode = 0`: Batched (default) -- flush only on PING every 100ms
-/// - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
-///
-/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
-/// `mode` is outside the documented `{0, 1}` set or when `config` is
-/// null. A rejected `mode` value carries
-/// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` (the same typed
-/// class the Python / TypeScript bindings raise for a bad enum value);
-/// a null `config` carries `THETADATADX_ERR_CONFIG`.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_flush_mode(
-    config: *mut ThetaDataDxConfig,
-    mode: i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() {
-            crate::error::set_error_with_code(
-                "thetadatadx_config_set_flush_mode: config handle is null",
-                crate::error::THETADATADX_ERR_CONFIG,
-            );
-            return -1;
-        }
-        let value = match mode {
-            0 => thetadatadx::StreamingFlushMode::Batched,
-            1 => thetadatadx::StreamingFlushMode::Immediate,
-            other => {
-                crate::error::set_error_with_code(
-                    &format!(
-                        "thetadatadx_config_set_flush_mode: invalid mode {other}; expected 0 (Batched) or 1 (Immediate)"
-                    ),
-                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
-                );
-                return -1;
-            }
-        };
-        // SAFETY: caller passes a pointer returned by `thetadatadx_direct_config_new`
-        // that has not been freed; null was rejected above; `&mut *` produces a
-        // unique reference valid for the call duration because the caller owns
-        // the Box and the FFI contract forbids concurrent calls on the same
-        // handle.
-        let config = unsafe { &mut *config };
-        config.inner.streaming.flush_mode = value;
-        0
-    })
-}
-
-/// Read the configured streaming flush mode. Same encoding as
-/// `thetadatadx_config_set_flush_mode`: writes `0` (`Batched`) or `1`
-/// (`Immediate`) into `*out_mode`. Returns `0` on success, `-1` if
-/// either pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_flush_mode(
-    config: *const ThetaDataDxConfig,
-    out_mode: *mut i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_mode.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
-        let config = unsafe { &*config };
-        let value = match config.inner.streaming.flush_mode {
-            thetadatadx::StreamingFlushMode::Batched => 0,
-            thetadatadx::StreamingFlushMode::Immediate => 1,
-            _ => 0,
-        };
-        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
-        unsafe {
-            *out_mode = value;
-        }
-        0
-    })
-}
-
 /// Read the historical environment carried by the config.
 ///
 /// On success, returns a heap-owned NUL-terminated C string (`"PROD"` or
@@ -416,7 +339,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_historical_environment(
             set_error("config handle is null");
             return ptr::null_mut();
         }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        // SAFETY: see `thetadatadx_config_get_flush_mode`.
         let config = unsafe { &*config };
         // `HistoricalEnvironment::as_str` is a `'static` label free of
         // interior NULs, so `CString::new` never fails here.
@@ -450,7 +373,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_streaming_environment(
             set_error("config handle is null");
             return ptr::null_mut();
         }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        // SAFETY: see `thetadatadx_config_get_flush_mode`.
         let config = unsafe { &*config };
         // `StreamingEnvironment::as_str` is a `'static` label free of
         // interior NULs, so `CString::new` never fails here.
@@ -463,84 +386,6 @@ pub unsafe extern "C" fn thetadatadx_config_get_streaming_environment(
                 ptr::null_mut()
             }
         }
-    })
-}
-
-/// Set the streaming event-ring consumer wait strategy on a config
-/// handle.
-///
-/// `mode` selects a preset: `0` = LowLatency (default, never sleeps),
-/// `1` = Balanced (brief park), `2` = Efficient (longer park), `3` =
-/// BusySpin (pure spin, pins a core). Tune the individual spin / yield /
-/// park counts via the `thetadatadx_config_set_wait_*` knobs.
-///
-/// Returns `0` on success. Returns `-1` with `thetadatadx_last_error`
-/// set when `mode` is outside the documented `{0, 1, 2, 3}` set (code
-/// `THETADATADX_ERR_INVALID_PARAMETER`) or when `config` is null (code
-/// `THETADATADX_ERR_CONFIG`).
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_wait_strategy(
-    config: *mut ThetaDataDxConfig,
-    mode: i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() {
-            crate::error::set_error_with_code(
-                "thetadatadx_config_set_wait_strategy: config handle is null",
-                crate::error::THETADATADX_ERR_CONFIG,
-            );
-            return -1;
-        }
-        let value = match mode {
-            0 => thetadatadx::StreamingWaitStrategy::LowLatency,
-            1 => thetadatadx::StreamingWaitStrategy::Balanced,
-            2 => thetadatadx::StreamingWaitStrategy::Efficient,
-            3 => thetadatadx::StreamingWaitStrategy::BusySpin,
-            other => {
-                crate::error::set_error_with_code(
-                    &format!(
-                        "thetadatadx_config_set_wait_strategy: invalid mode {other}; expected 0 (LowLatency), 1 (Balanced), 2 (Efficient), or 3 (BusySpin)"
-                    ),
-                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
-                );
-                return -1;
-            }
-        };
-        // SAFETY: see `thetadatadx_config_set_flush_mode`.
-        let config = unsafe { &mut *config };
-        config.inner.streaming.wait_strategy = value;
-        0
-    })
-}
-
-/// Read the configured streaming wait strategy. Same encoding as
-/// `thetadatadx_config_set_wait_strategy`: writes `0` (LowLatency), `1`
-/// (Balanced), `2` (Efficient), or `3` (BusySpin) into `*out_mode`.
-/// Returns `0` on success, `-1` if either pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_wait_strategy(
-    config: *const ThetaDataDxConfig,
-    out_mode: *mut i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_mode.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: see `thetadatadx_config_get_flush_mode`.
-        let config = unsafe { &*config };
-        let value = match config.inner.streaming.wait_strategy {
-            thetadatadx::StreamingWaitStrategy::LowLatency => 0,
-            thetadatadx::StreamingWaitStrategy::Balanced => 1,
-            thetadatadx::StreamingWaitStrategy::Efficient => 2,
-            thetadatadx::StreamingWaitStrategy::BusySpin => 3,
-            _ => 0,
-        };
-        // SAFETY: out pointer checked non-null above.
-        unsafe {
-            *out_mode = value;
-        }
-        0
     })
 }
 
@@ -812,7 +657,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_reconnect_policy(
             set_error("config or out-parameter pointer is null");
             return -1;
         }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        // SAFETY: see `thetadatadx_config_get_flush_mode`.
         let config = unsafe { &*config };
         let value = match &config.inner.reconnect.policy {
             thetadatadx::ReconnectPolicy::Auto(_) => 0,
@@ -827,89 +672,14 @@ pub unsafe extern "C" fn thetadatadx_config_get_reconnect_policy(
     })
 }
 
-// ── Reconnect cadence + replay pacing ──────────────────────────────
-
-/// Set the jitter strategy applied to every reconnect delay.
-///
-/// - `mode = 0`: Full (default) — sample uniformly from `[0, delay]`.
-/// - `mode = 1`: Equal — `delay/2 + uniform(0, delay/2)`.
-/// - `mode = 2`: Decorrelated — walk relative to the previous delay.
-/// - `mode = 3`: None — deterministic delays (tests only).
-///
-/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
-/// `mode` is outside the documented `{0, 1, 2, 3}` set or `config` is
-/// null. A rejected `mode` value carries
-/// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
-/// enum int surfaces the same typed class across every binding.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_reconnect_jitter(
-    config: *mut ThetaDataDxConfig,
-    mode: i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() {
-            set_error("thetadatadx_config_set_reconnect_jitter: config handle is null");
-            return -1;
-        }
-        let value = match mode {
-            0 => thetadatadx::JitterMode::Full,
-            1 => thetadatadx::JitterMode::Equal,
-            2 => thetadatadx::JitterMode::Decorrelated,
-            3 => thetadatadx::JitterMode::None,
-            other => {
-                crate::error::set_error_with_code(
-                    &format!(
-                        "thetadatadx_config_set_reconnect_jitter: invalid mode {other}; expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
-                    ),
-                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
-                );
-                return -1;
-            }
-        };
-        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
-        let config = unsafe { &mut *config };
-        config.inner.reconnect.jitter = value;
-        0
-    })
-}
-
-/// Read the configured reconnect jitter mode. Same encoding as
-/// `thetadatadx_config_set_reconnect_jitter`. Returns `0` on success, `-1` if
-/// either pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_reconnect_jitter(
-    config: *const ThetaDataDxConfig,
-    out_mode: *mut i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_mode.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
-        let config = unsafe { &*config };
-        let value = match config.inner.reconnect.jitter {
-            thetadatadx::JitterMode::Full => 0,
-            thetadatadx::JitterMode::Equal => 1,
-            thetadatadx::JitterMode::Decorrelated => 2,
-            _ => 3,
-        };
-        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
-        unsafe {
-            *out_mode = value;
-        }
-        0
-    })
-}
-
 // ── Streaming transport knobs ────────────────────────────────────────────
 //
 // Scalar tuning on `StreamingConfig` exposed for embedded callers: read
 // timeout, connect timeout, ping cadence, ring size, the I/O read
-// slice, the last-frame watchdog, the TCP keepalive schedule, and the
-// host-selection policy. Out-of-range values are rejected at connect
-// time by the core validator; the setters here store verbatim so the
-// rejection carries the canonical bounds message.
+// slice, the last-frame watchdog, and the TCP keepalive schedule.
+// Out-of-range values are rejected at connect time by the core
+// validator; the setters here store verbatim so the rejection carries
+// the canonical bounds message.
 
 /// Set the streaming event ring buffer size (slots).
 ///
@@ -942,142 +712,6 @@ pub unsafe extern "C" fn thetadatadx_config_set_streaming_ring_size(
         // SAFETY: config is a non-null pointer returned by thetadatadx_config_* and not yet freed.
         let config = unsafe { &mut *config };
         config.inner.streaming.ring_size = n;
-    })
-}
-
-/// Set the streaming host-selection policy.
-///
-/// - `policy = 0`: Shuffled (default) — fault-domain-aware per-client
-///   shuffle; a fleet spreads across hosts and consecutive failover
-///   attempts cross physical machines.
-/// - `policy = 1`: FixedOrder — use the declared host order verbatim.
-///
-/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error`
-/// when `policy` is outside the documented `{0, 1}` set or `config`
-/// is null. A rejected `policy` value carries
-/// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
-/// enum int surfaces the same typed class across every binding.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_streaming_host_selection(
-    config: *mut ThetaDataDxConfig,
-    policy: i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() {
-            set_error("thetadatadx_config_set_streaming_host_selection: config handle is null");
-            return -1;
-        }
-        let value = match policy {
-            0 => thetadatadx::HostSelectionPolicy::Shuffled,
-            1 => thetadatadx::HostSelectionPolicy::FixedOrder,
-            other => {
-                crate::error::set_error_with_code(
-                    &format!(
-                        "thetadatadx_config_set_streaming_host_selection: invalid policy {other}; expected 0 (Shuffled) or 1 (FixedOrder)"
-                    ),
-                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
-                );
-                return -1;
-            }
-        };
-        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
-        let config = unsafe { &mut *config };
-        config.inner.streaming.host_selection = value;
-        0
-    })
-}
-
-/// Read the configured streaming host-selection policy. Same encoding as
-/// `thetadatadx_config_set_streaming_host_selection`. Returns `0` on success, `-1`
-/// if either pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_streaming_host_selection(
-    config: *const ThetaDataDxConfig,
-    out_policy: *mut i32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_policy.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
-        let config = unsafe { &*config };
-        let value = match config.inner.streaming.host_selection {
-            thetadatadx::HostSelectionPolicy::Shuffled => 0,
-            _ => 1,
-        };
-        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
-        unsafe {
-            *out_policy = value;
-        }
-        0
-    })
-}
-
-/// Set the streaming host-shuffle seed using the `(has_value, seed)`
-/// widened ABI shape that preserves the `None` sentinel across the C
-/// boundary.
-///
-/// * `has_value = false` → `None` (default): every client derives a
-///   fresh per-instance seed, so a fleet shuffles independently.
-///   `seed` is ignored.
-/// * `has_value = true` → `Some(seed)`: the shuffled order becomes
-///   deterministic — useful for fleet sharding and tests.
-///
-/// Ignored under the `FixedOrder` host-selection policy. Returns `0`
-/// on success, `-1` if `config` is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_streaming_host_shuffle_seed(
-    config: *mut ThetaDataDxConfig,
-    has_value: bool,
-    seed: u64,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() {
-            set_error("config handle is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
-        let config = unsafe { &mut *config };
-        config.inner.streaming.host_shuffle_seed = if has_value { Some(seed) } else { None };
-        0
-    })
-}
-
-/// Read the current streaming host-shuffle seed. Same `(has_value, seed)`
-/// ABI as `thetadatadx_config_set_streaming_host_shuffle_seed`:
-///
-/// * `*out_has_value = false` → `None` (per-client entropy). `*out_seed` is left `0`.
-/// * `*out_has_value = true` → `Some(*out_seed)`.
-///
-/// Returns `0` on success, `-1` if any pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_streaming_host_shuffle_seed(
-    config: *const ThetaDataDxConfig,
-    out_has_value: *mut bool,
-    out_seed: *mut u64,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_has_value.is_null() || out_seed.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
-        let config = unsafe { &*config };
-        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
-        unsafe {
-            match config.inner.streaming.host_shuffle_seed {
-                Some(seed) => {
-                    *out_has_value = true;
-                    *out_seed = seed;
-                }
-                None => {
-                    *out_has_value = false;
-                    *out_seed = 0;
-                }
-            }
-        }
-        0
     })
 }
 
@@ -1249,7 +883,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_worker_threads(
             set_error("config or out-parameter pointer is null");
             return -1;
         }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        // SAFETY: see `thetadatadx_config_get_flush_mode`.
         let config = unsafe { &*config };
         let (has_value, n) = match config.inner.runtime.tokio_worker_threads {
             Some(v) => (true, v),
@@ -1274,88 +908,17 @@ pub unsafe extern "C" fn thetadatadx_config_get_worker_threads(
 // validated `*const c_char`, the getter returns an owned `*mut c_char` the
 // caller frees with `thetadatadx_string_free`.
 
-// ── MetricsConfig ──────────────────────────────────────────────────
-//
-// `MetricsConfig.port` is `Option<u16>`. The widened
-// `(has_value: bool, port: u16)` ABI shape mirrors the `Option`
-// fields already on the C surface (`tokio_worker_threads`):
-// `has_value = false` encodes the `None`
-// (exporter disabled) sentinel; `has_value = true` encodes
-// `Some(port)`.
-
-/// Set the Prometheus exporter port on a config handle.
-///
-/// * `has_value = false` encodes `None`: the exporter stays disabled
-///   even when the `metrics-prometheus` cargo feature is compiled in.
-///   `port` is ignored.
-/// * `has_value = true` encodes `Some(port)`: the exporter binds an
-///   HTTP listener on `0.0.0.0:<port>` whose `/metrics` endpoint
-///   exposes every counter and histogram recorded through the
-///   `metrics` crate.
-///
-/// Returns `0` on success, `-1` if `config` is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_metrics_port(
-    config: *mut ThetaDataDxConfig,
-    has_value: bool,
-    port: u16,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() {
-            set_error("config handle is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null pointer returned by
-        // thetadatadx_config_production / thetadatadx_config_dev / thetadatadx_config_stage
-        // and not yet freed.
-        let config = unsafe { &mut *config };
-        config.inner.metrics.port = if has_value { Some(port) } else { None };
-        0
-    })
-}
-
-/// Read the current `metrics.port` setting.
-///
-/// * `*out_has_value = false` → the config holds `None` (exporter
-///   disabled). `*out_port` is left as `0`.
-/// * `*out_has_value = true` → the config holds `Some(*out_port)`.
-///
-/// Returns `0` on success, `-1` if any pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_metrics_port(
-    config: *const ThetaDataDxConfig,
-    out_has_value: *mut bool,
-    out_port: *mut u16,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_has_value.is_null() || out_port.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
-        let config = unsafe { &*config };
-        let (has_value, port) = match config.inner.metrics.port {
-            Some(v) => (true, v),
-            None => (false, 0),
-        };
-        // SAFETY: out_has_value / out_port null-checked above; caller pins the storage they point at for the call duration.
-        unsafe {
-            *out_has_value = has_value;
-            *out_port = port;
-        }
-        0
-    })
-}
-
 // `DirectConfig` historical endpoint overrides (`historical_host` string
 // via `set_historical_host`, `historical_port` `u16`) are the generated
 // `string` / scalar accessors in config_surface.toml.
 
 // The uniform static config accessors — scalar / duration setters and
-// getters, plus the `policy_limit` (reconnect `Auto`-limit) and `string`
-// carve-outs — are generated from `config_surface.toml`. The divergent
-// accessors above (enum int/label, `Option`-widened, policy-selector,
-// validated, callback) stay hand-written.
+// getters, plus the `policy_limit` (reconnect `Auto`-limit), `string`,
+// `enum` (int code ↔ core variant), and `option` (`(has_value, value)` ↔
+// `Option<T>`) carve-outs — are generated from `config_surface.toml`.
+// The genuinely divergent accessors above (validated `ring_size`,
+// `consumer_cpu` sentinel, the `(has_value, n)` worker-thread setting,
+// and the reconnect-policy callback) stay hand-written.
 include!("config_accessors.rs");
 
 // ── HistoricalClient ──

--- a/ffi/src/config_accessors.rs
+++ b/ffi/src/config_accessors.rs
@@ -1530,3 +1530,429 @@ pub unsafe extern "C" fn thetadatadx_config_get_historical_host(
     })
 }
 
+/// Set streaming flush mode on a config handle.
+///
+/// - `mode = 0`: Batched (default) -- flush only on PING every 100ms
+/// - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
+///
+/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
+/// `mode` is outside the documented `{0, 1}` set or when `config` is
+/// null. A rejected `mode` value carries
+/// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` (the same typed
+/// class the Python / TypeScript bindings raise for a bad enum value);
+/// a null `config` carries `THETADATADX_ERR_CONFIG`.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_flush_mode(
+    config: *mut ThetaDataDxConfig,
+    mode: i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            crate::error::set_error_with_code(
+                "thetadatadx_config_set_flush_mode: config handle is null",
+                crate::error::THETADATADX_ERR_CONFIG,
+            );
+            return -1;
+        }
+        let value = match mode {
+            0 => thetadatadx::StreamingFlushMode::Batched,
+            1 => thetadatadx::StreamingFlushMode::Immediate,
+            other => {
+                crate::error::set_error_with_code(
+                    &format!(
+                        "thetadatadx_config_set_flush_mode: invalid mode {other}; expected 0 (Batched) or 1 (Immediate)"
+                    ),
+                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                );
+                return -1;
+            }
+        };
+        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
+        let config = unsafe { &mut *config };
+        config.inner.streaming.flush_mode = value;
+        0
+    })
+}
+
+/// Read the configured streaming flush mode. Same encoding as
+/// `thetadatadx_config_set_flush_mode`: writes `0` (`Batched`) or `1`
+/// (`Immediate`) into `*out_mode`. Returns `0` on success, `-1` if
+/// either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_flush_mode(
+    config: *const ThetaDataDxConfig,
+    out_mode: *mut i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_mode.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let value = match config.inner.streaming.flush_mode {
+            thetadatadx::StreamingFlushMode::Batched => 0,
+            _ => 1,
+        };
+        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
+        unsafe {
+            *out_mode = value;
+        }
+        0
+    })
+}
+
+/// Set the streaming event-ring consumer wait strategy on a config
+/// handle.
+///
+/// - `mode = 0`: LowLatency (default) — spin, yield, then a `spin_loop`
+///   hint; never sleeps. Lowest latency, highest idle CPU.
+/// - `mode = 1`: Balanced — short spin then a brief timed park. Low idle
+///   CPU, slightly higher tail latency.
+/// - `mode = 2`: Efficient — minimal spin then a longer timed park.
+///   Lowest idle CPU.
+/// - `mode = 3`: BusySpin — pure spin, no yield or sleep. Absolute
+///   minimum latency; pins a core while idle.
+///
+/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error`
+/// when `mode` is outside the documented `{0, 1, 2, 3}` set (code
+/// `THETADATADX_ERR_INVALID_PARAMETER`) or when `config` is null (code
+/// `THETADATADX_ERR_CONFIG`).
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_wait_strategy(
+    config: *mut ThetaDataDxConfig,
+    mode: i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            crate::error::set_error_with_code(
+                "thetadatadx_config_set_wait_strategy: config handle is null",
+                crate::error::THETADATADX_ERR_CONFIG,
+            );
+            return -1;
+        }
+        let value = match mode {
+            0 => thetadatadx::StreamingWaitStrategy::LowLatency,
+            1 => thetadatadx::StreamingWaitStrategy::Balanced,
+            2 => thetadatadx::StreamingWaitStrategy::Efficient,
+            3 => thetadatadx::StreamingWaitStrategy::BusySpin,
+            other => {
+                crate::error::set_error_with_code(
+                    &format!(
+                        "thetadatadx_config_set_wait_strategy: invalid mode {other}; expected 0 (LowLatency), 1 (Balanced), 2 (Efficient), or 3 (BusySpin)"
+                    ),
+                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                );
+                return -1;
+            }
+        };
+        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
+        let config = unsafe { &mut *config };
+        config.inner.streaming.wait_strategy = value;
+        0
+    })
+}
+
+/// Read the configured streaming wait strategy. Same encoding as
+/// `thetadatadx_config_set_wait_strategy`: writes `0` (LowLatency), `1`
+/// (Balanced), `2` (Efficient), or `3` (BusySpin) into `*out_mode`.
+/// Returns `0` on success, `-1` if either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_wait_strategy(
+    config: *const ThetaDataDxConfig,
+    out_mode: *mut i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_mode.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let value = match config.inner.streaming.wait_strategy {
+            thetadatadx::StreamingWaitStrategy::LowLatency => 0,
+            thetadatadx::StreamingWaitStrategy::Balanced => 1,
+            thetadatadx::StreamingWaitStrategy::Efficient => 2,
+            _ => 3,
+        };
+        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
+        unsafe {
+            *out_mode = value;
+        }
+        0
+    })
+}
+
+/// Set the jitter strategy applied to every reconnect delay.
+///
+/// - `mode = 0`: Full (default) — sample uniformly from `[0, delay]`.
+/// - `mode = 1`: Equal — `delay/2 + uniform(0, delay/2)`.
+/// - `mode = 2`: Decorrelated — walk relative to the previous delay.
+/// - `mode = 3`: None — deterministic delays (tests only).
+///
+/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
+/// `mode` is outside the documented `{0, 1, 2, 3}` set or `config` is
+/// null. A rejected `mode` value carries
+/// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
+/// enum int surfaces the same typed class across every binding.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_reconnect_jitter(
+    config: *mut ThetaDataDxConfig,
+    mode: i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            crate::error::set_error_with_code(
+                "thetadatadx_config_set_reconnect_jitter: config handle is null",
+                crate::error::THETADATADX_ERR_CONFIG,
+            );
+            return -1;
+        }
+        let value = match mode {
+            0 => thetadatadx::JitterMode::Full,
+            1 => thetadatadx::JitterMode::Equal,
+            2 => thetadatadx::JitterMode::Decorrelated,
+            3 => thetadatadx::JitterMode::None,
+            other => {
+                crate::error::set_error_with_code(
+                    &format!(
+                        "thetadatadx_config_set_reconnect_jitter: invalid mode {other}; expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
+                    ),
+                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                );
+                return -1;
+            }
+        };
+        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
+        let config = unsafe { &mut *config };
+        config.inner.reconnect.jitter = value;
+        0
+    })
+}
+
+/// Read the configured reconnect jitter mode. Same encoding as
+/// `thetadatadx_config_set_reconnect_jitter`. Returns `0` on success, `-1` if
+/// either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_reconnect_jitter(
+    config: *const ThetaDataDxConfig,
+    out_mode: *mut i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_mode.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let value = match config.inner.reconnect.jitter {
+            thetadatadx::JitterMode::Full => 0,
+            thetadatadx::JitterMode::Equal => 1,
+            thetadatadx::JitterMode::Decorrelated => 2,
+            _ => 3,
+        };
+        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
+        unsafe {
+            *out_mode = value;
+        }
+        0
+    })
+}
+
+/// Set the streaming host-selection policy.
+///
+/// - `policy = 0`: Shuffled (default) — fault-domain-aware per-client
+///   shuffle; a fleet spreads across hosts and consecutive failover
+///   attempts cross physical machines.
+/// - `policy = 1`: FixedOrder — use the declared host order verbatim.
+///
+/// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error`
+/// when `policy` is outside the documented `{0, 1}` set or `config`
+/// is null. A rejected `policy` value carries
+/// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
+/// enum int surfaces the same typed class across every binding.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_streaming_host_selection(
+    config: *mut ThetaDataDxConfig,
+    policy: i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            crate::error::set_error_with_code(
+                "thetadatadx_config_set_streaming_host_selection: config handle is null",
+                crate::error::THETADATADX_ERR_CONFIG,
+            );
+            return -1;
+        }
+        let value = match policy {
+            0 => thetadatadx::HostSelectionPolicy::Shuffled,
+            1 => thetadatadx::HostSelectionPolicy::FixedOrder,
+            other => {
+                crate::error::set_error_with_code(
+                    &format!(
+                        "thetadatadx_config_set_streaming_host_selection: invalid policy {other}; expected 0 (Shuffled) or 1 (FixedOrder)"
+                    ),
+                    crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                );
+                return -1;
+            }
+        };
+        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
+        let config = unsafe { &mut *config };
+        config.inner.streaming.host_selection = value;
+        0
+    })
+}
+
+/// Read the configured streaming host-selection policy. Same encoding as
+/// `thetadatadx_config_set_streaming_host_selection`. Returns `0` on success, `-1`
+/// if either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_streaming_host_selection(
+    config: *const ThetaDataDxConfig,
+    out_policy: *mut i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_policy.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let value = match config.inner.streaming.host_selection {
+            thetadatadx::HostSelectionPolicy::Shuffled => 0,
+            _ => 1,
+        };
+        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
+        unsafe {
+            *out_policy = value;
+        }
+        0
+    })
+}
+
+/// Set the Prometheus exporter port on a config handle.
+///
+/// * `has_value = false` encodes `None`: the exporter stays disabled
+///   even when the `metrics-prometheus` cargo feature is compiled in.
+///   `port` is ignored.
+/// * `has_value = true` encodes `Some(port)`: the exporter binds an
+///   HTTP listener on `0.0.0.0:<port>` whose `/metrics` endpoint
+///   exposes every counter and histogram recorded through the
+///   `metrics` crate.
+///
+/// Returns `0` on success, `-1` if `config` is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_metrics_port(
+    config: *mut ThetaDataDxConfig,
+    has_value: bool,
+    port: u16,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            set_error("config handle is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
+        let config = unsafe { &mut *config };
+        config.inner.metrics.port = if has_value { Some(port) } else { None };
+        0
+    })
+}
+
+/// Read the current `metrics.port` setting.
+///
+/// * `*out_has_value = false` → the config holds `None` (exporter
+///   disabled). `*out_port` is left as `0`.
+/// * `*out_has_value = true` → the config holds `Some(*out_port)`.
+///
+/// Returns `0` on success, `-1` if any pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_metrics_port(
+    config: *const ThetaDataDxConfig,
+    out_has_value: *mut bool,
+    out_port: *mut u16,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_has_value.is_null() || out_port.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let (has_value, value) = match config.inner.metrics.port {
+            Some(v) => (true, v),
+            None => (false, 0),
+        };
+        // SAFETY: out_has_value / out_port null-checked above; caller pins the storage they point at for the call duration.
+        unsafe {
+            *out_has_value = has_value;
+            *out_port = value;
+        }
+        0
+    })
+}
+
+/// Set the streaming host-shuffle seed using the `(has_value, seed)`
+/// widened ABI shape that preserves the `None` sentinel across the C
+/// boundary.
+///
+/// * `has_value = false` → `None` (default): every client derives a
+///   fresh per-instance seed, so a fleet shuffles independently.
+///   `seed` is ignored.
+/// * `has_value = true` → `Some(seed)`: the shuffled order becomes
+///   deterministic — useful for fleet sharding and tests.
+///
+/// Ignored under the `FixedOrder` host-selection policy. Returns `0`
+/// on success, `-1` if `config` is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_streaming_host_shuffle_seed(
+    config: *mut ThetaDataDxConfig,
+    has_value: bool,
+    seed: u64,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            set_error("config handle is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null pointer returned by `thetadatadx_config_*` and not yet freed; `&mut *` produces a unique reference valid for the call duration because the caller owns the Box and the FFI contract forbids concurrent calls on the same handle.
+        let config = unsafe { &mut *config };
+        config.inner.streaming.host_shuffle_seed = if has_value { Some(seed) } else { None };
+        0
+    })
+}
+
+/// Read the current streaming host-shuffle seed. Same `(has_value, seed)`
+/// ABI as `thetadatadx_config_set_streaming_host_shuffle_seed`:
+///
+/// * `*out_has_value = false` → `None` (per-client entropy). `*out_seed` is left `0`.
+/// * `*out_has_value = true` → `Some(*out_seed)`.
+///
+/// Returns `0` on success, `-1` if any pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_streaming_host_shuffle_seed(
+    config: *const ThetaDataDxConfig,
+    out_has_value: *mut bool,
+    out_seed: *mut u64,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_has_value.is_null() || out_seed.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let (has_value, value) = match config.inner.streaming.host_shuffle_seed {
+            Some(v) => (true, v),
+            None => (false, 0),
+        };
+        // SAFETY: out_has_value / out_seed null-checked above; caller pins the storage they point at for the call duration.
+        unsafe {
+            *out_has_value = has_value;
+            *out_seed = value;
+        }
+        0
+    })
+}
+

--- a/sdks/cpp/include/config_accessors.hpp.inc
+++ b/sdks/cpp/include/config_accessors.hpp.inc
@@ -521,3 +521,134 @@
         detail::FfiString s(thetadatadx_config_get_historical_host(handle_.get()));
         return s.str();
     }
+
+    /// Set streaming flush mode. 0=Batched (default), 1=Immediate. Throws
+    /// @c thetadatadx::InvalidParameterError when @p mode is outside the
+    /// documented `{0, 1}` set (and @c thetadatadx::ThetaDataError on a null
+    /// handle), routing through the typed leaf the FFI error code
+    /// selects.
+    void set_flush_mode(int mode) {
+        if (thetadatadx_config_set_flush_mode(handle_.get(), mode) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /// Read the current streaming flush mode. Same encoding as
+    /// @c set_flush_mode: `0` = Batched, `1` = Immediate. Returns `0`
+    /// (Batched) on a null handle (matching the C ABI's `-1` failure
+    /// mapping at the boundary).
+    int get_flush_mode() const {
+        int32_t out{};
+        thetadatadx_config_get_flush_mode(handle_.get(), &out);
+        return out;
+    }
+
+    /// Set the streaming event-ring consumer wait strategy.
+    /// 0=LowLatency (default), 1=Balanced, 2=Efficient, 3=BusySpin
+    /// (see the @c THETADATADX_WAIT_* constants). Throws
+    /// @c thetadatadx::InvalidParameterError when @p mode is outside the
+    /// documented `{0, 1, 2, 3}` set (and @c thetadatadx::ThetaDataError
+    /// on a null handle).
+    void set_wait_strategy(int mode) {
+        if (thetadatadx_config_set_wait_strategy(handle_.get(), mode) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /// Read the current streaming wait strategy. Same encoding as
+    /// @c set_wait_strategy. Returns `0` (LowLatency) on a null handle.
+    int get_wait_strategy() const {
+        int32_t out{};
+        thetadatadx_config_get_wait_strategy(handle_.get(), &out);
+        return out;
+    }
+
+    /// Set the reconnect jitter mode: 0=Full (default), 1=Equal,
+    /// 2=Decorrelated, 3=None. Throws @c thetadatadx::InvalidParameterError on
+    /// an out-of-domain mode (and @c thetadatadx::ThetaDataError on a null
+    /// handle), routing through the typed leaf the FFI error code
+    /// selects.
+    void set_reconnect_jitter(int mode) {
+        if (thetadatadx_config_set_reconnect_jitter(handle_.get(), mode) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /// Current reconnect jitter mode (same encoding as the setter).
+    int get_reconnect_jitter() const {
+        int32_t out{};
+        thetadatadx_config_get_reconnect_jitter(handle_.get(), &out);
+        return out;
+    }
+
+    /// Set the streaming host-selection policy: 0=Shuffled (default),
+    /// 1=FixedOrder. Throws @c thetadatadx::InvalidParameterError on an
+    /// out-of-domain policy (and @c thetadatadx::ThetaDataError on a null
+    /// handle), routing through the typed leaf the FFI error code
+    /// selects.
+    void set_streaming_host_selection(int policy) {
+        if (thetadatadx_config_set_streaming_host_selection(handle_.get(), policy) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /// Current streaming host-selection policy (same encoding as the
+    /// setter).
+    int get_streaming_host_selection() const {
+        int32_t out{};
+        thetadatadx_config_get_streaming_host_selection(handle_.get(), &out);
+        return out;
+    }
+
+    /// Set the Prometheus exporter port. Pass @c std::nullopt to leave
+    /// the exporter disabled (the @c None default); pass an explicit
+    /// @c std::uint16_t to bind an HTTP listener on @c 0.0.0.0:<port>
+    /// when the @c metrics-prometheus feature is compiled in.
+    ///
+    /// Throws a @c thetadatadx::ThetaDataError leaf on a null-handle FFI failure,
+    /// routing through the typed class the FFI error code selects.
+    void set_metrics_port(std::optional<std::uint16_t> port) {
+        const bool has_value = port.has_value();
+        const std::uint16_t arg = port.value_or(0);
+        if (thetadatadx_config_set_metrics_port(handle_.get(), has_value, arg) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /// Read the current @c metrics.port setting. Returns
+    /// @c std::nullopt for the disabled sentinel; returns the wrapped
+    /// @c std::uint16_t when an explicit port is set.
+    ///
+    /// Throws a @c thetadatadx::ThetaDataError leaf on a null-handle FFI failure,
+    /// routing through the typed class the FFI error code selects.
+    std::optional<std::uint16_t> get_metrics_port() const {
+        bool has_value = false;
+        std::uint16_t port = 0;
+        if (thetadatadx_config_get_metrics_port(handle_.get(), &has_value, &port) != 0) {
+            detail::throw_last_ffi_error();
+        }
+        return has_value ? std::optional<std::uint16_t>{port} : std::nullopt;
+    }
+
+    /// Set the streaming host-shuffle seed using the (has_value, seed)
+    /// shape. has_value=false derives a fresh per-client seed;
+    /// has_value=true makes the shuffled order deterministic.
+    void set_streaming_host_shuffle_seed(std::optional<std::uint64_t> seed) {
+        const bool has_value = seed.has_value();
+        const std::uint64_t arg = seed.value_or(0);
+        if (thetadatadx_config_set_streaming_host_shuffle_seed(handle_.get(), has_value, arg) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /// Read the streaming host-shuffle seed back. Returns @c std::nullopt for
+    /// the per-client-entropy sentinel (no pinned seed); returns the
+    /// wrapped seed when the shuffled order is deterministic.
+    std::optional<std::uint64_t> get_streaming_host_shuffle_seed() const {
+        bool has_value = false;
+        std::uint64_t seed = 0;
+        if (thetadatadx_config_get_streaming_host_shuffle_seed(handle_.get(), &has_value, &seed) != 0) {
+            detail::throw_last_ffi_error();
+        }
+        return has_value ? std::optional<std::uint64_t>{seed} : std::nullopt;
+    }

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -826,24 +826,6 @@ public:
         return out;
     }
 
-    /** Set the reconnect jitter mode: 0=Full (default), 1=Equal,
-     *  2=Decorrelated, 3=None. Throws @c thetadatadx::InvalidParameterError on
-     *  an out-of-domain mode (and @c thetadatadx::ThetaDataError on a null
-     *  handle), routing through the typed leaf the FFI error code
-     *  selects. */
-    void set_reconnect_jitter(int32_t mode) {
-        if (thetadatadx_config_set_reconnect_jitter(handle_.get(), mode) != 0) {
-            detail::throw_last_ffi_error();
-        }
-    }
-
-    /** Current reconnect jitter mode (same encoding as the setter). */
-    int32_t get_reconnect_jitter() const {
-        int32_t out{};
-        thetadatadx_config_get_reconnect_jitter(handle_.get(), &out);
-        return out;
-    }
-
     /** Install a custom reconnect policy driven by a C callback.
      *  Permanent disconnect reasons never reach the callback; it runs
      *  on the SDK's streaming I/O thread and must be thread-safe.
@@ -859,43 +841,6 @@ public:
     void set_streaming_ring_size(size_t n) {
         thetadatadx_config_set_streaming_ring_size(handle_.get(), n);
     }
-
-    /** Set the streaming host-selection policy: 0=Shuffled (default),
-     *  1=FixedOrder. Throws @c thetadatadx::InvalidParameterError on an
-     *  out-of-domain policy (and @c thetadatadx::ThetaDataError on a null
-     *  handle), routing through the typed leaf the FFI error code
-     *  selects. */
-    void set_streaming_host_selection(int32_t policy) {
-        if (thetadatadx_config_set_streaming_host_selection(handle_.get(), policy) != 0) {
-            detail::throw_last_ffi_error();
-        }
-    }
-
-    /** Current streaming host-selection policy (same encoding as the
-     *  setter). */
-    int32_t get_streaming_host_selection() const {
-        int32_t out{};
-        thetadatadx_config_get_streaming_host_selection(handle_.get(), &out);
-        return out;
-    }
-
-    /** Set the streaming host-shuffle seed using the (has_value, seed)
-     *  shape. has_value=false derives a fresh per-client seed;
-     *  has_value=true makes the shuffled order deterministic. */
-    int32_t set_streaming_host_shuffle_seed(bool has_value, uint64_t seed) {
-        return thetadatadx_config_set_streaming_host_shuffle_seed(handle_.get(), has_value, seed);
-    }
-
-    /** Read the streaming host-shuffle seed back. Returns @c std::nullopt for
-     *  the per-client-entropy sentinel (no pinned seed); returns the
-     *  wrapped seed when the shuffled order is deterministic. */
-    std::optional<uint64_t> get_streaming_host_shuffle_seed() const {
-        bool has_value = false;
-        uint64_t seed = 0;
-        thetadatadx_config_get_streaming_host_shuffle_seed(handle_.get(), &has_value, &seed);
-        return has_value ? std::optional<uint64_t>{seed} : std::nullopt;
-    }
-
 
     /** Set the async worker-thread count using the (has_value, n) shape
      *  that preserves an explicit 0 across the C boundary. has_value=false
@@ -921,63 +866,6 @@ public:
     // `auth.nexus_url` / `auth.client_type` string accessors are generated
     // into config_accessors.hpp.inc from config_surface.toml.
 
-    // ── MetricsConfig field setter/getter ──
-
-    /**
-     * Set the Prometheus exporter port. Pass @c std::nullopt to leave
-     * the exporter disabled (the @c None default); pass an explicit
-     * @c std::uint16_t to bind an HTTP listener on @c 0.0.0.0:<port>
-     * when the @c metrics-prometheus feature is compiled in.
-     *
-     * Throws a @c thetadatadx::ThetaDataError leaf on a null-handle FFI failure,
-     * routing through the typed class the FFI error code selects.
-     */
-    void set_metrics_port(std::optional<std::uint16_t> port) {
-        const bool has_value = port.has_value();
-        const std::uint16_t arg = port.value_or(0);
-        if (thetadatadx_config_set_metrics_port(handle_.get(), has_value, arg) != 0) {
-            detail::throw_last_ffi_error();
-        }
-    }
-
-    /**
-     * Read the current @c metrics.port setting. Returns
-     * @c std::nullopt for the disabled sentinel; returns the wrapped
-     * @c std::uint16_t when an explicit port is set.
-     *
-     * Throws a @c thetadatadx::ThetaDataError leaf on a null-handle FFI failure,
-     * routing through the typed class the FFI error code selects.
-     */
-    std::optional<std::uint16_t> get_metrics_port() const {
-        bool has_value = false;
-        std::uint16_t port = 0;
-        if (thetadatadx_config_get_metrics_port(handle_.get(), &has_value, &port) != 0) {
-            detail::throw_last_ffi_error();
-        }
-        return has_value ? std::optional<std::uint16_t>{port} : std::nullopt;
-    }
-
-    /** Set streaming flush mode. 0=Batched (default), 1=Immediate. Throws
-     *  @c thetadatadx::InvalidParameterError when @p mode is outside the
-     *  documented `{0, 1}` set (and @c thetadatadx::ThetaDataError on a null
-     *  handle), routing through the typed leaf the FFI error code
-     *  selects. */
-    void set_flush_mode(int mode) {
-        if (thetadatadx_config_set_flush_mode(handle_.get(), mode) != 0) {
-            detail::throw_last_ffi_error();
-        }
-    }
-
-    /** Read the current streaming flush mode. Same encoding as
-     *  @c set_flush_mode: `0` = Batched, `1` = Immediate. Returns `0`
-     *  (Batched) on a null handle (matching the C ABI's `-1` failure
-     *  mapping at the boundary). */
-    int get_flush_mode() const {
-        int32_t mode = 0;
-        thetadatadx_config_get_flush_mode(handle_.get(), &mode);
-        return mode;
-    }
-
     /** Target historical environment carried by this configuration:
      *  `"PROD"` for the production cluster or `"STAGE"` for staging. The
      *  historical and streaming environments are selected independently;
@@ -1000,26 +888,6 @@ public:
     std::string get_streaming_environment() const {
         detail::FfiString s(thetadatadx_config_get_streaming_environment(handle_.get()));
         return s.str();
-    }
-
-    /** Set the streaming event-ring consumer wait strategy.
-     *  0=LowLatency (default), 1=Balanced, 2=Efficient, 3=BusySpin
-     *  (see the @c THETADATADX_WAIT_* constants). Throws
-     *  @c thetadatadx::InvalidParameterError when @p mode is outside the
-     *  documented `{0, 1, 2, 3}` set (and @c thetadatadx::ThetaDataError
-     *  on a null handle). */
-    void set_wait_strategy(int mode) {
-        if (thetadatadx_config_set_wait_strategy(handle_.get(), mode) != 0) {
-            detail::throw_last_ffi_error();
-        }
-    }
-
-    /** Read the current streaming wait strategy. Same encoding as
-     *  @c set_wait_strategy. Returns `0` (LowLatency) on a null handle. */
-    int get_wait_strategy() const {
-        int32_t mode = 0;
-        thetadatadx_config_get_wait_strategy(handle_.get(), &mode);
-        return mode;
     }
 
     /** Set the wait-strategy spin iteration count. Throws on a null handle. */

--- a/sdks/python/src/_generated/config_accessors.rs
+++ b/sdks/python/src/_generated/config_accessors.rs
@@ -667,4 +667,148 @@ impl Config {
         guard.historical_host().to_string()
     }
 
+    /// Set the streaming write-flush policy.
+    ///
+    /// Accepts ``"batched"`` (default, flushes on the PING heartbeat,
+    /// roughly every 100 ms — best throughput) or ``"immediate"``
+    /// (flushes after every wire write — lowest latency, higher
+    /// per-frame syscall cost).
+    #[setter]
+    fn set_flush_mode(&self, mode: &str) -> PyResult<()> {
+        let parsed = config::StreamingFlushMode::parse(mode).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "flush_mode must be \"batched\" or \"immediate\"; got {mode:?}"
+            ))
+        })?;
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.flush_mode = parsed;
+        Ok(())
+    }
+
+    /// Current streaming write-flush policy (``"batched"`` or
+    /// ``"immediate"``).
+    #[getter]
+    fn get_flush_mode(&self) -> &'static str {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.flush_mode.as_str()
+    }
+
+    /// Set the streaming event-ring consumer wait strategy — the
+    /// latency-vs-CPU knob applied on each ring-empty poll.
+    ///
+    /// Accepts ``"low_latency"`` (default, never sleeps — lowest
+    /// latency, highest idle CPU), ``"balanced"`` (brief park — low idle
+    /// CPU), ``"efficient"`` (longer park — lowest idle CPU), or
+    /// ``"busy_spin"`` (pure spin — pins a core). Tune the individual
+    /// spin / yield / park counts via ``wait_spin_iters`` /
+    /// ``wait_yield_iters`` / ``wait_park_us``.
+    #[setter]
+    fn set_wait_strategy(&self, strategy: &str) -> PyResult<()> {
+        let parsed = config::StreamingWaitStrategy::parse(strategy).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "wait_strategy must be \"low_latency\", \"balanced\", \"efficient\", or \"busy_spin\"; got {strategy:?}"
+            ))
+        })?;
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.wait_strategy = parsed;
+        Ok(())
+    }
+
+    /// Current streaming wait strategy (``"low_latency"``,
+    /// ``"balanced"``, ``"efficient"``, or ``"busy_spin"``).
+    #[getter]
+    fn get_wait_strategy(&self) -> &'static str {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.wait_strategy.as_str()
+    }
+
+    /// Set the jitter strategy applied to every reconnect delay.
+    /// Accepts ``"full"`` (default), ``"equal"``, ``"decorrelated"``,
+    /// or ``"none"`` (case-insensitive).
+    #[setter]
+    fn set_reconnect_jitter(&self, mode: &str) -> PyResult<()> {
+        let parsed = config::JitterMode::parse(mode).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "unknown reconnect_jitter: {mode:?} (expected \"full\", \"equal\", \"decorrelated\", or \"none\")"
+            ))
+        })?;
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.reconnect.jitter = parsed;
+        Ok(())
+    }
+
+    /// Current reconnect jitter mode as a lowercase string.
+    #[getter]
+    fn get_reconnect_jitter(&self) -> &'static str {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.reconnect.jitter.as_str()
+    }
+
+    /// Set the streaming host-selection policy. Accepts ``"shuffled"``
+    /// (default — fault-domain-aware per-client shuffle) or
+    /// ``"fixed_order"`` (declared order verbatim), case-insensitive.
+    #[setter]
+    fn set_streaming_host_selection(&self, policy: &str) -> PyResult<()> {
+        let parsed = config::HostSelectionPolicy::parse(policy).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "unknown streaming_host_selection: {policy:?} (expected \"shuffled\" or \"fixed_order\")"
+            ))
+        })?;
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.host_selection = parsed;
+        Ok(())
+    }
+
+    /// Current streaming host-selection policy as a lowercase string.
+    #[getter]
+    fn get_streaming_host_selection(&self) -> &'static str {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.host_selection.as_str()
+    }
+
+    /// Set the Prometheus exporter port. ``None`` (the default) keeps
+    /// the exporter disabled; an ``int`` binds an HTTP listener whose
+    /// ``/metrics`` endpoint exposes every counter and histogram.
+    ///
+    /// Raises ``ValueError`` if the value is outside the ``u16`` range
+    /// (``0..=65535``).
+    #[setter]
+    fn set_metrics_port(&self, port: Option<u32>) -> PyResult<()> {
+        let resolved = match port {
+            Some(v) => Some(u16::try_from(v).map_err(|_| {
+                PyValueError::new_err(format!("metrics_port must be in 0..=65535; got {v}"))
+            })?),
+            None => None,
+        };
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.metrics.port = resolved;
+        Ok(())
+    }
+
+    /// Current ``metrics.port`` setting. ``None`` means the exporter is
+    /// disabled; an ``int`` is the bound port.
+    #[getter]
+    fn get_metrics_port(&self) -> Option<u16> {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.metrics.port
+    }
+
+    /// Set the streaming host-shuffle seed. ``None`` (default) derives a
+    /// fresh per-client seed so a fleet shuffles independently; an
+    /// explicit value makes the shuffled order deterministic — useful
+    /// for fleet sharding and tests. Ignored under ``"fixed_order"``.
+    #[setter]
+    fn set_streaming_host_shuffle_seed(&self, seed: Option<u64>) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.host_shuffle_seed = seed;
+    }
+
+    /// Current ``streaming.host_shuffle_seed`` value (``None`` = per-client
+    /// entropy).
+    #[getter]
+    fn get_streaming_host_shuffle_seed(&self) -> Option<u64> {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.streaming.host_shuffle_seed
+    }
+
 }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -364,28 +364,6 @@ impl Config {
         }
     }
 
-    /// Set the jitter strategy applied to every reconnect delay.
-    /// Accepts ``"full"`` (default), ``"equal"``, ``"decorrelated"``,
-    /// or ``"none"`` (case-insensitive).
-    #[setter]
-    fn set_reconnect_jitter(&self, mode: &str) -> PyResult<()> {
-        let parsed = config::JitterMode::parse(mode).ok_or_else(|| {
-            PyValueError::new_err(format!(
-                "unknown reconnect_jitter: {mode:?} (expected \"full\", \"equal\", \"decorrelated\", or \"none\")"
-            ))
-        })?;
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.reconnect.jitter = parsed;
-        Ok(())
-    }
-
-    /// Current reconnect jitter mode as a lowercase string.
-    #[getter]
-    fn get_reconnect_jitter(&self) -> &'static str {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.reconnect.jitter.as_str()
-    }
-
     /// Install a custom reconnect policy driven by a Python callable.
     ///
     /// ``callback(reason: int, attempt: int)`` is invoked on the
@@ -453,46 +431,6 @@ impl Config {
         guard.streaming.ring_size = n;
     }
 
-    /// Set the streaming host-selection policy. Accepts ``"shuffled"``
-    /// (default — fault-domain-aware per-client shuffle) or
-    /// ``"fixed_order"`` (declared order verbatim), case-insensitive.
-    #[setter]
-    fn set_streaming_host_selection(&self, policy: &str) -> PyResult<()> {
-        let parsed = config::HostSelectionPolicy::parse(policy).ok_or_else(|| {
-            PyValueError::new_err(format!(
-                "unknown streaming_host_selection: {policy:?} (expected \"shuffled\" or \"fixed_order\")"
-            ))
-        })?;
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.host_selection = parsed;
-        Ok(())
-    }
-
-    /// Current streaming host-selection policy as a lowercase string.
-    #[getter]
-    fn get_streaming_host_selection(&self) -> &'static str {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.host_selection.as_str()
-    }
-
-    /// Set the streaming host-shuffle seed. ``None`` (default) derives a
-    /// fresh per-client seed so a fleet shuffles independently; an
-    /// explicit value makes the shuffled order deterministic — useful
-    /// for fleet sharding and tests. Ignored under ``"fixed_order"``.
-    #[setter]
-    fn set_streaming_host_shuffle_seed(&self, seed: Option<u64>) {
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.host_shuffle_seed = seed;
-    }
-
-    /// Current ``streaming.host_shuffle_seed`` value (``None`` = per-client
-    /// entropy).
-    #[getter]
-    fn get_streaming_host_shuffle_seed(&self) -> Option<u64> {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.host_shuffle_seed
-    }
-
     /// Set the async worker-thread count for embedded bindings that own
     /// their runtime (Python / FFI / napi). ``None`` (the default)
     /// defers to the default sizing (one worker per logical CPU);
@@ -523,73 +461,10 @@ impl Config {
     // ``client_type``) are the generated ``ms`` / ``string`` accessors in
     // config_surface.toml.
 
-    // ── MetricsConfig field setter/getter ─────────────────────────────
-    //
-    // ``DirectConfig.metrics.port`` is ``Optional[int]``. ``None``
-    // (the default) leaves the Prometheus exporter disabled even when
-    // the ``metrics-prometheus`` cargo feature is compiled in; an
-    // ``int`` binds the exporter on ``0.0.0.0:<port>``.
-
-    /// Set the Prometheus exporter port. ``None`` (the default) keeps
-    /// the exporter disabled; an ``int`` binds an HTTP listener whose
-    /// ``/metrics`` endpoint exposes every counter and histogram.
-    ///
-    /// Raises ``ValueError`` if the value is outside the ``u16`` range
-    /// (``0..=65535``).
-    #[setter]
-    fn set_metrics_port(&self, port: Option<u32>) -> PyResult<()> {
-        let resolved = match port {
-            Some(v) => Some(u16::try_from(v).map_err(|_| {
-                PyValueError::new_err(format!("metrics_port must be in 0..=65535; got {v}"))
-            })?),
-            None => None,
-        };
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.metrics.port = resolved;
-        Ok(())
-    }
-
-    /// Current ``metrics.port`` setting. ``None`` means the exporter is
-    /// disabled; an ``int`` is the bound port.
-    #[getter]
-    fn get_metrics_port(&self) -> Option<u16> {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.metrics.port
-    }
-
-    /// Set the streaming write-flush policy.
-    ///
-    /// Accepts ``"batched"`` (default, flushes on the PING heartbeat,
-    /// roughly every 100 ms — best throughput) or ``"immediate"``
-    /// (flushes after every wire write — lowest latency, higher
-    /// per-frame syscall cost).
-    #[setter]
-    fn set_flush_mode(&self, mode: &str) -> pyo3::PyResult<()> {
-        let parsed = match mode.to_ascii_lowercase().as_str() {
-            "batched" => config::StreamingFlushMode::Batched,
-            "immediate" => config::StreamingFlushMode::Immediate,
-            other => {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "flush_mode must be \"batched\" or \"immediate\"; got {other:?}"
-                )));
-            }
-        };
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.flush_mode = parsed;
-        Ok(())
-    }
-
-    /// Current streaming write-flush policy (``"batched"`` or
-    /// ``"immediate"``).
-    #[getter]
-    fn get_flush_mode(&self) -> &'static str {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        match guard.streaming.flush_mode {
-            config::StreamingFlushMode::Batched => "batched",
-            config::StreamingFlushMode::Immediate => "immediate",
-            _ => "unknown",
-        }
-    }
+    // ``DirectConfig.metrics.port`` (``Optional[int]``, exporter port),
+    // the ``streaming.flush_mode`` / ``wait_strategy`` enums, and the
+    // ``reconnect.jitter`` / ``streaming.host_selection`` enums are the
+    // generated ``enum`` / ``option`` accessors in config_surface.toml.
 
     /// Target historical environment carried by this configuration:
     /// ``"PROD"`` for the production cluster or ``"STAGE"`` for staging.
@@ -617,36 +492,6 @@ impl Config {
     fn get_streaming_environment(&self) -> &'static str {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.streaming_environment().as_str()
-    }
-
-    /// Set the streaming event-ring consumer wait strategy — the
-    /// latency-vs-CPU knob applied on each ring-empty poll.
-    ///
-    /// Accepts ``"low_latency"`` (default, never sleeps — lowest
-    /// latency, highest idle CPU), ``"balanced"`` (brief park — low idle
-    /// CPU), ``"efficient"`` (longer park — lowest idle CPU), or
-    /// ``"busy_spin"`` (pure spin — pins a core). Tune the individual
-    /// spin / yield / park counts via ``wait_spin_iters`` /
-    /// ``wait_yield_iters`` / ``wait_park_us``.
-    #[setter]
-    fn set_wait_strategy(&self, strategy: &str) -> pyo3::PyResult<()> {
-        let parsed = config::StreamingWaitStrategy::parse(strategy).ok_or_else(|| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "wait_strategy must be \"low_latency\", \"balanced\", \"efficient\", \
-                 or \"busy_spin\"; got {strategy:?}"
-            ))
-        })?;
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.wait_strategy = parsed;
-        Ok(())
-    }
-
-    /// Current streaming wait strategy (``"low_latency"``,
-    /// ``"balanced"``, ``"efficient"``, or ``"busy_spin"``).
-    #[getter]
-    fn get_wait_strategy(&self) -> &'static str {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.streaming.wait_strategy.as_str()
     }
 
     /// Spin iterations the wait strategy busy-waits before yielding /

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -138,14 +138,6 @@ export declare class Config {
    */
   setReconnectPolicy(policy: string): void
   /**
-   * Set the jitter strategy applied to every reconnect delay.
-   * Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
-   * `"none"` (case-insensitive).
-   */
-  setReconnectJitter(mode: string): void
-  /** Current reconnect jitter mode as a lowercase string. */
-  get reconnectJitter(): string
-  /**
    * Current reconnect policy as a string (`"auto"`, `"manual"`, or
    * `"custom"`).
    */
@@ -177,27 +169,6 @@ export declare class Config {
    */
   setStreamingRingSize(n: bigint): void
   /**
-   * Set the streaming host-selection policy. Accepts `"shuffled"`
-   * (default — fault-domain-aware per-client shuffle) or
-   * `"fixed_order"` (declared order verbatim), case-insensitive.
-   */
-  setStreamingHostSelection(policy: string): void
-  /** Current streaming host-selection policy as a lowercase string. */
-  get streamingHostSelection(): string
-  /**
-   * Set the streaming host-shuffle seed. `null` (default) derives a
-   * fresh per-client seed so a fleet shuffles independently; an
-   * explicit `bigint` makes the shuffled order deterministic —
-   * useful for fleet sharding and tests. Ignored under
-   * `"fixed_order"`.
-   */
-  setStreamingHostShuffleSeed(seed?: bigint | undefined | null): void
-  /**
-   * Current `streaming.host_shuffle_seed` value (`null` = per-client
-   * entropy).
-   */
-  get streamingHostShuffleSeed(): bigint | null
-  /**
    * Set the async worker-thread count for embedded runtimes.
    * `hasValue=false` defers to the default sizing; `hasValue=true`
    * pins worker count to `n` (with `n=0` preserved verbatim rather
@@ -215,34 +186,6 @@ export declare class Config {
    * `hasValue=false` encodes the unset (auto) sentinel.
    */
   get workerThreads(): WorkerThreadsSetting
-  /**
-   * Set the Prometheus exporter port. Pass `null` or `undefined`
-   * to leave the exporter disabled (the default); pass a
-   * `number` to bind an HTTP listener on `0.0.0.0:<port>` when the
-   * `metrics-prometheus` feature is compiled in.
-   *
-   * Rejects values outside the `0..=65535` port range.
-   */
-  setMetricsPort(port?: number | undefined | null): void
-  /**
-   * Current `metrics.port` setting. `null` means the exporter is
-   * disabled; a `number` is the bound port.
-   */
-  get metricsPort(): number | null
-  /**
-   * Set the streaming write-flush policy.
-   *
-   * Accepts `"batched"` (default — flushes on the PING heartbeat,
-   * roughly every 100 ms — best throughput) or `"immediate"`
-   * (flushes after every wire write — lowest latency, higher
-   * per-frame syscall cost).
-   */
-  setFlushMode(mode: string): void
-  /**
-   * Current streaming write-flush policy (`"batched"` or
-   * `"immediate"`).
-   */
-  get flushMode(): string
   /**
    * Target historical environment carried by this configuration:
    * `"PROD"` for the production cluster or `"STAGE"` for staging. The
@@ -263,22 +206,6 @@ export declare class Config {
    * `streamingType` string the inline `Client.connectWith` factory accepts.
    */
   get streamingEnvironment(): string
-  /**
-   * Set the streaming event-ring consumer wait strategy — the
-   * latency-vs-CPU knob applied on each ring-empty poll.
-   *
-   * Accepts `"low_latency"` (default — never sleeps, lowest latency,
-   * highest idle CPU), `"balanced"` (brief park — low idle CPU),
-   * `"efficient"` (longer park — lowest idle CPU), or `"busy_spin"`
-   * (pure spin — pins a core). Tune the spin / yield / park counts via
-   * `setWaitSpinIters` / `setWaitYieldIters` / `setWaitParkUs`.
-   */
-  setWaitStrategy(strategy: string): void
-  /**
-   * Current streaming wait strategy (`"low_latency"`, `"balanced"`,
-   * `"efficient"`, or `"busy_spin"`).
-   */
-  get waitStrategy(): string
   /** Set the wait-strategy spin iteration count. */
   setWaitSpinIters(iters: number): void
   /** Current wait-strategy spin iteration count. */
@@ -642,6 +569,79 @@ export declare class Config {
   setHistoricalHost(host: string): void
   /** Current historical gRPC host. */
   get historicalHost(): string
+  /**
+   * Set the streaming write-flush policy.
+   *
+   * Accepts `"batched"` (default — flushes on the PING heartbeat,
+   * roughly every 100 ms — best throughput) or `"immediate"`
+   * (flushes after every wire write — lowest latency, higher
+   * per-frame syscall cost).
+   */
+  setFlushMode(mode: string): void
+  /**
+   * Current streaming write-flush policy (`"batched"` or
+   * `"immediate"`).
+   */
+  get flushMode(): string
+  /**
+   * Set the streaming event-ring consumer wait strategy — the
+   * latency-vs-CPU knob applied on each ring-empty poll.
+   *
+   * Accepts `"low_latency"` (default — never sleeps, lowest latency,
+   * highest idle CPU), `"balanced"` (brief park — low idle CPU),
+   * `"efficient"` (longer park — lowest idle CPU), or `"busy_spin"`
+   * (pure spin — pins a core). Tune the spin / yield / park counts via
+   * `setWaitSpinIters` / `setWaitYieldIters` / `setWaitParkUs`.
+   */
+  setWaitStrategy(strategy: string): void
+  /**
+   * Current streaming wait strategy (`"low_latency"`, `"balanced"`,
+   * `"efficient"`, or `"busy_spin"`).
+   */
+  get waitStrategy(): string
+  /**
+   * Set the jitter strategy applied to every reconnect delay.
+   * Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
+   * `"none"` (case-insensitive).
+   */
+  setReconnectJitter(mode: string): void
+  /** Current reconnect jitter mode as a lowercase string. */
+  get reconnectJitter(): string
+  /**
+   * Set the streaming host-selection policy. Accepts `"shuffled"`
+   * (default — fault-domain-aware per-client shuffle) or
+   * `"fixed_order"` (declared order verbatim), case-insensitive.
+   */
+  setStreamingHostSelection(policy: string): void
+  /** Current streaming host-selection policy as a lowercase string. */
+  get streamingHostSelection(): string
+  /**
+   * Set the Prometheus exporter port. Pass `null` or `undefined`
+   * to leave the exporter disabled (the default); pass a
+   * `number` to bind an HTTP listener on `0.0.0.0:<port>` when the
+   * `metrics-prometheus` feature is compiled in.
+   *
+   * Rejects values outside the `0..=65535` port range.
+   */
+  setMetricsPort(port?: number | undefined | null): void
+  /**
+   * Current `metrics.port` setting. `null` means the exporter is
+   * disabled; a `number` is the bound port.
+   */
+  get metricsPort(): number | null
+  /**
+   * Set the streaming host-shuffle seed. `null` (default) derives a
+   * fresh per-client seed so a fleet shuffles independently; an
+   * explicit `bigint` makes the shuffled order deterministic —
+   * useful for fleet sharding and tests. Ignored under
+   * `"fixed_order"`.
+   */
+  setStreamingHostShuffleSeed(seed?: bigint | undefined | null): void
+  /**
+   * Current `streaming.host_shuffle_seed` value (`null` = per-client
+   * entropy).
+   */
+  get streamingHostShuffleSeed(): bigint | null
 }
 
 /**

--- a/sdks/typescript/src/_generated/config_accessors.rs
+++ b/sdks/typescript/src/_generated/config_accessors.rs
@@ -955,4 +955,196 @@ impl Config {
         Ok(guard.historical_host().to_string())
     }
 
+    /// Set the streaming write-flush policy.
+    ///
+    /// Accepts `"batched"` (default — flushes on the PING heartbeat,
+    /// roughly every 100 ms — best throughput) or `"immediate"`
+    /// (flushes after every wire write — lowest latency, higher
+    /// per-frame syscall cost).
+    #[napi(js_name = "setFlushMode")]
+    pub fn set_flush_mode(&self, mode: String) -> napi::Result<()> {
+        let parsed = config::StreamingFlushMode::parse(&mode).ok_or_else(|| {
+            crate::invalid_parameter_err(format!(
+                "setFlushMode: mode must be \"batched\" or \"immediate\"; got {mode:?}"
+            ))
+        })?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.streaming.flush_mode = parsed;
+        Ok(())
+    }
+
+    /// Current streaming write-flush policy (`"batched"` or
+    /// `"immediate"`).
+    #[napi(getter, js_name = "flushMode")]
+    pub fn flush_mode(&self) -> napi::Result<&'static str> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.streaming.flush_mode.as_str())
+    }
+
+    /// Set the streaming event-ring consumer wait strategy — the
+    /// latency-vs-CPU knob applied on each ring-empty poll.
+    ///
+    /// Accepts `"low_latency"` (default — never sleeps, lowest latency,
+    /// highest idle CPU), `"balanced"` (brief park — low idle CPU),
+    /// `"efficient"` (longer park — lowest idle CPU), or `"busy_spin"`
+    /// (pure spin — pins a core). Tune the spin / yield / park counts via
+    /// `setWaitSpinIters` / `setWaitYieldIters` / `setWaitParkUs`.
+    #[napi(js_name = "setWaitStrategy")]
+    pub fn set_wait_strategy(&self, strategy: String) -> napi::Result<()> {
+        let parsed = config::StreamingWaitStrategy::parse(&strategy).ok_or_else(|| {
+            crate::invalid_parameter_err(format!(
+                "setWaitStrategy: strategy must be \"low_latency\", \"balanced\", \"efficient\", or \"busy_spin\"; got {strategy:?}"
+            ))
+        })?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.streaming.wait_strategy = parsed;
+        Ok(())
+    }
+
+    /// Current streaming wait strategy (`"low_latency"`, `"balanced"`,
+    /// `"efficient"`, or `"busy_spin"`).
+    #[napi(getter, js_name = "waitStrategy")]
+    pub fn wait_strategy(&self) -> napi::Result<&'static str> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.streaming.wait_strategy.as_str())
+    }
+
+    /// Set the jitter strategy applied to every reconnect delay.
+    /// Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
+    /// `"none"` (case-insensitive).
+    #[napi(js_name = "setReconnectJitter")]
+    pub fn set_reconnect_jitter(&self, mode: String) -> napi::Result<()> {
+        let parsed = config::JitterMode::parse(&mode).ok_or_else(|| {
+            crate::invalid_parameter_err(format!(
+                "setReconnectJitter: unknown mode {mode:?}; expected \"full\", \"equal\", \"decorrelated\", or \"none\""
+            ))
+        })?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.reconnect.jitter = parsed;
+        Ok(())
+    }
+
+    /// Current reconnect jitter mode as a lowercase string.
+    #[napi(getter, js_name = "reconnectJitter")]
+    pub fn reconnect_jitter(&self) -> napi::Result<&'static str> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.reconnect.jitter.as_str())
+    }
+
+    /// Set the streaming host-selection policy. Accepts `"shuffled"`
+    /// (default — fault-domain-aware per-client shuffle) or
+    /// `"fixed_order"` (declared order verbatim), case-insensitive.
+    #[napi(js_name = "setStreamingHostSelection")]
+    pub fn set_streaming_host_selection(&self, policy: String) -> napi::Result<()> {
+        let parsed = config::HostSelectionPolicy::parse(&policy).ok_or_else(|| {
+            crate::invalid_parameter_err(format!(
+                "setStreamingHostSelection: unknown policy {policy:?}; expected \"shuffled\" or \"fixed_order\""
+            ))
+        })?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.streaming.host_selection = parsed;
+        Ok(())
+    }
+
+    /// Current streaming host-selection policy as a lowercase string.
+    #[napi(getter, js_name = "streamingHostSelection")]
+    pub fn streaming_host_selection(&self) -> napi::Result<&'static str> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.streaming.host_selection.as_str())
+    }
+
+    /// Set the Prometheus exporter port. Pass `null` or `undefined`
+    /// to leave the exporter disabled (the default); pass a
+    /// `number` to bind an HTTP listener on `0.0.0.0:<port>` when the
+    /// `metrics-prometheus` feature is compiled in.
+    ///
+    /// Rejects values outside the `0..=65535` port range.
+    #[napi(js_name = "setMetricsPort")]
+    pub fn set_metrics_port(&self, port: Option<u32>) -> napi::Result<()> {
+        let resolved = match port {
+            Some(v) => Some(u16::try_from(v).map_err(|_| {
+                crate::invalid_parameter_err(format!(
+                    "setMetricsPort: port must be in 0..=65535; got {v}"
+                ))
+            })?),
+            None => None,
+        };
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.metrics.port = resolved;
+        Ok(())
+    }
+
+    /// Current `metrics.port` setting. `null` means the exporter is
+    /// disabled; a `number` is the bound port.
+    #[napi(getter, js_name = "metricsPort")]
+    pub fn metrics_port(&self) -> napi::Result<Option<u32>> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.metrics.port.map(u32::from))
+    }
+
+    /// Set the streaming host-shuffle seed. `null` (default) derives a
+    /// fresh per-client seed so a fleet shuffles independently; an
+    /// explicit `bigint` makes the shuffled order deterministic —
+    /// useful for fleet sharding and tests. Ignored under
+    /// `"fixed_order"`.
+    #[napi(js_name = "setStreamingHostShuffleSeed")]
+    pub fn set_streaming_host_shuffle_seed(
+        &self,
+        seed: Option<napi::bindgen_prelude::BigInt>,
+    ) -> napi::Result<()> {
+        let resolved = match seed {
+            Some(v) => Some(bigint_to_u64("setStreamingHostShuffleSeed", &v)?),
+            None => None,
+        };
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.streaming.host_shuffle_seed = resolved;
+        Ok(())
+    }
+
+    /// Current `streaming.host_shuffle_seed` value (`null` = per-client
+    /// entropy).
+    #[napi(getter, js_name = "streamingHostShuffleSeed")]
+    pub fn streaming_host_shuffle_seed(
+        &self,
+    ) -> napi::Result<Option<napi::bindgen_prelude::BigInt>> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.streaming.host_shuffle_seed.map(napi::bindgen_prelude::BigInt::from))
+    }
+
 }

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -149,34 +149,6 @@ impl Config {
         Ok(())
     }
 
-    /// Set the jitter strategy applied to every reconnect delay.
-    /// Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
-    /// `"none"` (case-insensitive).
-    #[napi(js_name = "setReconnectJitter")]
-    pub fn set_reconnect_jitter(&self, mode: String) -> napi::Result<()> {
-        let parsed = config::JitterMode::parse(&mode).ok_or_else(|| {
-            crate::invalid_parameter_err(format!(
-                "setReconnectJitter: unknown mode {mode:?}; expected \"full\", \"equal\", \"decorrelated\", or \"none\""
-            ))
-        })?;
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.reconnect.jitter = parsed;
-        Ok(())
-    }
-
-    /// Current reconnect jitter mode as a lowercase string.
-    #[napi(getter, js_name = "reconnectJitter")]
-    pub fn reconnect_jitter(&self) -> napi::Result<&'static str> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(guard.reconnect.jitter.as_str())
-    }
-
     /// Current reconnect policy as a string (`"auto"`, `"manual"`, or
     /// `"custom"`).
     #[napi(getter, js_name = "reconnectPolicy")]
@@ -298,72 +270,6 @@ impl Config {
         Ok(())
     }
 
-    /// Set the streaming host-selection policy. Accepts `"shuffled"`
-    /// (default — fault-domain-aware per-client shuffle) or
-    /// `"fixed_order"` (declared order verbatim), case-insensitive.
-    #[napi(js_name = "setStreamingHostSelection")]
-    pub fn set_streaming_host_selection(&self, policy: String) -> napi::Result<()> {
-        let parsed = config::HostSelectionPolicy::parse(&policy).ok_or_else(|| {
-            crate::invalid_parameter_err(format!(
-                "setStreamingHostSelection: unknown policy {policy:?}; expected \"shuffled\" or \"fixed_order\""
-            ))
-        })?;
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.streaming.host_selection = parsed;
-        Ok(())
-    }
-
-    /// Current streaming host-selection policy as a lowercase string.
-    #[napi(getter, js_name = "streamingHostSelection")]
-    pub fn streaming_host_selection(&self) -> napi::Result<&'static str> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(guard.streaming.host_selection.as_str())
-    }
-
-    /// Set the streaming host-shuffle seed. `null` (default) derives a
-    /// fresh per-client seed so a fleet shuffles independently; an
-    /// explicit `bigint` makes the shuffled order deterministic —
-    /// useful for fleet sharding and tests. Ignored under
-    /// `"fixed_order"`.
-    #[napi(js_name = "setStreamingHostShuffleSeed")]
-    pub fn set_streaming_host_shuffle_seed(
-        &self,
-        seed: Option<napi::bindgen_prelude::BigInt>,
-    ) -> napi::Result<()> {
-        let resolved = match seed {
-            Some(v) => Some(bigint_to_u64("setStreamingHostShuffleSeed", &v)?),
-            None => None,
-        };
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.streaming.host_shuffle_seed = resolved;
-        Ok(())
-    }
-
-    /// Current `streaming.host_shuffle_seed` value (`null` = per-client
-    /// entropy).
-    #[napi(getter, js_name = "streamingHostShuffleSeed")]
-    pub fn streaming_host_shuffle_seed(
-        &self,
-    ) -> napi::Result<Option<napi::bindgen_prelude::BigInt>> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(guard
-            .streaming
-            .host_shuffle_seed
-            .map(napi::bindgen_prelude::BigInt::from))
-    }
-
     /// Set the async worker-thread count for embedded runtimes.
     /// `hasValue=false` defers to the default sizing; `hasValue=true`
     /// pins worker count to `n` (with `n=0` preserved verbatim rather
@@ -409,82 +315,10 @@ impl Config {
     // `historical_host` string accessor are generated from
     // config_surface.toml (the `ms` / `string` carve-out kinds).
 
-    // ── MetricsConfig field setter/getter ─────────────────────────
-
-    /// Set the Prometheus exporter port. Pass `null` or `undefined`
-    /// to leave the exporter disabled (the default); pass a
-    /// `number` to bind an HTTP listener on `0.0.0.0:<port>` when the
-    /// `metrics-prometheus` feature is compiled in.
-    ///
-    /// Rejects values outside the `0..=65535` port range.
-    #[napi(js_name = "setMetricsPort")]
-    pub fn set_metrics_port(&self, port: Option<u32>) -> napi::Result<()> {
-        let resolved = match port {
-            Some(v) => Some(u16::try_from(v).map_err(|_| {
-                crate::invalid_parameter_err(format!(
-                    "setMetricsPort: port must be in 0..=65535; got {v}"
-                ))
-            })?),
-            None => None,
-        };
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.metrics.port = resolved;
-        Ok(())
-    }
-
-    /// Current `metrics.port` setting. `null` means the exporter is
-    /// disabled; a `number` is the bound port.
-    #[napi(getter, js_name = "metricsPort")]
-    pub fn metrics_port(&self) -> napi::Result<Option<u32>> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(guard.metrics.port.map(u32::from))
-    }
-
-    /// Set the streaming write-flush policy.
-    ///
-    /// Accepts `"batched"` (default — flushes on the PING heartbeat,
-    /// roughly every 100 ms — best throughput) or `"immediate"`
-    /// (flushes after every wire write — lowest latency, higher
-    /// per-frame syscall cost).
-    #[napi(js_name = "setFlushMode")]
-    pub fn set_flush_mode(&self, mode: String) -> napi::Result<()> {
-        let parsed = match mode.to_ascii_lowercase().as_str() {
-            "batched" => config::StreamingFlushMode::Batched,
-            "immediate" => config::StreamingFlushMode::Immediate,
-            other => {
-                return Err(crate::invalid_parameter_err(format!(
-                    "setFlushMode: mode must be \"batched\" or \"immediate\"; got {other:?}"
-                )));
-            }
-        };
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.streaming.flush_mode = parsed;
-        Ok(())
-    }
-
-    /// Current streaming write-flush policy (`"batched"` or
-    /// `"immediate"`).
-    #[napi(getter, js_name = "flushMode")]
-    pub fn flush_mode(&self) -> napi::Result<&'static str> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(match guard.streaming.flush_mode {
-            config::StreamingFlushMode::Batched => "batched",
-            config::StreamingFlushMode::Immediate => "immediate",
-            _ => "unknown",
-        })
-    }
+    // `metrics.port` (`Option<number>` exporter port), the
+    // `streaming.flushMode` / `waitStrategy` enums, and the
+    // `reconnectJitter` / `streamingHostSelection` enums are the
+    // generated `enum` / `option` accessors from config_surface.toml.
 
     /// Target historical environment carried by this configuration:
     /// `"PROD"` for the production cluster or `"STAGE"` for staging. The
@@ -516,41 +350,6 @@ impl Config {
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         Ok(guard.streaming_environment().as_str())
-    }
-
-    /// Set the streaming event-ring consumer wait strategy — the
-    /// latency-vs-CPU knob applied on each ring-empty poll.
-    ///
-    /// Accepts `"low_latency"` (default — never sleeps, lowest latency,
-    /// highest idle CPU), `"balanced"` (brief park — low idle CPU),
-    /// `"efficient"` (longer park — lowest idle CPU), or `"busy_spin"`
-    /// (pure spin — pins a core). Tune the spin / yield / park counts via
-    /// `setWaitSpinIters` / `setWaitYieldIters` / `setWaitParkUs`.
-    #[napi(js_name = "setWaitStrategy")]
-    pub fn set_wait_strategy(&self, strategy: String) -> napi::Result<()> {
-        let parsed = config::StreamingWaitStrategy::parse(&strategy).ok_or_else(|| {
-            crate::invalid_parameter_err(format!(
-                "setWaitStrategy: strategy must be \"low_latency\", \"balanced\", \
-                 \"efficient\", or \"busy_spin\"; got {strategy:?}"
-            ))
-        })?;
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.streaming.wait_strategy = parsed;
-        Ok(())
-    }
-
-    /// Current streaming wait strategy (`"low_latency"`, `"balanced"`,
-    /// `"efficient"`, or `"busy_spin"`).
-    #[napi(getter, js_name = "waitStrategy")]
-    pub fn wait_strategy(&self) -> napi::Result<&'static str> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(guard.streaming.wait_strategy.as_str())
     }
 
     /// Set the wait-strategy spin iteration count.


### PR DESCRIPTION
Finishes the config-accessor SSOT by adding two emitter kinds a review proved templatable, replacing the last hand-written config accessors that a single reusable template (driven purely by TOML data) can produce.

## The two kinds

`kind="enum"` — the four plain string↔variant bijection enums (`flush_mode`, `wait_strategy`, `reconnect_jitter`, `host_selection`). A `[[accessor.variant]]` table carries the `int` code, the Rust variant, and the lowercase label. One render arm per binding emits that binding's shape from the same variant table: FFI `match int { N => Variant, _ => typed error }` set and `match variant { Variant => N }` get; C++ int passthrough; Python/TypeScript the lowercase string via the core enum's `parse` / `as_str`.

`kind="option"` — the two plain `(has_value, N)`↔`Option<T>` accessors (`metrics_port` as `u16`, `streaming_host_shuffle_seed` as `u64`). FFI carries the widened `(has_value, value)` shape; C++ wraps `std::optional<T>`; the TypeScript arm switches on `abi_type` to pick `number` vs `BigInt`, the same switch the scalar arm already runs.

## Drift fixed by construction

The four enums had diverged: the FFI null path used a bare `set_error` on `flush_mode` / `wait_strategy` but the typed `set_error_with_code(... ERR_CONFIG)` on `jitter` / `host_selection`, and Python/TypeScript hand-rolled `flush_mode` inline instead of routing through `parse` / `as_str` like the other three. The generated template is uniform: every enum null-handle path is `set_error_with_code(... ERR_CONFIG)`, every rejected int is `ERR_INVALID_PARAMETER`, and every binding string surface goes through the core enum. `StreamingFlushMode` lacked `parse` / `as_str`, so this adds them (mirroring `JitterMode` / `HostSelectionPolicy` / `StreamingWaitStrategy`); the getter then drops its dead `"unknown"` arm. The two `option` accessors are likewise unified to one `std::optional<T>` C++ template (the host-shuffle-seed setter previously diverged as a raw `(bool, u64) -> int32_t` passthrough).

## Functions collapsed per binding

Each kind is one template across all four bindings: `enum` collapses 4 FFI + 4 C++ + 4 Python + 4 TypeScript hand-written setter/getter pairs into one render arm apiece, and `option` collapses 2 of each. Twelve hand-written FFI symbols, twelve C++ methods, and the matching Python `#[pymethods]` / TypeScript `#[napi]` accessors are deleted and regenerated from `config_surface.toml`.

## Kept hand-written

The genuine singletons a template could only express with per-field branching stay hand-written: `reconnect_policy` (data-carrying `Auto(limits)` / `Custom(callback)`, asymmetric set/get), `worker_threads` (unique JS struct), `streaming_ring_size` (power-of-two validation), `consumer_cpu` (`-1` sentinel), `reconnect_callback` (trampoline), and the two `*_environment` label getters.

## Per-binding API identity

The public surface is byte-identical per binding. FFI: the twelve `#[no_mangle]` symbols and signatures relocate from `ffi/src/auth.rs` to the generated `ffi/src/config_accessors.rs` with zero set delta (`check_c_abi_completeness` clean, 342 symbols bidirectional). C++: same method set, same names and effective signatures, spliced through `config_accessors.hpp.inc` into the same `Config` class body. Python `.pyi`: stubtest passes with no issues (the hand-written stub still matches the runtime). TypeScript `index.d.ts`: a pure reorder — sorting both before and after yields identical line multisets (73 lines moved, 0 added or removed). Generated bodies are behavior-identical to the deleted ones (same error messages, same mappings; the unreachable enum `_` fallthrough folds to the last variant for `#[non_exhaustive]` coverage).

## Gates

`cargo check -p thetadatadx` (default / `__test-helpers` / `arrow,polars,frames,config-file`), Python maturin build, TypeScript napi build with `index.d.ts` reorder-only, C++ test target build, `check_binding_parity.py`, `check_doc_defaults.py`, `generate_sdk_surfaces --check`, `generate_docs_site --check`, `.pyi` stubtest, `clippy --workspace --all-targets --locked -D warnings` (plus both binding workspaces), `cargo doc --no-deps --workspace --locked`, `cargo fmt --check`, `check_c_abi_completeness.py`, and the test suites (core lib 1018, FFI, Python 462, TypeScript 202, C++ 68 offline) all pass. No new `#[allow]`. Additions to `sdk_render/` are append-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)