### PR TITLE
refactor: final binding dedups + forwarder guard + server fmt

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
@@ -651,7 +651,7 @@ fn napi_field_camel(snake: &str) -> String {
 fn ts_napi_optional_type(param: &super::super::model::GeneratedParam) -> &'static str {
     match param.param_type.as_str() {
         // `Int` filters ride in as a JS `number` (f64) and are validated +
-        // narrowed to `i32` in the method body via `validate_nonneg_i32`,
+        // narrowed to `i32` in the method body via `validate_optional_nonneg_i32`,
         // rather than typed `i32` here where V8's `ToInt32` would silently
         // wrap a hostile or oversized input instead of rejecting it.
         "Int" => "Option<f64>",

--- a/crates/thetadatadx/build_support_bin/sdk_surface/python.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/python.rs
@@ -5,7 +5,9 @@ use std::fmt::Write as _;
 use super::common::{
     generated_header, greek_result_fields, push_rust_doc_comment, python_field_ident, python_type,
 };
-use super::spec::{ForwardReturn, MethodKind, MethodSpec, UtilityKind, UtilitySpec};
+use super::spec::{
+    assert_forwarder_code_params, ForwardReturn, MethodKind, MethodSpec, UtilityKind, UtilitySpec,
+};
 
 /// Renders the Python streaming methods source: the FPSS method-name inventory const and the `#[pymethods]` block on `Client`.
 pub(super) fn render_python_streaming_methods(methods: &[&MethodSpec]) -> String {
@@ -564,6 +566,7 @@ fn python_utility_function(utility: &UtilitySpec) -> String {
     }
     match utility.kind {
         UtilityKind::Forwarder => {
+            assert_forwarder_code_params(utility);
             let ret = match utility.forward_return.expect("forwarder return validated") {
                 ForwardReturn::Str => "&'static str",
                 ForwardReturn::Bool => "bool",

--- a/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
@@ -449,6 +449,34 @@ fn validate_method_spec(method: &MethodSpec) -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
+/// The single `(code, i32)` parameter shape that every lookup-table
+/// `Forwarder` (and the `CalendarStatusName` helper) takes. Both the
+/// spec validator and the per-language emitters key on this: `validate`
+/// pins a forwarder's declared params to it, and the emitters hardcode
+/// `(code: i32)` in the generated body, so any other shape must fail the
+/// build rather than silently mis-emit.
+pub(super) const FORWARDER_CODE_PARAMS: &[(&str, ParamType)] = &[("code", ParamType::I32)];
+
+/// Assert at emit time that a `Forwarder` utility's params are exactly the
+/// `(code, i32)` shape the emitters hardcode. `validate_spec` already
+/// enforces this, but the emitters bake `(code: i32)` in directly; this
+/// guard makes that assumption self-failing so a future differently-shaped
+/// forwarder panics here instead of emitting a body that ignores its spec.
+pub(super) fn assert_forwarder_code_params(utility: &UtilitySpec) {
+    let ok = utility.params.len() == FORWARDER_CODE_PARAMS.len()
+        && utility
+            .params
+            .iter()
+            .zip(FORWARDER_CODE_PARAMS)
+            .all(|(param, (name, kind))| param.name == *name && param.param_type == *kind);
+    assert!(
+        ok,
+        "forwarder '{}' emits a hardcoded (code: i32) body but declares params {:?}; \
+         only the (code, i32) shape is supported",
+        utility.name, utility.params
+    );
+}
+
 fn validate_utility_spec(utility: &UtilitySpec) -> Result<(), Box<dyn std::error::Error>> {
     if utility.targets.is_empty() {
         return Err(format!(
@@ -495,7 +523,6 @@ fn validate_utility_spec(utility: &UtilitySpec) -> Result<(), Box<dyn std::error
 
     use UtilityTarget::{Cli, Cpp, Mcp, Python, Typescript};
     let greeks_params = offline_greeks_param_layout();
-    const CODE: &[(&str, ParamType)] = &[("code", ParamType::I32)];
     // Forwarders are name-agnostic (the name is the forwarded helper's
     // name); `expected_name = None` skips the fixed-name check below.
     let (expected_name, allowed_targets, exact_targets, params): (
@@ -518,12 +545,12 @@ fn validate_utility_spec(utility: &UtilitySpec) -> Result<(), Box<dyn std::error
             false,
             &greeks_params,
         ),
-        UtilityKind::Forwarder => (None, &[Python, Typescript], true, CODE),
+        UtilityKind::Forwarder => (None, &[Python, Typescript], true, FORWARDER_CODE_PARAMS),
         UtilityKind::CalendarStatusName => (
             Some("calendar_status_name"),
             &[Python, Typescript],
             true,
-            CODE,
+            FORWARDER_CODE_PARAMS,
         ),
         UtilityKind::TimestampMs => (
             Some("timestamp_ms"),

--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -6,7 +6,9 @@ use std::fmt::Write as _;
 use heck::ToLowerCamelCase;
 
 use super::common::{generated_header, greek_result_fields, push_rust_doc_comment, ts_field_ident};
-use super::spec::{ForwardReturn, MethodKind, MethodSpec, UtilityKind, UtilitySpec};
+use super::spec::{
+    assert_forwarder_code_params, ForwardReturn, MethodKind, MethodSpec, UtilityKind, UtilitySpec,
+};
 
 /// Renders the TypeScript streaming methods source: the `#[napi]` block on `StreamView`.
 pub(super) fn render_ts_streaming_methods(methods: &[&MethodSpec]) -> String {
@@ -338,6 +340,7 @@ fn ts_util_method(utility: &UtilitySpec) -> String {
     let js_name = to_ts_camel_case(&utility.name);
     match utility.kind {
         UtilityKind::Forwarder => {
+            assert_forwarder_code_params(utility);
             push_rust_doc_comment(&mut out, "    ", &utility.doc);
             writeln!(out, "    #[napi(js_name = \"{js_name}\")]").unwrap();
             let call = utility

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -2254,17 +2254,16 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         // free-path drain budget; on timeout we surface the error
         // rather than racing.
         if let Some(flag) = prev_drain_flag {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5_000);
-            while !flag.load(std::sync::atomic::Ordering::Acquire) {
-                if std::time::Instant::now() >= deadline {
-                    set_error(
-                        "reconnect drain barrier timed out after 5s — \
-                         previous callback is still in flight; refusing \
-                         to bind the new session to the same ctx",
-                    );
-                    return -1;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(1));
+            if !await_flags(
+                std::slice::from_ref(&flag),
+                std::time::Duration::from_millis(5_000),
+            ) {
+                set_error(
+                    "reconnect drain barrier timed out after 5s — \
+                     previous callback is still in flight; refusing \
+                     to bind the new session to the same ctx",
+                );
+                return -1;
             }
         }
 

--- a/sdks/python/src/bench_streaming.rs
+++ b/sdks/python/src/bench_streaming.rs
@@ -217,7 +217,11 @@ where
 /// one `call1` per delivered event. Returns `(delivered, elapsed_ns)`; the
 /// caller asserts `delivered == n` (zero-drop).
 #[pyfunction]
-pub(crate) fn __bench_flood_events(py: Python<'_>, n: u64, callback: Py<PyAny>) -> PyResult<(u64, u64)> {
+pub(crate) fn __bench_flood_events(
+    py: Python<'_>,
+    n: u64,
+    callback: Py<PyAny>,
+) -> PyResult<(u64, u64)> {
     let dispatch_cb = Arc::new(callback);
     let body = move |evt: &StreamEvent| {
         Python::attach(|py| {

--- a/sdks/python/src/flatfile_methods.rs
+++ b/sdks/python/src/flatfile_methods.rs
@@ -24,7 +24,7 @@
 
 use std::sync::Arc;
 
-use pyo3::exceptions::{PyImportError, PyValueError};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
@@ -32,8 +32,8 @@ use thetadatadx::flatfiles::{self, FlatFileFormat, FlatFileRow, FlatFileValue, R
 
 use crate::async_runtime::spawn_awaitable;
 use crate::errors::to_py_err;
-use crate::record_batch_to_pyarrow_table;
 use crate::run_blocking;
+use crate::{pyarrow_table_to_pandas, pyarrow_table_to_polars, record_batch_to_pyarrow_table};
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -77,30 +77,6 @@ fn rows_to_pyarrow_table(py: Python<'_>, rows: &[FlatFileRow]) -> PyResult<Py<Py
     record_batch_to_pyarrow_table(py, batch)
 }
 
-fn pyarrow_table_to_pandas_local(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAny>> {
-    let bound = table.bind(py);
-    let df = bound.call_method0("to_pandas").map_err(|e| {
-        if e.is_instance_of::<PyImportError>(py) {
-            PyImportError::new_err(
-                "pandas is required for .to_pandas(). Install with: pip install thetadatadx[pandas]",
-            )
-        } else {
-            e
-        }
-    })?;
-    Ok(df.unbind())
-}
-
-fn pyarrow_table_to_polars_local(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAny>> {
-    let polars = py.import("polars").map_err(|_| {
-        PyImportError::new_err(
-            "polars is not installed. Install it with: pip install thetadatadx[polars]",
-        )
-    })?;
-    let df = polars.call_method1("from_arrow", (table,))?;
-    Ok(df.unbind())
-}
-
 // ── FlatFileRowList ────────────────────────────────────────────────────
 
 /// Result of a decoded flat-file pull. Wraps `Vec<FlatFileRow>` and
@@ -135,13 +111,13 @@ impl FlatFileRowList {
     /// Return a `pandas.DataFrame`. Requires pandas + pyarrow.
     fn to_pandas(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let table = rows_to_pyarrow_table(py, &self.rows)?;
-        pyarrow_table_to_pandas_local(py, table)
+        pyarrow_table_to_pandas(py, table)
     }
 
     /// Return a `polars.DataFrame`. Requires polars + pyarrow.
     fn to_polars(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let table = rows_to_pyarrow_table(py, &self.rows)?;
-        pyarrow_table_to_polars_local(py, table)
+        pyarrow_table_to_polars(py, table)
     }
 
     /// Return a plain Python list of dicts, one per row. Useful for

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1642,7 +1642,7 @@ include!("_generated/decode_bench.rs");
 /// pyarrow.Table -> pandas.DataFrame. pandas 2.x is required for the
 /// numpy-backed zero-copy path (see `pyproject.toml` extras for the
 /// version pin).
-fn pyarrow_table_to_pandas(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAny>> {
+pub(crate) fn pyarrow_table_to_pandas(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAny>> {
     // We don't import `pandas` explicitly -- `pyarrow.Table.to_pandas()`
     // does that internally and raises its own ImportError if pandas is
     // missing, which we re-wrap so the message guides users to the right
@@ -1665,7 +1665,7 @@ fn pyarrow_table_to_pandas(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAn
 
 /// pyarrow.Table -> polars.DataFrame via `polars.from_arrow`. Requires
 /// polars >= 0.20 (see `pyproject.toml`).
-fn pyarrow_table_to_polars(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAny>> {
+pub(crate) fn pyarrow_table_to_polars(py: Python<'_>, table: Py<PyAny>) -> PyResult<Py<PyAny>> {
     let polars = py.import("polars").map_err(|_| {
         pyo3::exceptions::PyImportError::new_err(
             "polars is not installed. Install it with: pip install thetadatadx[polars]",

--- a/sdks/typescript/src/bench_streaming.rs
+++ b/sdks/typescript/src/bench_streaming.rs
@@ -269,9 +269,11 @@ fn trade_ticks_to_arrow_ipc(rows: &[thetadatadx::TradeTick]) -> napi::Result<Vec
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
     {
-        let mut writer =
-            arrow_ipc::writer::StreamWriter::try_new(std::io::Cursor::new(&mut buf), &batch.schema())
-                .map_err(|e| napi::Error::from_reason(format!("arrow ipc writer init failed: {e}")))?;
+        let mut writer = arrow_ipc::writer::StreamWriter::try_new(
+            std::io::Cursor::new(&mut buf),
+            &batch.schema(),
+        )
+        .map_err(|e| napi::Error::from_reason(format!("arrow ipc writer init failed: {e}")))?;
         writer
             .write(&batch)
             .map_err(|e| napi::Error::from_reason(format!("arrow ipc write failed: {e}")))?;

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -491,7 +491,10 @@ mod bigint_to_u64_tests {
     #[test]
     fn accepts_in_range_values() {
         assert_eq!(bigint_to_u64("test", &BigInt::from(0u64)).unwrap(), 0);
-        assert_eq!(bigint_to_u64("test", &BigInt::from(50_000u64)).unwrap(), 50_000);
+        assert_eq!(
+            bigint_to_u64("test", &BigInt::from(50_000u64)).unwrap(),
+            50_000
+        );
         assert_eq!(
             bigint_to_u64("test", &BigInt::from(u64::MAX)).unwrap(),
             u64::MAX,

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -48,7 +48,6 @@ use std::time::{Duration, Instant};
 
 use thetadatadx::auth::{self, Credentials as RustCredentials};
 use thetadatadx::config::DirectConfig;
-use thetadatadx::fpss::protocol::SubscriptionKind;
 use thetadatadx::fpss::{self, StreamingClient as RustStreamingClient};
 use thetadatadx::DispatcherSession;
 
@@ -734,22 +733,9 @@ impl StreamingClient {
         let Some(client) = guard.as_ref() else {
             return Ok(serde_json::json!([]));
         };
-        Ok(serde_json::json!(client
-            .active_full_subscriptions()
-            .into_iter()
-            .filter_map(|(kind, sec_type)| {
-                let kind_str = match kind {
-                    SubscriptionKind::Trade => "full_trades",
-                    SubscriptionKind::OpenInterest => "full_open_interest",
-                    SubscriptionKind::Quote => return None,
-                    _ => return None,
-                };
-                Some(serde_json::json!({
-                    "kind": kind_str,
-                    "contract": format!("{sec_type:?}"),
-                }))
-            })
-            .collect::<Vec<_>>()))
+        Ok(crate::project_full_subscriptions(
+            client.active_full_subscriptions(),
+        ))
     }
 
     /// Cumulative count of streaming events the TLS reader could not publish into
@@ -806,7 +792,8 @@ impl StreamingClient {
     ) -> napi::Result<()> {
         // Reject a negative or over-u64 BigInt rather than silently passing a
         // wrapped/truncated value, matching the config setters' lossless check.
-        let value = crate::config_class::bigint_to_u64("setSlowCallbackThresholdUs", &threshold_us)?;
+        let value =
+            crate::config_class::bigint_to_u64("setSlowCallbackThresholdUs", &threshold_us)?;
         let guard = self.lock_inner();
         if let Some(c) = guard.as_ref() {
             c.set_slow_callback_threshold(std::time::Duration::from_micros(value));

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -83,6 +83,36 @@ pub(crate) fn invalid_parameter_err(message: impl std::fmt::Display) -> napi::Er
     napi::Error::from_reason(format!("[InvalidParameterError] {message}"))
 }
 
+/// Project the core's active full-subscription set into the cross-binding
+/// `[{ kind, contract }]` JSON shape returned by `activeFullSubscriptions()`
+/// on both the unified `Client` and the standalone `StreamingClient`. `kind`
+/// is `"full_trades"` / `"full_open_interest"`; `contract` carries the
+/// wire-level security type. Quote is never a valid full-stream kind on the
+/// streaming wire, so any such row is dropped to keep the projection clean.
+pub(crate) fn project_full_subscriptions(
+    subs: Vec<(
+        thetadatadx::fpss::protocol::SubscriptionKind,
+        thetadatadx::SecType,
+    )>,
+) -> serde_json::Value {
+    use thetadatadx::fpss::protocol::SubscriptionKind;
+    serde_json::json!(subs
+        .into_iter()
+        .filter_map(|(kind, sec_type)| {
+            let kind_str = match kind {
+                SubscriptionKind::Trade => "full_trades",
+                SubscriptionKind::OpenInterest => "full_open_interest",
+                SubscriptionKind::Quote => return None,
+                _ => return None,
+            };
+            Some(serde_json::json!({
+                "kind": kind_str,
+                "contract": format!("{sec_type:?}"),
+            }))
+        })
+        .collect::<Vec<_>>())
+}
+
 // ── Credentials ──
 //
 // A first-class credentials handle mirroring the Python `Credentials`
@@ -373,8 +403,9 @@ pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
     Ok(timeout_ms as u64)
 }
 
-/// Validate a non-negative integer query parameter and convert it to the
-/// `i32` domain the core request builders take.
+/// Validate an optional non-negative integer query parameter and convert
+/// it to the `i32` domain the core request builders take, leaving an
+/// omitted value (`None`) untouched.
 ///
 /// The bounded integer filters (`maxDte`, `strikeRange` — days-to-expiry
 /// and strike windows that are counts, never negative) ride in the options
@@ -388,7 +419,11 @@ pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
 /// identical input) rather than coercing them, so a caller's
 /// `catch (e instanceof InvalidParameterError)` branch ports across
 /// bindings. `param` names the camelCase key in the rejection message.
-pub(crate) fn validate_nonneg_i32(param: &str, value: f64) -> napi::Result<i32> {
+pub(crate) fn validate_optional_nonneg_i32(
+    param: &str,
+    value: Option<f64>,
+) -> napi::Result<Option<i32>> {
+    let Some(value) = value else { return Ok(None) };
     if !value.is_finite() {
         return Err(invalid_parameter_err(format!(
             "{param} must be a non-negative whole number; got {value}"
@@ -409,21 +444,7 @@ pub(crate) fn validate_nonneg_i32(param: &str, value: f64) -> napi::Result<i32> 
             "{param} exceeds the representable range; got {value}"
         )));
     }
-    Ok(value as i32)
-}
-
-/// Validate an optional non-negative integer query parameter, leaving an
-/// omitted value (`None`) untouched. Thin `Option` wrapper over
-/// [`validate_nonneg_i32`] so the generated method bodies validate
-/// optional `Int` filters with a single expression.
-pub(crate) fn validate_optional_nonneg_i32(
-    param: &str,
-    value: Option<f64>,
-) -> napi::Result<Option<i32>> {
-    match value {
-        Some(v) => Ok(Some(validate_nonneg_i32(param, v)?)),
-        None => Ok(None),
-    }
+    Ok(Some(value as i32))
 }
 
 /// Run an endpoint round-trip off the runtime's execution thread and
@@ -989,7 +1010,8 @@ impl StreamView {
     ) -> napi::Result<()> {
         // Reject a negative or over-u64 BigInt rather than silently passing a
         // wrapped/truncated value, matching the config setters' lossless check.
-        let value = crate::config_class::bigint_to_u64("setSlowCallbackThresholdUs", &threshold_us)?;
+        let value =
+            crate::config_class::bigint_to_u64("setSlowCallbackThresholdUs", &threshold_us)?;
         self.client
             .stream()
             .set_slow_callback_threshold(std::time::Duration::from_micros(value));
@@ -1018,30 +1040,10 @@ impl StreamView {
     /// Empty array when streaming has not started.
     #[napi(js_name = "activeFullSubscriptions")]
     pub fn active_full_subscriptions(&self) -> napi::Result<serde_json::Value> {
-        use thetadatadx::fpss::protocol::SubscriptionKind;
         self.client
             .stream()
             .active_full_subscriptions()
-            .map(|subs| {
-                serde_json::json!(subs
-                    .into_iter()
-                    .filter_map(|(kind, sec_type)| {
-                        let kind_str = match kind {
-                            SubscriptionKind::Trade => "full_trades",
-                            SubscriptionKind::OpenInterest => "full_open_interest",
-                            // Quote is not a valid full-stream kind on
-                            // the streaming wire, drop the row to keep the
-                            // projection cross-binding clean.
-                            SubscriptionKind::Quote => return None,
-                            _ => return None,
-                        };
-                        Some(serde_json::json!({
-                            "kind": kind_str,
-                            "contract": format!("{sec_type:?}"),
-                        }))
-                    })
-                    .collect::<Vec<_>>())
-            })
+            .map(project_full_subscriptions)
             .map_err(to_napi_err)
     }
 }

--- a/tools/server/src/flatfile_routes.rs
+++ b/tools/server/src/flatfile_routes.rs
@@ -370,9 +370,7 @@ fn classify_flatfile_error(e: &thetadatadx::Error) -> (StatusCode, &'static str)
         // condition answers 404 via one frame type and 502 via the other.
         thetadatadx::Error::FlatFilesUnavailable(FlatFilesUnavailableReason::RequestRejected {
             server_message,
-        }) if rejection_is_no_data(server_message) => {
-            (StatusCode::NOT_FOUND, "flatfiles_no_data")
-        }
+        }) if rejection_is_no_data(server_message) => (StatusCode::NOT_FOUND, "flatfiles_no_data"),
         thetadatadx::Error::FlatFilesUnavailable(reason) if reason.is_no_data() => {
             (StatusCode::NOT_FOUND, "flatfiles_no_data")
         }
@@ -616,9 +614,10 @@ mod tests {
     /// `502`, while the same no-data via an `ERROR` frame answered `404`.
     #[test]
     fn no_data_disconnect_maps_to_404() {
-        let e = thetadatadx::Error::FlatFilesUnavailable(
-            FlatFilesUnavailableReason::AuthRejected { reason_code: 13 },
-        );
+        let e =
+            thetadatadx::Error::FlatFilesUnavailable(FlatFilesUnavailableReason::AuthRejected {
+                reason_code: 13,
+            });
         assert_eq!(
             classify_flatfile_error(&e),
             (StatusCode::NOT_FOUND, "flatfiles_no_data"),

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -290,8 +290,9 @@ fn list_rows(ep: &EndpointMeta, symbol: Option<&str>, items: &[String]) -> Vec<R
     // The symbol-scoped lists (`option_list_expirations` / `_strikes`) pair
     // each value with the requested `symbol`; the bare symbol / date lists
     // do not.
-    let pair_symbol =
-        symbol.filter(|s| !s.is_empty()).filter(|_| key == "expiration" || key == "strike");
+    let pair_symbol = symbol
+        .filter(|s| !s.is_empty())
+        .filter(|_| key == "expiration" || key == "strike");
 
     items
         .iter()
@@ -306,9 +307,8 @@ fn list_rows(ep: &EndpointMeta, symbol: Option<&str>, items: &[String]) -> Vec<R
                 // v3 renders strikes as JSON numbers; fall back to the raw
                 // string only if the wire value is not finite-parseable.
                 match raw.parse::<f64>() {
-                    Ok(n) if n.is_finite() => {
-                        sonic_rs::to_value(&n).unwrap_or_else(|_| sonic_rs::Value::from(raw.as_str()))
-                    }
+                    Ok(n) if n.is_finite() => sonic_rs::to_value(&n)
+                        .unwrap_or_else(|_| sonic_rs::Value::from(raw.as_str())),
                     _ => sonic_rs::Value::from(raw.as_str()),
                 }
             } else {
@@ -405,7 +405,10 @@ fn splice_identity(
             .get("expiration")
             .cloned()
             .or_else(|| contract.expiration_value());
-        let strike = row.get("strike").cloned().or_else(|| contract.strike_value());
+        let strike = row
+            .get("strike")
+            .cloned()
+            .or_else(|| contract.strike_value());
         let right = row.get("right").cloned().or_else(|| contract.right_value());
         // Drop the serializer's trailing id columns so they are not duplicated
         // when re-inserted at the identity slot.
@@ -797,7 +800,10 @@ pub(crate) fn trade_ticks_to_json(ticks: &[TradeTick], shape: RowShape) -> Vec<R
                 // per-OPRA execution record).
                 row.push("size", sonic_rs::Value::from(t.size));
                 row.push("condition", sonic_rs::Value::from(t.condition));
-                row.push("price", sonic_rs::to_value(&t.price).expect("f64 serializes"));
+                row.push(
+                    "price",
+                    sonic_rs::to_value(&t.price).expect("f64 serializes"),
+                );
             } else {
                 // Full execution record: `...ext_condition1..4,condition,size,
                 // exchange,price`.
@@ -808,7 +814,10 @@ pub(crate) fn trade_ticks_to_json(ticks: &[TradeTick], shape: RowShape) -> Vec<R
                 row.push("condition", sonic_rs::Value::from(t.condition));
                 row.push("size", sonic_rs::Value::from(t.size));
                 row.push("exchange", sonic_rs::Value::from(t.exchange));
-                row.push("price", sonic_rs::to_value(&t.price).expect("f64 serializes"));
+                row.push(
+                    "price",
+                    sonic_rs::to_value(&t.price).expect("f64 serializes"),
+                );
             }
             insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
             row
@@ -1570,27 +1579,451 @@ fn representative_output(ep: &EndpointMeta) -> EndpointOutput {
     };
     match ep.returns {
         ReturnType::StringList => EndpointOutput::StringList(vec![String::new()]),
-        ReturnType::EodTicks => EndpointOutput::EodTicks(vec![EodTick { created_ms_of_day: 0, last_trade_ms_of_day: 0, open: 0.0, high: 0.0, low: 0.0, close: 0.0, volume: 0, count: 0, bid_size: 0, bid_exchange: 0, bid: 0.0, bid_condition: 0, ask_size: 0, ask_exchange: 0, ask: 0.0, ask_condition: 0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::OhlcTicks => EndpointOutput::OhlcTicks(vec![OhlcTick { ms_of_day: 0, open: 0.0, high: 0.0, low: 0.0, close: 0.0, volume: 0, count: 0, vwap: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::TradeTicks => EndpointOutput::TradeTicks(vec![TradeTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, condition_flags: 0, price_flags: 0, volume_type: 0, records_back: 0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::QuoteTicks => EndpointOutput::QuoteTicks(vec![QuoteTick { ms_of_day: 0, bid_size: 0, bid_exchange: 0, bid: 0.0, bid_condition: 0, ask_size: 0, ask_exchange: 0, ask: 0.0, ask_condition: 0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right, midpoint: 0.0 }]),
-        ReturnType::TradeQuoteTicks => EndpointOutput::TradeQuoteTicks(vec![TradeQuoteTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, condition_flags: 0, price_flags: 0, volume_type: 0, records_back: 0, quote_ms_of_day: 0, bid_size: 0, bid_exchange: 0, bid: 0.0, bid_condition: 0, ask_size: 0, ask_exchange: 0, ask: 0.0, ask_condition: 0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::OpenInterestTicks => EndpointOutput::OpenInterestTicks(vec![OpenInterestTick { ms_of_day: 0, open_interest: 0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::MarketValueTicks => EndpointOutput::MarketValueTicks(vec![MarketValueTick { ms_of_day: 0, market_bid: 0.0, market_ask: 0.0, market_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::GreeksAllTicks => EndpointOutput::GreeksAllTicks(vec![GreeksAllTick { ms_of_day: 0, bid: 0.0, ask: 0.0, implied_volatility: 0.0, delta: 0.0, gamma: 0.0, theta: 0.0, vega: 0.0, rho: 0.0, iv_error: 0.0, vanna: 0.0, charm: 0.0, vomma: 0.0, veta: 0.0, speed: 0.0, zomma: 0.0, color: 0.0, ultima: 0.0, d1: 0.0, d2: 0.0, dual_delta: 0.0, dual_gamma: 0.0, epsilon: 0.0, lambda: 0.0, vera: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::GreeksEodTicks => EndpointOutput::GreeksEodTicks(vec![GreeksEodTick { ms_of_day: 0, open: 0.0, high: 0.0, low: 0.0, close: 0.0, volume: 0, count: 0, bid_size: 0, bid_exchange: 0, bid: 0.0, bid_condition: 0, ask_size: 0, ask_exchange: 0, ask: 0.0, ask_condition: 0, delta: 0.0, theta: 0.0, vega: 0.0, rho: 0.0, epsilon: 0.0, lambda: 0.0, gamma: 0.0, vanna: 0.0, charm: 0.0, vomma: 0.0, veta: 0.0, vera: 0.0, speed: 0.0, zomma: 0.0, color: 0.0, ultima: 0.0, d1: 0.0, d2: 0.0, dual_delta: 0.0, dual_gamma: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::GreeksFirstOrderTicks => EndpointOutput::GreeksFirstOrderTicks(vec![GreeksFirstOrderTick { ms_of_day: 0, bid: 0.0, ask: 0.0, delta: 0.0, theta: 0.0, vega: 0.0, rho: 0.0, epsilon: 0.0, lambda: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::GreeksSecondOrderTicks => EndpointOutput::GreeksSecondOrderTicks(vec![GreeksSecondOrderTick { ms_of_day: 0, bid: 0.0, ask: 0.0, gamma: 0.0, vanna: 0.0, charm: 0.0, vomma: 0.0, veta: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::GreeksThirdOrderTicks => EndpointOutput::GreeksThirdOrderTicks(vec![GreeksThirdOrderTick { ms_of_day: 0, bid: 0.0, ask: 0.0, speed: 0.0, zomma: 0.0, color: 0.0, ultima: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::TradeGreeksAllTicks => EndpointOutput::TradeGreeksAllTicks(vec![TradeGreeksAllTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, delta: 0.0, theta: 0.0, vega: 0.0, rho: 0.0, epsilon: 0.0, lambda: 0.0, gamma: 0.0, vanna: 0.0, charm: 0.0, vomma: 0.0, veta: 0.0, vera: 0.0, speed: 0.0, zomma: 0.0, color: 0.0, ultima: 0.0, d1: 0.0, d2: 0.0, dual_delta: 0.0, dual_gamma: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::TradeGreeksFirstOrderTicks => EndpointOutput::TradeGreeksFirstOrderTicks(vec![TradeGreeksFirstOrderTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, delta: 0.0, theta: 0.0, vega: 0.0, rho: 0.0, epsilon: 0.0, lambda: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::TradeGreeksSecondOrderTicks => EndpointOutput::TradeGreeksSecondOrderTicks(vec![TradeGreeksSecondOrderTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, gamma: 0.0, vanna: 0.0, charm: 0.0, vomma: 0.0, veta: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::TradeGreeksThirdOrderTicks => EndpointOutput::TradeGreeksThirdOrderTicks(vec![TradeGreeksThirdOrderTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, speed: 0.0, zomma: 0.0, color: 0.0, ultima: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::TradeGreeksImpliedVolatilityTicks => EndpointOutput::TradeGreeksImpliedVolatilityTicks(vec![TradeGreeksImpliedVolatilityTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::IvTicks => EndpointOutput::IvTicks(vec![IvTick { ms_of_day: 0, bid: 0.0, bid_implied_volatility: 0.0, midpoint: 0.0, implied_volatility: 0.0, ask: 0.0, ask_implied_volatility: 0.0, iv_error: 0.0, underlying_ms_of_day: 0, underlying_price: 0.0, date: 0, expiration: id_expiration, strike: id_strike, right: id_right }]),
-        ReturnType::PriceTicks => EndpointOutput::PriceTicks(vec![PriceTick { ms_of_day: 0, price: 0.0, date: 0 }]),
-        ReturnType::IndexPriceAtTimeTicks => EndpointOutput::IndexPriceAtTimeTicks(vec![IndexPriceAtTimeTick { ms_of_day: 0, sequence: 0, ext_condition1: 0, ext_condition2: 0, ext_condition3: 0, ext_condition4: 0, condition: 0, size: 0, exchange: 0, price: 0.0, date: 0 }]),
-        ReturnType::InterestRateTicks => EndpointOutput::InterestRateTicks(vec![InterestRateTick { date: 0, rate: 0.0 }]),
+        ReturnType::EodTicks => EndpointOutput::EodTicks(vec![EodTick {
+            created_ms_of_day: 0,
+            last_trade_ms_of_day: 0,
+            open: 0.0,
+            high: 0.0,
+            low: 0.0,
+            close: 0.0,
+            volume: 0,
+            count: 0,
+            bid_size: 0,
+            bid_exchange: 0,
+            bid: 0.0,
+            bid_condition: 0,
+            ask_size: 0,
+            ask_exchange: 0,
+            ask: 0.0,
+            ask_condition: 0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::OhlcTicks => EndpointOutput::OhlcTicks(vec![OhlcTick {
+            ms_of_day: 0,
+            open: 0.0,
+            high: 0.0,
+            low: 0.0,
+            close: 0.0,
+            volume: 0,
+            count: 0,
+            vwap: 0.0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::TradeTicks => EndpointOutput::TradeTicks(vec![TradeTick {
+            ms_of_day: 0,
+            sequence: 0,
+            ext_condition1: 0,
+            ext_condition2: 0,
+            ext_condition3: 0,
+            ext_condition4: 0,
+            condition: 0,
+            size: 0,
+            exchange: 0,
+            price: 0.0,
+            condition_flags: 0,
+            price_flags: 0,
+            volume_type: 0,
+            records_back: 0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::QuoteTicks => EndpointOutput::QuoteTicks(vec![QuoteTick {
+            ms_of_day: 0,
+            bid_size: 0,
+            bid_exchange: 0,
+            bid: 0.0,
+            bid_condition: 0,
+            ask_size: 0,
+            ask_exchange: 0,
+            ask: 0.0,
+            ask_condition: 0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+            midpoint: 0.0,
+        }]),
+        ReturnType::TradeQuoteTicks => EndpointOutput::TradeQuoteTicks(vec![TradeQuoteTick {
+            ms_of_day: 0,
+            sequence: 0,
+            ext_condition1: 0,
+            ext_condition2: 0,
+            ext_condition3: 0,
+            ext_condition4: 0,
+            condition: 0,
+            size: 0,
+            exchange: 0,
+            price: 0.0,
+            condition_flags: 0,
+            price_flags: 0,
+            volume_type: 0,
+            records_back: 0,
+            quote_ms_of_day: 0,
+            bid_size: 0,
+            bid_exchange: 0,
+            bid: 0.0,
+            bid_condition: 0,
+            ask_size: 0,
+            ask_exchange: 0,
+            ask: 0.0,
+            ask_condition: 0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::OpenInterestTicks => {
+            EndpointOutput::OpenInterestTicks(vec![OpenInterestTick {
+                ms_of_day: 0,
+                open_interest: 0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::MarketValueTicks => EndpointOutput::MarketValueTicks(vec![MarketValueTick {
+            ms_of_day: 0,
+            market_bid: 0.0,
+            market_ask: 0.0,
+            market_price: 0.0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::GreeksAllTicks => EndpointOutput::GreeksAllTicks(vec![GreeksAllTick {
+            ms_of_day: 0,
+            bid: 0.0,
+            ask: 0.0,
+            implied_volatility: 0.0,
+            delta: 0.0,
+            gamma: 0.0,
+            theta: 0.0,
+            vega: 0.0,
+            rho: 0.0,
+            iv_error: 0.0,
+            vanna: 0.0,
+            charm: 0.0,
+            vomma: 0.0,
+            veta: 0.0,
+            speed: 0.0,
+            zomma: 0.0,
+            color: 0.0,
+            ultima: 0.0,
+            d1: 0.0,
+            d2: 0.0,
+            dual_delta: 0.0,
+            dual_gamma: 0.0,
+            epsilon: 0.0,
+            lambda: 0.0,
+            vera: 0.0,
+            underlying_ms_of_day: 0,
+            underlying_price: 0.0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::GreeksEodTicks => EndpointOutput::GreeksEodTicks(vec![GreeksEodTick {
+            ms_of_day: 0,
+            open: 0.0,
+            high: 0.0,
+            low: 0.0,
+            close: 0.0,
+            volume: 0,
+            count: 0,
+            bid_size: 0,
+            bid_exchange: 0,
+            bid: 0.0,
+            bid_condition: 0,
+            ask_size: 0,
+            ask_exchange: 0,
+            ask: 0.0,
+            ask_condition: 0,
+            delta: 0.0,
+            theta: 0.0,
+            vega: 0.0,
+            rho: 0.0,
+            epsilon: 0.0,
+            lambda: 0.0,
+            gamma: 0.0,
+            vanna: 0.0,
+            charm: 0.0,
+            vomma: 0.0,
+            veta: 0.0,
+            vera: 0.0,
+            speed: 0.0,
+            zomma: 0.0,
+            color: 0.0,
+            ultima: 0.0,
+            d1: 0.0,
+            d2: 0.0,
+            dual_delta: 0.0,
+            dual_gamma: 0.0,
+            implied_volatility: 0.0,
+            iv_error: 0.0,
+            underlying_ms_of_day: 0,
+            underlying_price: 0.0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::GreeksFirstOrderTicks => {
+            EndpointOutput::GreeksFirstOrderTicks(vec![GreeksFirstOrderTick {
+                ms_of_day: 0,
+                bid: 0.0,
+                ask: 0.0,
+                delta: 0.0,
+                theta: 0.0,
+                vega: 0.0,
+                rho: 0.0,
+                epsilon: 0.0,
+                lambda: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::GreeksSecondOrderTicks => {
+            EndpointOutput::GreeksSecondOrderTicks(vec![GreeksSecondOrderTick {
+                ms_of_day: 0,
+                bid: 0.0,
+                ask: 0.0,
+                gamma: 0.0,
+                vanna: 0.0,
+                charm: 0.0,
+                vomma: 0.0,
+                veta: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::GreeksThirdOrderTicks => {
+            EndpointOutput::GreeksThirdOrderTicks(vec![GreeksThirdOrderTick {
+                ms_of_day: 0,
+                bid: 0.0,
+                ask: 0.0,
+                speed: 0.0,
+                zomma: 0.0,
+                color: 0.0,
+                ultima: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::TradeGreeksAllTicks => {
+            EndpointOutput::TradeGreeksAllTicks(vec![TradeGreeksAllTick {
+                ms_of_day: 0,
+                sequence: 0,
+                ext_condition1: 0,
+                ext_condition2: 0,
+                ext_condition3: 0,
+                ext_condition4: 0,
+                condition: 0,
+                size: 0,
+                exchange: 0,
+                price: 0.0,
+                delta: 0.0,
+                theta: 0.0,
+                vega: 0.0,
+                rho: 0.0,
+                epsilon: 0.0,
+                lambda: 0.0,
+                gamma: 0.0,
+                vanna: 0.0,
+                charm: 0.0,
+                vomma: 0.0,
+                veta: 0.0,
+                vera: 0.0,
+                speed: 0.0,
+                zomma: 0.0,
+                color: 0.0,
+                ultima: 0.0,
+                d1: 0.0,
+                d2: 0.0,
+                dual_delta: 0.0,
+                dual_gamma: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::TradeGreeksFirstOrderTicks => {
+            EndpointOutput::TradeGreeksFirstOrderTicks(vec![TradeGreeksFirstOrderTick {
+                ms_of_day: 0,
+                sequence: 0,
+                ext_condition1: 0,
+                ext_condition2: 0,
+                ext_condition3: 0,
+                ext_condition4: 0,
+                condition: 0,
+                size: 0,
+                exchange: 0,
+                price: 0.0,
+                delta: 0.0,
+                theta: 0.0,
+                vega: 0.0,
+                rho: 0.0,
+                epsilon: 0.0,
+                lambda: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::TradeGreeksSecondOrderTicks => {
+            EndpointOutput::TradeGreeksSecondOrderTicks(vec![TradeGreeksSecondOrderTick {
+                ms_of_day: 0,
+                sequence: 0,
+                ext_condition1: 0,
+                ext_condition2: 0,
+                ext_condition3: 0,
+                ext_condition4: 0,
+                condition: 0,
+                size: 0,
+                exchange: 0,
+                price: 0.0,
+                gamma: 0.0,
+                vanna: 0.0,
+                charm: 0.0,
+                vomma: 0.0,
+                veta: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::TradeGreeksThirdOrderTicks => {
+            EndpointOutput::TradeGreeksThirdOrderTicks(vec![TradeGreeksThirdOrderTick {
+                ms_of_day: 0,
+                sequence: 0,
+                ext_condition1: 0,
+                ext_condition2: 0,
+                ext_condition3: 0,
+                ext_condition4: 0,
+                condition: 0,
+                size: 0,
+                exchange: 0,
+                price: 0.0,
+                speed: 0.0,
+                zomma: 0.0,
+                color: 0.0,
+                ultima: 0.0,
+                implied_volatility: 0.0,
+                iv_error: 0.0,
+                underlying_ms_of_day: 0,
+                underlying_price: 0.0,
+                date: 0,
+                expiration: id_expiration,
+                strike: id_strike,
+                right: id_right,
+            }])
+        }
+        ReturnType::TradeGreeksImpliedVolatilityTicks => {
+            EndpointOutput::TradeGreeksImpliedVolatilityTicks(vec![
+                TradeGreeksImpliedVolatilityTick {
+                    ms_of_day: 0,
+                    sequence: 0,
+                    ext_condition1: 0,
+                    ext_condition2: 0,
+                    ext_condition3: 0,
+                    ext_condition4: 0,
+                    condition: 0,
+                    size: 0,
+                    exchange: 0,
+                    price: 0.0,
+                    implied_volatility: 0.0,
+                    iv_error: 0.0,
+                    underlying_ms_of_day: 0,
+                    underlying_price: 0.0,
+                    date: 0,
+                    expiration: id_expiration,
+                    strike: id_strike,
+                    right: id_right,
+                },
+            ])
+        }
+        ReturnType::IvTicks => EndpointOutput::IvTicks(vec![IvTick {
+            ms_of_day: 0,
+            bid: 0.0,
+            bid_implied_volatility: 0.0,
+            midpoint: 0.0,
+            implied_volatility: 0.0,
+            ask: 0.0,
+            ask_implied_volatility: 0.0,
+            iv_error: 0.0,
+            underlying_ms_of_day: 0,
+            underlying_price: 0.0,
+            date: 0,
+            expiration: id_expiration,
+            strike: id_strike,
+            right: id_right,
+        }]),
+        ReturnType::PriceTicks => EndpointOutput::PriceTicks(vec![PriceTick {
+            ms_of_day: 0,
+            price: 0.0,
+            date: 0,
+        }]),
+        ReturnType::IndexPriceAtTimeTicks => {
+            EndpointOutput::IndexPriceAtTimeTicks(vec![IndexPriceAtTimeTick {
+                ms_of_day: 0,
+                sequence: 0,
+                ext_condition1: 0,
+                ext_condition2: 0,
+                ext_condition3: 0,
+                ext_condition4: 0,
+                condition: 0,
+                size: 0,
+                exchange: 0,
+                price: 0.0,
+                date: 0,
+            }])
+        }
+        ReturnType::InterestRateTicks => {
+            EndpointOutput::InterestRateTicks(vec![InterestRateTick { date: 0, rate: 0.0 }])
+        }
         ReturnType::CalendarDays => EndpointOutput::CalendarDays(vec![CalendarDay {
             date: calendar_date,
             is_open: true,
@@ -1844,7 +2277,10 @@ mod tests {
         .expect("scalar list should format as CSV");
 
         // v3 CSV is CRLF-framed.
-        assert_eq!(csv, "value\r\nAAPL\r\n\"MS,FT\"\r\n\"He said \"\"hi\"\"\"\r\n");
+        assert_eq!(
+            csv,
+            "value\r\nAAPL\r\n\"MS,FT\"\r\n\"He said \"\"hi\"\"\"\r\n"
+        );
     }
 
     #[test]
@@ -2077,7 +2513,10 @@ mod tests {
             Some("2024-01-02T17:17:53.606".to_string())
         );
         assert!(r.get("midpoint").is_none(), "v3 quote drops midpoint");
-        assert!(r.get("ms_of_day").is_none(), "v3 folds ms_of_day into timestamp");
+        assert!(
+            r.get("ms_of_day").is_none(),
+            "v3 folds ms_of_day into timestamp"
+        );
         assert!(r.get("date").is_none(), "v3 folds date into timestamp");
         assert_eq!(
             r.get("expiration")
@@ -2227,7 +2666,12 @@ mod tests {
         }
         // v3 renames + folds: the integer time columns and the long
         // `implied_volatility` spelling must not survive.
-        for k in ["implied_volatility", "ms_of_day", "underlying_ms_of_day", "date"] {
+        for k in [
+            "implied_volatility",
+            "ms_of_day",
+            "underlying_ms_of_day",
+            "date",
+        ] {
             assert!(r.get(k).is_none(), "v3 greeks must drop: {k}");
         }
         assert_eq!(
@@ -2350,12 +2794,16 @@ mod tests {
                 .collect()
         );
         assert_eq!(
-            contract_obj.get("symbol").and_then(|v: &sonic_rs::Value| v.as_str()),
+            contract_obj
+                .get("symbol")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("AAPL"),
             "contract symbol comes from the request param"
         );
         assert_eq!(
-            contract_obj.get("right").and_then(|v: &sonic_rs::Value| v.as_str()),
+            contract_obj
+                .get("right")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("CALL")
         );
         assert_eq!(
@@ -2377,7 +2825,10 @@ mod tests {
                 "contract field must be lifted out of the data row: {dropped}"
             );
         }
-        assert!(data_row.get("bid").is_some(), "data row keeps the quote fields");
+        assert!(
+            data_row.get("bid").is_some(),
+            "data row keeps the quote fields"
+        );
     }
 
     /// A single-contract option query carries no contract columns on the
@@ -2407,7 +2858,8 @@ mod tests {
             Some("AAPL")
         );
         assert_eq!(
-            c.get("expiration").and_then(|v: &sonic_rs::Value| v.as_str()),
+            c.get("expiration")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("2024-11-08"),
             "expiration falls back to the request param, ISO-formatted"
         );
@@ -2487,7 +2939,9 @@ mod tests {
             &EndpointOutput::StringList(vec!["AAPL".into()]),
         );
         assert_eq!(
-            rows[0].get("symbol").and_then(|v: &sonic_rs::Value| v.as_str()),
+            rows[0]
+                .get("symbol")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("AAPL")
         );
 
@@ -2499,7 +2953,9 @@ mod tests {
             &EndpointOutput::StringList(vec!["20160816".into()]),
         );
         assert_eq!(
-            rows[0].get("date").and_then(|v: &sonic_rs::Value| v.as_str()),
+            rows[0]
+                .get("date")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("2016-08-16")
         );
 
@@ -2514,11 +2970,15 @@ mod tests {
             &EndpointOutput::StringList(vec!["20120601".into()]),
         );
         assert_eq!(
-            rows[0].get("symbol").and_then(|v: &sonic_rs::Value| v.as_str()),
+            rows[0]
+                .get("symbol")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("AAPL")
         );
         assert_eq!(
-            rows[0].get("expiration").and_then(|v: &sonic_rs::Value| v.as_str()),
+            rows[0]
+                .get("expiration")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("2012-06-01")
         );
 
@@ -2533,11 +2993,15 @@ mod tests {
             &EndpointOutput::StringList(vec!["80.000".into()]),
         );
         assert_eq!(
-            rows[0].get("symbol").and_then(|v: &sonic_rs::Value| v.as_str()),
+            rows[0]
+                .get("symbol")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("AAPL")
         );
         assert_eq!(
-            rows[0].get("strike").and_then(|v: &sonic_rs::Value| v.as_f64()),
+            rows[0]
+                .get("strike")
+                .and_then(|v: &sonic_rs::Value| v.as_f64()),
             Some(80.0)
         );
     }
@@ -2672,7 +3136,11 @@ mod tests {
         }
     }
 
-    fn market_value_tick(expiration: i32, strike: f64, right: char) -> thetadatadx::MarketValueTick {
+    fn market_value_tick(
+        expiration: i32,
+        strike: f64,
+        right: char,
+    ) -> thetadatadx::MarketValueTick {
         thetadatadx::MarketValueTick {
             ms_of_day: 34_200_000,
             market_bid: 1.0,
@@ -2695,10 +3163,7 @@ mod tests {
         };
         let rows = response_rows(ep, &contract, &output);
         let csv = json_to_csv(ep, &rows).expect("CSV");
-        csv.split("\r\n")
-            .next()
-            .expect("header line")
-            .to_string()
+        csv.split("\r\n").next().expect("header line").to_string()
     }
 
     /// One snapshot + one history endpoint per asset class, asserted against
@@ -2803,7 +3268,14 @@ mod tests {
             assert_eq!(
                 cols,
                 vec![
-                    "timestamp", "open", "high", "low", "close", "volume", "count", "vwap",
+                    "timestamp",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "count",
+                    "vwap",
                 ],
                 "{ep_name} derived column order is the bare serializer order"
             );
@@ -2874,7 +3346,10 @@ mod tests {
             is_option: false,
         };
         let s = ohlc_ticks_to_json(&[ohlc_tick(34_200_000, 0, 0.0, '\0')], snap);
-        assert!(s[0].get("vwap").is_none(), "snapshot OHLC must not emit vwap");
+        assert!(
+            s[0].get("vwap").is_none(),
+            "snapshot OHLC must not emit vwap"
+        );
         assert!(s[0].get("count").is_some(), "snapshot OHLC keeps count");
         let h = ohlc_ticks_to_json(&[ohlc_tick(34_200_000, 0, 0.0, '\0')], hist);
         assert!(h[0].get("vwap").is_some(), "history OHLC must emit vwap");
@@ -3047,14 +3522,20 @@ mod tests {
             .get("response")
             .and_then(|v: &sonic_rs::Value| v.as_array())
             .expect("response array");
-        assert_eq!(response.len(), 2, "one flat row per expiration, not grouped");
+        assert_eq!(
+            response.len(),
+            2,
+            "one flat row per expiration, not grouped"
+        );
         let first = &response[0];
         assert!(
             first.get("contract").is_none() && first.get("data").is_none(),
             "list endpoints must stay flat: {first:?}"
         );
         assert_eq!(
-            first.get("symbol").and_then(|v: &sonic_rs::Value| v.as_str()),
+            first
+                .get("symbol")
+                .and_then(|v: &sonic_rs::Value| v.as_str()),
             Some("AAPL")
         );
         assert_eq!(
@@ -3110,46 +3591,45 @@ mod tests {
     fn csv_header_is_derived_from_serializer_declaration_order() {
         // Build the row straight from the serializer and capture its column
         // order — this is the single source.
-        let serializer_order: Vec<&'static str> =
-            greeks_all_ticks_to_json(&[GreeksAllTick {
-                ms_of_day: 0,
-                bid: 0.0,
-                ask: 0.0,
-                implied_volatility: 0.0,
-                delta: 0.0,
-                gamma: 0.0,
-                theta: 0.0,
-                vega: 0.0,
-                rho: 0.0,
-                iv_error: 0.0,
-                vanna: 0.0,
-                charm: 0.0,
-                vomma: 0.0,
-                veta: 0.0,
-                speed: 0.0,
-                zomma: 0.0,
-                color: 0.0,
-                ultima: 0.0,
-                d1: 0.0,
-                d2: 0.0,
-                dual_delta: 0.0,
-                dual_gamma: 0.0,
-                epsilon: 0.0,
-                lambda: 0.0,
-                vera: 0.0,
-                underlying_ms_of_day: 0,
-                underlying_price: 0.0,
-                date: 0,
-                // expiration 0 -> the serializer emits no contract id columns,
-                // so this is the bare data order the CSV header must follow.
-                expiration: 0,
-                strike: 0.0,
-                right: '\0',
-            }])
-            .first()
-            .expect("one row")
-            .columns()
-            .collect();
+        let serializer_order: Vec<&'static str> = greeks_all_ticks_to_json(&[GreeksAllTick {
+            ms_of_day: 0,
+            bid: 0.0,
+            ask: 0.0,
+            implied_volatility: 0.0,
+            delta: 0.0,
+            gamma: 0.0,
+            theta: 0.0,
+            vega: 0.0,
+            rho: 0.0,
+            iv_error: 0.0,
+            vanna: 0.0,
+            charm: 0.0,
+            vomma: 0.0,
+            veta: 0.0,
+            speed: 0.0,
+            zomma: 0.0,
+            color: 0.0,
+            ultima: 0.0,
+            d1: 0.0,
+            d2: 0.0,
+            dual_delta: 0.0,
+            dual_gamma: 0.0,
+            epsilon: 0.0,
+            lambda: 0.0,
+            vera: 0.0,
+            underlying_ms_of_day: 0,
+            underlying_price: 0.0,
+            date: 0,
+            // expiration 0 -> the serializer emits no contract id columns,
+            // so this is the bare data order the CSV header must follow.
+            expiration: 0,
+            strike: 0.0,
+            right: '\0',
+        }])
+        .first()
+        .expect("one row")
+        .columns()
+        .collect();
 
         // The order is intentionally not sorted: `bid`/`ask` lead the data,
         // the first-order block (`delta,theta,vega,rho,epsilon,lambda`) precedes
@@ -3777,7 +4257,14 @@ mod tests {
                 "snapshot IV must drop {trimmed}"
             );
         }
-        for kept in ["timestamp", "bid", "ask", "implied_vol", "iv_error", "underlying_price"] {
+        for kept in [
+            "timestamp",
+            "bid",
+            "ask",
+            "implied_vol",
+            "iv_error",
+            "underlying_price",
+        ] {
             assert!(srow.get(kept).is_some(), "snapshot IV keeps {kept}");
         }
 
@@ -3788,7 +4275,13 @@ mod tests {
         };
         let h = iv_ticks_to_json(&[iv_tick()], hist);
         let hrow = &h[0];
-        for kept in ["bid_implied_vol", "midpoint", "ask_implied_vol", "implied_vol", "iv_error"] {
+        for kept in [
+            "bid_implied_vol",
+            "midpoint",
+            "ask_implied_vol",
+            "implied_vol",
+            "iv_error",
+        ] {
             assert!(hrow.get(kept).is_some(), "history IV keeps {kept}");
         }
     }

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -1116,7 +1116,10 @@ mod tests {
         let exp_at = body.find("exp -> expiration").expect("exp mapped");
         let ivl_at = body.find("ivl -> interval").expect("ivl mapped");
         let csv_at = body.find("use_csv -> format").expect("use_csv mapped");
-        assert!(exp_at < ivl_at && ivl_at < csv_at, "entries must be sorted: {body}");
+        assert!(
+            exp_at < ivl_at && ivl_at < csv_at,
+            "entries must be sorted: {body}"
+        );
     }
 
     #[test]

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -266,8 +266,14 @@ pub fn build(state: AppState, rate_limit: Option<RateLimit>) -> Router {
     // governor; the rest fall under the global governor attached below.
     app = app
         .route("/v3/system/status", get(handler::system_status))
-        .route("/v3/system/historical/status", get(handler::system_historical_status))
-        .route("/v3/system/streaming/status", get(handler::system_streaming_status))
+        .route(
+            "/v3/system/historical/status",
+            get(handler::system_historical_status),
+        )
+        .route(
+            "/v3/system/streaming/status",
+            get(handler::system_streaming_status),
+        )
         .route(
             "/v3/system/shutdown",
             post(handler::system_shutdown).route_layer(
@@ -721,9 +727,7 @@ mod tests {
         async fn flat_marker() -> &'static str {
             "FLAT"
         }
-        async fn rt_marker(
-            axum::extract::Path(rt): axum::extract::Path<String>,
-        ) -> String {
+        async fn rt_marker(axum::extract::Path(rt): axum::extract::Path<String>) -> String {
             format!("RT:{rt}")
         }
 

--- a/tools/server/src/ws/format.rs
+++ b/tools/server/src/ws/format.rs
@@ -411,7 +411,13 @@ mod tests {
             .expect("Trade serialization must succeed");
 
         for key in [
-            "ms_of_day", "sequence", "size", "condition", "price", "exchange", "date",
+            "ms_of_day",
+            "sequence",
+            "size",
+            "condition",
+            "price",
+            "exchange",
+            "date",
         ] {
             assert!(
                 json.contains(&format!("\"{key}\":")),
@@ -451,7 +457,13 @@ mod tests {
         let json = fpss_event_to_ws_json(&event, Some(&contract))
             .expect("MARKET_VALUE serialization must succeed");
 
-        for key in ["ms_of_day", "market_bid", "market_ask", "market_price", "date"] {
+        for key in [
+            "ms_of_day",
+            "market_bid",
+            "market_ask",
+            "market_price",
+            "date",
+        ] {
             assert!(
                 json.contains(&format!("\"{key}\":")),
                 "MARKET_VALUE frame must carry the `{key}` column: {json}"
@@ -602,7 +614,8 @@ mod tests {
             // Key order inside the header object is serializer-defined;
             // assert on content, not byte-exact key ordering.
             assert!(
-                json.contains("\"type\":\"STATUS\"") && json.contains("\"status\":\"DISCONNECTED\""),
+                json.contains("\"type\":\"STATUS\"")
+                    && json.contains("\"status\":\"DISCONNECTED\""),
                 "disconnect must be a bare STATUS:DISCONNECTED frame: {json}"
             );
             // The terminal's STATUS frame carries no `reason` field.
@@ -670,7 +683,8 @@ mod tests {
             // Key order inside the header object is serializer-defined;
             // assert on content, not byte-exact key ordering.
             assert!(
-                json.contains("\"type\":\"STATE\"") && json.contains(&format!("\"state\":\"{state}\"")),
+                json.contains("\"type\":\"STATE\"")
+                    && json.contains(&format!("\"state\":\"{state}\"")),
                 "lifecycle must be a STATE/{state} frame: {json}"
             );
             assert!(
@@ -687,21 +701,19 @@ mod tests {
     #[test]
     fn our_only_frame_types_are_not_emitted() {
         // ServerError -> no ERROR frame.
-        let server_error =
-            StreamEvent::Control(thetadatadx::fpss::StreamControl::ServerError {
-                message: "boom".to_string(),
-            });
+        let server_error = StreamEvent::Control(thetadatadx::fpss::StreamControl::ServerError {
+            message: "boom".to_string(),
+        });
         assert!(
             fpss_event_to_ws_json(&server_error, None).is_none(),
             "ServerError must not emit a header.type=ERROR frame"
         );
 
         // ContractAssigned -> no standalone CONTRACT frame.
-        let assigned =
-            StreamEvent::Control(thetadatadx::fpss::StreamControl::ContractAssigned {
-                id: 7,
-                contract: Arc::new(Contract::stock("AAPL")),
-            });
+        let assigned = StreamEvent::Control(thetadatadx::fpss::StreamControl::ContractAssigned {
+            id: 7,
+            contract: Arc::new(Contract::stock("AAPL")),
+        });
         assert!(
             fpss_event_to_ws_json(&assigned, None).is_none(),
             "ContractAssigned must not emit a standalone CONTRACT frame"
@@ -716,8 +728,11 @@ mod tests {
             received_at_ns: 0,
         });
         assert!(
-            fpss_event_to_ws_json(&oi, Some(&Contract::option_raw("SPY", 20_260_417, true, 550_000)))
-                .is_none(),
+            fpss_event_to_ws_json(
+                &oi,
+                Some(&Contract::option_raw("SPY", 20_260_417, true, 550_000))
+            )
+            .is_none(),
             "OpenInterest must not emit an OPEN_INTEREST frame"
         );
     }

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -708,7 +708,10 @@ mod tests {
             parse_strike_thousandths(&sonic_rs::json!(550_500)).unwrap(),
             550_500
         );
-        assert_eq!(parse_strike_thousandths(&sonic_rs::json!(500)).unwrap(), 500);
+        assert_eq!(
+            parse_strike_thousandths(&sonic_rs::json!(500)).unwrap(),
+            500
+        );
     }
 
     #[test]


### PR DESCRIPTION
Final cleanup pass of the de-bloat campaign: the remaining small binding dedups, two review nits, and a long-standing rustfmt drift, each build-verified.

## Binding dedups

**Finding 4 (TypeScript activeFullSubscriptions projection).** The byte-identical `{ kind, contract }` `filter_map` in `sdks/typescript/src/lib.rs` (unified `Client`) and `sdks/typescript/src/fpss_client.rs` (standalone `StreamingClient`) is hoisted into one `pub(crate) fn project_full_subscriptions` in `lib.rs`, called from both. Net about -15 lines. The unified caller drops to `.map(project_full_subscriptions)`; the standalone caller passes the `Vec` directly. The now-unused `SubscriptionKind` import in `fpss_client.rs` is removed.

**Finding 5 (Python pyarrow conversions).** `pyarrow_table_to_pandas` / `pyarrow_table_to_polars` in `sdks/python/src/lib.rs` were re-copied byte-for-byte as `_local` variants in `flatfile_methods.rs`. The originals are promoted to `pub(crate)`, the copies deleted, and the flat-file surface now imports and calls the originals. Net about -24 lines. The newly-unused `PyImportError` import in `flatfile_methods.rs` is dropped.

**Finding 7 (TypeScript validate_nonneg_i32).** The standalone `validate_nonneg_i32` had zero direct callers; all 170 sites route through the `validate_optional_nonneg_i32` wrapper. The standalone is inlined into the wrapper and deleted; the wrapper doc and a stale codegen-template comment are updated to match. Net about -11 lines.

**Finding 8 (C++ ClientBuilder & / && setter pairs) — KEPT, not collapsed.** The 13 fluent setters are written as lvalue (`&`) / rvalue (`&&`) overload pairs. The split is load-bearing: the C++ test suite chains setters on named (lvalue) builders (`thetadatadx_client.cpp` lines 85, 112, 129), which an `&&`-only collapse would stop compiling. The alternative, a forwarding macro, would introduce the first function-like macro into an otherwise macro-free 3.5K-line public header, trading mechanical low-risk duplication for harder-to-read indirection. Per the campaign brief (do not force a dedup onto a load-bearing shape), the pairs stay. `check_binding_parity.py` confirms `builder_setters rust=13 cpp=13`.

## Review nits

**Forwarder param-shape guard.** The Forwarder emitter in `sdk_surface/typescript.rs` and `sdk_surface/python.rs` hardcodes a single `(code: i32)` parameter in the generated body rather than reading the spec params. Spec validation already pins a Forwarder to the `(code, i32)` layout, but the emitters trusted that implicitly. Added `assert_forwarder_code_params` (sharing a lifted `FORWARDER_CODE_PARAMS` constant with the validator) and call it from both emitter arms, so a future differently-shaped forwarder fails the build at emit time instead of silently mis-emitting a body that ignores its spec.

**Reconnect-site dedup — DONE.** Re-examined the three reconnect/drain sites. Two (`await_drain`, `free`) already route through the shared `await_flags` helper from the prior pass. The third, the reconnect drain barrier in `ffi/src/streaming.rs`, was the only inline spin loop left in non-test code; it cleanly routes through `await_flags` via `std::slice::from_ref` with no per-site branching, with the `set_error` + `-1` return kept caller-side. The two test-only helpers (`wait_for_drain`, `wait_for_deliveries`) have count-based / panic-on-timeout shapes and stay as-is.

## Formatting

A separate `style:` commit clears pre-existing `cargo fmt --check` drift in `tools/server` (in files this campaign did not otherwise touch) and in the python / typescript benchmark and config helpers. No behavior change.

## Verification

All green: `cargo check -p thetadatadx` across default / `__test-helpers` / `arrow,polars,frames,config-file`; python maturin build; typescript napi `npm run build` with `index.d.ts` and `index.js` byte-identical (no surface drift); C++ test target builds and the ClientBuilder suite passes; `check_binding_parity.py` clean; `generate_sdk_surfaces --check` and `generate_docs_site --check` no drift; `regen_byte_identical.sh` byte-identical across 324 files; `.pyi` stubtest passes; `clippy --workspace --all-targets --locked -D warnings` plus the excluded SDK crates clean; `cargo doc --no-deps --workspace`; `cargo fmt --check` clean across the workspace and every standalone crate; tests pass (core lib 1018, ffi lib 91, python 437, typescript 202, server 186). No new `#[allow]`. All five lockfiles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)