### PR TITLE
fix: drop inner lock before streaming-session teardown + dead libc dep + stale doc

### DIFF
--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -286,14 +286,6 @@ heck = "0.5.0"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
 
-# POSIX `pipe2` / `write` / `close` for the asyncio wake-fd bridge used
-# by the Python SDK's `streaming_async()` surface (see
-# `src/fpss/wake.rs`). Pure libc — no abstraction layer — because we
-# only need three syscalls and want the wake path to stay
-# zero-allocation.
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [[bench]]
 # Drives `thetadatadx::wire` proto types + `thetadatadx::decode` cell
 # extractors against fixture-built `DataTable` payloads; gated on

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -143,7 +143,7 @@ pub mod grpc;
 pub(crate) mod observability;
 
 // The binary-encoding data layer — tick types, enums, `Price`, the
-// FIT/FIE codecs, Black-Scholes Greeks, and the condition / exchange /
+// FIT codec, Black-Scholes Greeks, and the condition / exchange /
 // sequence lookups. The crate root re-exports its public surface under
 // stable `thetadatadx::*` paths (see the re-export blocks below); the
 // `tdbe` name itself stays internal so the SDK ships as one crate with
@@ -151,7 +151,7 @@ pub(crate) mod observability;
 // the `tdbe` path consumers must not depend on.
 //
 // The layer carries the complete data-format API: some entry points
-// (the per-Greek Black-Scholes primitives, the FIE encoder, the
+// (the per-Greek Black-Scholes primitives, the FIT codec, the
 // canonical-JSON helpers, a handful of enum/error constructors) have no
 // caller inside a default-feature build — they are reached by the
 // `__internal` re-exports below (workspace tools and bindings) and by the
@@ -499,7 +499,7 @@ pub mod utils {
 // (`tools/cli`, `tools/server`, `tools/mcp`), bindings (`ffi`,
 // `sdks/python`, `sdks/typescript`), and the bench harnesses reach a few
 // more data-layer items: the DST-aware epoch math, the canonical JSON
-// finite-or-null sanitiser, the FIT/FIE codecs, and the calendar-status
+// finite-or-null sanitiser, the FIT codec, and the calendar-status
 // enum the generated tick constructors validate against. These are gated
 // on `__internal` so they stay out of the SemVer commitment and rendered
 // rustdoc; external crates MUST NOT enable that feature. The `tdbe` name
@@ -525,7 +525,7 @@ pub use crate::tdbe::time;
 #[doc(hidden)]
 pub use crate::tdbe::json_canon;
 
-/// FIT/FIE 4-bit nibble codecs for FPSS tick compression.
+/// FIT 4-bit nibble codec for FPSS tick compression.
 ///
 /// Only available when the `__internal` feature is enabled. NOT a stable
 /// public surface — for workspace tools and bindings only.

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -2486,7 +2486,13 @@ fn join_extracted_session(handle: &ThetaDataDxStreamHandle, session: FfpssDispat
 /// the handle terminal under the `dispatcher` lock before extracting
 /// `session`.
 fn retire_session(handle: &ThetaDataDxStreamHandle, session: FfpssDispatcherSession) {
-    if let Some(client) = handle.inner.lock_recover().take() {
+    // Bind the take to a `let` so the `inner` guard drops at the end of THIS
+    // statement, before `shutdown()`/`drop()` — keeping a dispatcher that
+    // re-enters `handle.inner` via the user callback from observing the lock
+    // held. Holding it across the if-let block (scrutinee form) would extend
+    // the guard over the teardown and break the lock-free re-entry invariant.
+    let taken = handle.inner.lock_recover().take();
+    if let Some(client) = taken {
         handle
             .prev_drained
             .lock_recover()

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2245,7 +2245,6 @@ dependencies = [
  "heck",
  "http",
  "hyper-util",
- "libc",
  "metrics",
  "prost",
  "prost-build",

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2057,7 +2057,6 @@ dependencies = [
  "heck",
  "http",
  "hyper-util",
- "libc",
  "metrics",
  "prost",
  "prost-build",

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1747,7 +1747,6 @@ dependencies = [
  "heck",
  "http",
  "hyper-util",
- "libc",
  "metrics",
  "prost",
  "prost-build",

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2276,7 +2276,6 @@ dependencies = [
  "heck",
  "http",
  "hyper-util",
- "libc",
  "metrics",
  "prost",
  "prost-build",


### PR DESCRIPTION
Applies three findings from a deep audit of the de-bloat campaign.

## `retire_session` held the `inner` lock across `shutdown()`/`drop()` [medium]

The if-let scrutinee form `if let Some(client) = handle.inner.lock_recover().take()` keeps the `MutexGuard` temporary alive to the end of the if-let block, so `inner` stayed locked across `prev_drained.lock()`, `shutdown()`, and `drop()`. That contradicts the function's documented invariant (a dispatcher re-entering `handle.inner` via the user callback must never observe the lock held during teardown) and diverges from the sibling `_reconnect` path, which binds the take to a `let` first. Binding `let taken = handle.inner.lock_recover().take();` drops the guard at the end of the `let` statement, before shutdown/drop, restoring the lock-free re-entry contract.

Guard-scope proof (throwaway rustc probe, since deleted): with the `let`-bound shape a `try_lock` inside the if-let body succeeds (lock already released); with the scrutinee shape the same `try_lock` fails (lock still held). Both asserts passed.

## Dead runtime `libc` dependency [low]

The `[target.'cfg(unix)'.dependencies] libc = "0.2"` block named the deleted `src/fpss/wake.rs` as its sole consumer; `grep -rn 'libc::' crates/thetadatadx/src/` is now empty. Removed the runtime block and its comment. The separate `cfg(unix)` dev-dependency `libc` is retained — still live via `benches/grpc_transport_comparison.rs`. `cargo metadata` confirms `libc` is now a `dev`-only dep of `thetadatadx`; `cargo deny check` and `--locked` builds stay green with no Cargo.lock change.

## Stale FIT/FIE codec docs [low]

`tdbe/codec/fie.rs` was deleted (`codec/mod.rs` now declares only `pub mod fit;`, decode-only). Reworded the data-layer doc comments at lib.rs 146, 154, 502, and 528 from "FIT/FIE codecs" / "FIE encoder" to "FIT codec".

## Verification

`cargo check -p thetadatadx` (default / `__test-helpers` / `arrow,polars,frames,config-file`), FFI cdylib build, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo doc --no-deps --workspace --locked`, `cargo fmt --check`, `cargo test -p thetadatadx --lib` (1018 passed), `cargo test -p thetadatadx-ffi --lib` (91 passed, including `teardown_does_not_deadlock_when_callback_re_enters_the_dispatcher_lock`), `cargo deny check`, and both `generate_sdk_surfaces --check` / `generate_docs_site --check` (no drift) all green. No new `#[allow]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)