### PR TITLE
fix(ffi): release dispatcher lock before the streaming-free drain wait

### DIFF
--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -2944,6 +2944,11 @@ pub unsafe extern "C" fn thetadatadx_streaming_free(handle: *mut ThetaDataDxStre
                 let session = extract_dispatcher_session(&mut disp_guard);
                 drop(disp_guard);
                 retire_session(h, session);
+            } else {
+                // Already terminal: nothing to retire, but the drain wait
+                // below must run lock-free on this path too, so release the
+                // dispatcher lock here rather than holding it to scope end.
+                drop(disp_guard);
             }
 
             // Wait for every superseded session's consumer thread to


### PR DESCRIPTION
## Summary

`thetadatadx_streaming_free` accepts the handle in either lifecycle state. The live branch flips the state to terminal, extracts the session, and drops the dispatcher guard *before* the `await_flags` drain wait. The already-shutdown branch skipped that body entirely, so the guard lived to lexical scope end and was held *across* the drain wait. The doc comment above the lock asserts "the drain wait further down runs lock-free" — that was false on the already-terminal path.

This matters because a dispatcher draining ring-buffered events through the user callback can re-enter a `thetadatadx_streaming_*` status reader that takes the same `dispatcher` lock. Holding the lock across the drain wait on the terminal path reintroduces the exact re-entrancy deadlock window the live path is written to avoid.

The fix adds an `else { drop(disp_guard); }` so both branches release the dispatcher lock before the drain wait. Both paths are now symmetric and the lock-free-drain invariant is honest. No behavior change for in-contract callers (the function still drains then frees).

## Verification

- `cargo fmt -p thetadatadx-ffi -- --check`
- `cargo check` across the default workspace, the `arrow,polars,frames,__test-helpers,config-file` set, and the `testing-panic-boundary` / workspace `__test-helpers` set
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p thetadatadx-ffi --lib` — 91 passed, including `teardown_does_not_deadlock_when_callback_re_enters_the_dispatcher_lock`
- `cargo test -p thetadatadx --lib` — 1018 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)