### PR TITLE
fix(server): WS subscribe + emit option strike in dollars, not thousandths

### DIFF
--- a/tools/server/src/ws/format.rs
+++ b/tools/server/src/ws/format.rs
@@ -306,11 +306,9 @@ fn parse_unresolved_contract_id(symbol: &str) -> Option<i32> {
 /// - `security_type` / `root` are always present (the terminal names the
 ///   keys `security_type` and `root`, not `sec_type` / `symbol`).
 /// - `expiration` / `strike` / `right` are present only for options.
-/// - `strike` is the raw fixed-point integer in thousandths of a dollar —
-///   a `$550.00` strike serializes as `550000`. The terminal carries the
-///   strike as a bare `int` on the wire in both directions
-///   (`Contract.strike` is `int`; `readContract` emits `c.getStrike()`),
-///   so the integer is the contract, not a dollars float.
+/// - `strike` is dollars (a `$550.00` strike serializes as `550.0`), the
+///   same unit every other public surface speaks; the wire's fixed-point
+///   integer never leaves the codec layer.
 fn contract_to_json(c: &Contract) -> sonic_rs::Value {
     let mut obj = sonic_rs::Object::new();
     obj.insert("security_type", sonic_rs::Value::from(c.sec_type.as_str()));
@@ -318,12 +316,13 @@ fn contract_to_json(c: &Contract) -> sonic_rs::Value {
     if let Some(exp) = c.expiration {
         obj.insert("expiration", sonic_rs::Value::from(exp));
     }
-    // Emit the raw thousandths integer the terminal puts on the wire,
-    // never the dollars float: the terminal's `Contract.strike` is an
-    // `int` and `readContract` serializes `c.getStrike()` verbatim, so a
-    // strict terminal client parses `strike` with `getAsInt()`.
-    if let Some(strike) = c.strike_thousandths {
-        obj.insert("strike", sonic_rs::Value::from(strike));
+    // `strike` is dollars on every public surface; the wire's
+    // fixed-point integer never leaves the codec layer.
+    if let Some(strike) = c.strike_dollars() {
+        obj.insert(
+            "strike",
+            sonic_rs::to_value(&strike).expect("f64 should serialize"),
+        );
     }
     if let Some(is_call) = c.is_call {
         obj.insert(
@@ -630,13 +629,12 @@ mod tests {
         }
     }
 
-    /// The contract envelope uses the terminal's key names and unit: an
-    /// option carries `security_type` / `root` (not `sec_type` / `symbol`)
-    /// and `strike` as the raw thousandths integer (a `$550.00` strike is
-    /// `550000`), matching `EventSerializer.readContract` emitting
-    /// `c.getStrike()` verbatim.
+    /// The contract envelope uses the terminal's key names (`security_type`
+    /// / `root`, not `sec_type` / `symbol`) and emits `strike` in dollars
+    /// (a `$550.00` strike serializes as `550.0`) — the same unit every
+    /// other public surface speaks.
     #[test]
-    fn option_contract_envelope_uses_terminal_keys_and_raw_strike() {
+    fn option_contract_envelope_uses_terminal_keys_and_dollar_strike() {
         let contract = Arc::new(Contract::option_raw("SPY", 20_260_417, true, 550_000));
         let event = make_quote(Arc::clone(&contract));
         let json = fpss_event_to_ws_json(&event, Some(&contract))
@@ -650,14 +648,14 @@ mod tests {
             json.contains("\"root\":\"SPY\""),
             "contract must carry `root`, not `symbol`: {json}"
         );
-        // Raw thousandths integer, NOT a dollars float (`550.0`).
+        // Dollars float (`550.0`), NOT the raw thousandths integer.
         assert!(
-            json.contains("\"strike\":550000"),
-            "strike must serialize as the raw thousandths integer: {json}"
+            json.contains("\"strike\":550.0"),
+            "strike must serialize as a dollars float: {json}"
         );
         assert!(
-            !json.contains("\"strike\":550.0") && !json.contains("\"strike\":550,"),
-            "strike must NOT serialize as a dollars float: {json}"
+            !json.contains("\"strike\":550000"),
+            "strike must NOT serialize as the raw thousandths integer: {json}"
         );
         assert!(json.contains("\"expiration\":20260417"), "{json}");
         assert!(json.contains("\"right\":\"C\""), "{json}");

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -279,15 +279,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
-        // `strike` is the raw fixed-point integer in thousandths of a
-        // dollar — the exact value the terminal puts on the wire in both
-        // directions (`Contract.strike` is `int`; `WSEvents` parses it
-        // with `conObj.get("strike").getAsInt()`). A `$550.00` strike is
-        // the integer `550000`. The SDK stores thousandths internally, so
-        // the parsed integer flows straight into `Contract::option_raw`
-        // with no dollar scaling.
+        // `strike` is the price in dollars — the same unit every other
+        // public surface speaks. The wire's fixed-point conversion is
+        // the SDK's job (`parse_strike_dollars` scales to thousandths
+        // internally before `Contract::option_raw`).
         let strike_val = contract_obj.get("strike").unwrap_or(&null_val);
-        let strike = match parse_strike_thousandths(strike_val) {
+        let strike = match parse_strike_dollars(strike_val.as_f64()) {
             Ok(v) => v,
             Err(err_msg) => {
                 tracing::warn!(error = %err_msg, "WS subscribe: invalid option 'strike'");
@@ -499,36 +496,44 @@ const ACCEPTED_REQ_TYPES: &[&str] = &[
     "FULL_OPEN_INTEREST",
 ];
 
-/// Parse the option `strike` field — the FPSS wire's fixed-point integer
-/// in thousandths of a dollar — into the `i32` the contract codec stores.
+/// Parse the option `strike` field (dollars, JSON number) into the
+/// FPSS wire's fixed-point thousandths integer.
 ///
-/// The terminal carries `strike` as a bare integer on the wire and reads
-/// it with `conObj.get("strike").getAsInt()` (`WSEvents.onWebSocketText`),
-/// so a `$550.00` strike arrives as the JSON integer `550000`. This parser
-/// mirrors that: it requires an integer JSON value (a fractional value like
-/// `550.5` is rejected — thousandths are already whole units, so a
-/// fractional thousandths value is malformed), and the value must be a
-/// positive `i32` (the smallest real strike is `1` = $0.001; a non-positive
-/// strike is not a real instrument). Values outside `i32` range are
-/// rejected rather than silently narrowed.
-fn parse_strike_thousandths(raw: &sonic_rs::Value) -> Result<i32, String> {
-    // `as_i64` succeeds only for an integer JSON number, so a fractional
-    // `strike` (e.g. `550.5`) falls through to the error below — the wire
-    // unit is whole thousandths, never a fraction of one.
-    let thousandths = raw.as_i64().ok_or_else(|| {
-        "'strike' must be an integer in thousandths of a dollar (e.g. 550000 for $550.00), \
-         got: <missing, non-numeric, or fractional>"
+/// Accepts any positive finite number at or above the smallest
+/// representable strike; rejects missing / non-numeric values,
+/// non-positive strikes, positive strikes that round to zero in the
+/// thousandths unit (the smallest valid strike is $0.001), and values
+/// whose thousandths scaling overflows `i32`. Dollars are the only
+/// accepted unit; clients holding the wire integer divide by 1000
+/// before subscribing.
+fn parse_strike_dollars(raw: Option<f64>) -> Result<i32, String> {
+    let dollars = raw.ok_or_else(|| {
+        "'strike' must be a number in dollars (e.g. 550 or 550.5), got: <missing or non-numeric>"
             .to_string()
     })?;
-    if thousandths <= 0 {
+    if !dollars.is_finite() || dollars <= 0.0 {
         return Err(format!(
-            "'strike' must be a positive integer in thousandths of a dollar \
-             (e.g. 550000 for $550.00), got {thousandths}"
+            "'strike' must be a positive number in dollars (got {dollars})"
         ));
     }
-    i32::try_from(thousandths).map_err(|_| {
-        format!("'strike' {thousandths} thousandths exceeds the representable i32 range")
-    })
+    let scaled = (dollars * 1000.0).round();
+    // A positive strike below half the smallest representable unit
+    // rounds to zero thousandths. A zero strike is not a real
+    // instrument, so reject it rather than silently collapse the
+    // contract to a $0.00 strike.
+    if scaled < 1.0 {
+        return Err(format!(
+            "'strike' {dollars} is below the smallest representable strike ($0.001)"
+        ));
+    }
+    if scaled > f64::from(i32::MAX) {
+        return Err(format!(
+            "'strike' {dollars} exceeds the representable range after fixed-point scaling"
+        ));
+    }
+    // Reason: bounds checked above; positivity checked above.
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(scaled as i32)
 }
 
 /// Parse the option `right` field into the contract sides to subscribe.
@@ -690,62 +695,42 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    //  strike: raw thousandths integer on the wire (matches the terminal)
+    //  strike dollars -> fixed-point thousandths
     // -----------------------------------------------------------------------
 
     #[test]
-    fn strike_accepts_raw_thousandths_integer() {
-        // The terminal puts `strike` on the wire as the raw thousandths
-        // integer (a `$550.00` strike is `550000`), read via `getAsInt()`.
-        assert_eq!(
-            parse_strike_thousandths(&sonic_rs::json!(550_000)).unwrap(),
-            550_000
-        );
-        // Smallest real strike: 1 thousandth = $0.001.
-        assert_eq!(parse_strike_thousandths(&sonic_rs::json!(1)).unwrap(), 1);
-        // Fractional-dollar strike, still a whole thousandths integer.
-        assert_eq!(
-            parse_strike_thousandths(&sonic_rs::json!(550_500)).unwrap(),
-            550_500
-        );
-        assert_eq!(
-            parse_strike_thousandths(&sonic_rs::json!(500)).unwrap(),
-            500
-        );
+    fn strike_accepts_smallest_representable_and_normal_values() {
+        // $0.001 is the smallest representable strike: it maps to the
+        // smallest nonzero thousandths value.
+        assert_eq!(parse_strike_dollars(Some(0.001)).unwrap(), 1);
+        // Ordinary strikes round-trip through the thousandths scaling.
+        assert_eq!(parse_strike_dollars(Some(550.0)).unwrap(), 550_000);
+        assert_eq!(parse_strike_dollars(Some(550.5)).unwrap(), 550_500);
+        assert_eq!(parse_strike_dollars(Some(0.5)).unwrap(), 500);
     }
 
     #[test]
-    fn strike_rejects_dollars_float_shape() {
-        // A dollars float like `550.5` is NOT the wire shape: thousandths
-        // are whole units, so a fractional value is malformed and must be
-        // rejected rather than silently truncated.
-        let err = parse_strike_thousandths(&sonic_rs::json!(550.5)).unwrap_err();
+    fn strike_rejects_sub_smallest_unit_positive_value() {
+        // 0.0004 dollars scales to 0.4 thousandths, which rounds to 0.
+        // A 0-strike contract is not a real instrument, so the value
+        // must be rejected rather than silently collapsed to zero.
+        let err = parse_strike_dollars(Some(0.0004)).unwrap_err();
         assert!(
-            err.contains("integer in thousandths"),
-            "diagnostic must name the wire unit: {err}"
+            err.contains("smallest representable strike"),
+            "diagnostic must explain the sub-unit floor: {err}"
         );
-        // A whole-number-valued float (`550.0`) is likewise not an integer
-        // JSON number under `as_i64`; the wire carries a bare integer.
-        assert!(parse_strike_thousandths(&sonic_rs::json!(550.0)).is_err());
+        // The boundary: anything in (0, 0.0005) rounds to 0 and is
+        // rejected; $0.0005 rounds up to the smallest valid unit.
+        assert!(parse_strike_dollars(Some(0.0001)).is_err());
+        assert!(parse_strike_dollars(Some(0.0005)).is_ok());
     }
 
     #[test]
     fn strike_rejects_non_positive_and_non_numeric() {
-        assert!(parse_strike_thousandths(&sonic_rs::json!(0)).is_err());
-        assert!(parse_strike_thousandths(&sonic_rs::json!(-1)).is_err());
-        assert!(parse_strike_thousandths(&sonic_rs::json!("550000")).is_err());
-        assert!(parse_strike_thousandths(&sonic_rs::Value::default()).is_err());
-    }
-
-    #[test]
-    fn strike_rejects_out_of_i32_range() {
-        // Beyond i32::MAX thousandths must be rejected, never narrowed.
-        let too_big = i64::from(i32::MAX) + 1;
-        let err = parse_strike_thousandths(&sonic_rs::json!(too_big)).unwrap_err();
-        assert!(
-            err.contains("i32 range"),
-            "diagnostic must name the range bound: {err}"
-        );
+        assert!(parse_strike_dollars(Some(0.0)).is_err());
+        assert!(parse_strike_dollars(Some(-1.0)).is_err());
+        assert!(parse_strike_dollars(Some(f64::NAN)).is_err());
+        assert!(parse_strike_dollars(None).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
The WebSocket subscribe surface accepted and emitted the option `strike` as the raw fixed-point integer in thousandths of a dollar, diverging from the dollars unit the Rust/Python SDK, the REST surface, the docs, and the `scripts/ci/check_docs_consistency.py` gate all speak. A `$550.00` strike had to be sent as `550000` on the wire and came back as `550000` in the contract envelope, which no other public surface does.

This restores the dollars convention on both directions. Inbound, `subscribe.rs` parses `strike` as a dollars number (`570` -> $570.00, `550.5` -> $550.50) and scales to the wire's fixed-point integer internally before building the contract. Outbound, the contract envelope in `format.rs` emits `strike` in dollars (a `$550.00` strike serializes as `550.0`).

Scope is the strike unit only. The terminal contract key names (`security_type` / `root`), the dropped CONTRACT / ERROR / OPEN_INTEREST frames, and the `STATE` lifecycle handling are unchanged. The WS subscribe and format tests are updated to the dollars contract; the OPEN_INTEREST / server-error drop tests are untouched and still pass.

Gates run locally and green: `check_docs_consistency.py`, `cargo check` (core + server), `cargo clippy --all-targets -D warnings` (workspace + server), `cargo fmt --check` (workspace + server), the server and core test suites, and the `generate_sdk_surfaces` / `generate_docs_site` drift checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)