### PR TITLE
refactor(ffi): dedup arrow-ipc batch encode + box-buf + inline single-use error helper

### DIFF
--- a/crates/thetadatadx/src/fpss/ring.rs
+++ b/crates/thetadatadx/src/fpss/ring.rs
@@ -491,8 +491,6 @@ impl Default for RingCursors {
 // ring consumer can share the same contract. Re-export the items here
 // under their historical FPSS paths so existing consumers do not have
 // to change.
-#[cfg(test)]
-use crate::util::ring::RingSizeError;
 pub(crate) use crate::util::ring::{check_ring_size, MIN_RING_SIZE};
 
 // ---------------------------------------------------------------------------
@@ -583,44 +581,6 @@ mod tests {
     fn ring_event_default_is_empty() {
         let e = RingEvent::default();
         assert!(matches!(e.event, FpssEventInternal::Empty));
-    }
-
-    #[test]
-    fn check_ring_size_accepts_powers_of_two() {
-        assert_eq!(check_ring_size(64), Ok(64));
-        assert_eq!(check_ring_size(1024), Ok(1024));
-        assert_eq!(check_ring_size(131_072), Ok(131_072));
-    }
-
-    #[test]
-    fn check_ring_size_rejects_non_power_of_two() {
-        let err = check_ring_size(65).unwrap_err();
-        assert_eq!(
-            err,
-            RingSizeError::NotPowerOfTwo {
-                provided: 65,
-                suggested: 128,
-            }
-        );
-    }
-
-    #[test]
-    fn check_ring_size_rejects_below_minimum() {
-        let err = check_ring_size(32).unwrap_err();
-        assert_eq!(
-            err,
-            RingSizeError::TooSmall {
-                provided: 32,
-                minimum: MIN_RING_SIZE,
-            }
-        );
-    }
-
-    #[test]
-    fn check_ring_size_error_messages_name_offender() {
-        let msg = check_ring_size(1000).unwrap_err().to_string();
-        assert!(msg.contains("1000"));
-        assert!(msg.contains("1024"));
     }
 
     #[test]

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -98,7 +98,9 @@ pub(crate) fn set_error_with_code(msg: &str, code: i32) {
 /// on to pick the right exception class. A rate-limit back-off hint, if
 /// the error carries one, is stashed for [`thetadatadx_last_error_retry_after_ms`].
 pub(crate) fn set_error_from(err: &thetadatadx::Error) {
-    set_error_string_only(&err.to_string());
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = CString::new(err.to_string()).ok();
+    });
     LAST_ERROR_CODE.with(|c| c.set(error_code_for(err)));
     let retry_after_ms = err
         .retry_after()
@@ -113,16 +115,6 @@ pub(crate) fn set_error_from(err: &thetadatadx::Error) {
 /// failure.
 fn clear_retry_after() {
     LAST_ERROR_RETRY_AFTER_MS.with(|c| c.set(THETADATADX_RETRY_AFTER_NONE));
-}
-
-/// Set the error string without touching the typed code. Used by the
-/// `set_error_from` helper above (which sets the code separately) and
-/// by call sites that surface a non-thetadatadx error (e.g. parse
-/// errors raised inside the FFI before any RPC fires).
-fn set_error_string_only(msg: &str) {
-    LAST_ERROR.with(|e| {
-        *e.borrow_mut() = CString::new(msg).ok();
-    });
 }
 
 /// Map a `thetadatadx::Error` to its typed C ABI discriminant. The

--- a/ffi/src/flatfiles.rs
+++ b/ffi/src/flatfiles.rs
@@ -16,11 +16,9 @@
 //! so language wrappers can defer the schema-inferring Arrow conversion
 //! until the user picks a representation.
 
-use std::io::Cursor;
 use std::os::raw::c_char;
 use std::ptr;
 
-use arrow_ipc::writer::StreamWriter;
 use thetadatadx::flatfiles::{self, FlatFileFormat, FlatFileRow, ReqType, SecType};
 
 use crate::error::{cstr_to_str, set_error, set_error_from};
@@ -63,9 +61,7 @@ impl ThetaDataDxFlatFileBytes {
                 len: 0,
             };
         }
-        let boxed = buf.into_boxed_slice();
-        let len = boxed.len();
-        let data = Box::into_raw(boxed) as *const u8;
+        let (data, len) = crate::types::box_buf(buf);
         Self { data, len }
     }
 }
@@ -246,35 +242,16 @@ pub unsafe extern "C" fn thetadatadx_flatfile_rows_to_arrow_ipc(
                     };
                 }
             };
-            let schema = batch.schema();
-            let mut buf: Vec<u8> = Vec::new();
-            {
-                let mut writer = match StreamWriter::try_new(Cursor::new(&mut buf), &schema) {
-                    Ok(w) => w,
-                    Err(e) => {
-                        set_error(&format!("arrow ipc writer init failed: {e}"));
-                        return ThetaDataDxFlatFileBytes {
-                            data: ptr::null(),
-                            len: 0,
-                        };
+            match crate::streaming_batches_ipc::bytes_from_batch(&batch) {
+                Ok(buf) => ThetaDataDxFlatFileBytes::from_vec(buf),
+                Err(e) => {
+                    set_error(&e);
+                    ThetaDataDxFlatFileBytes {
+                        data: ptr::null(),
+                        len: 0,
                     }
-                };
-                if let Err(e) = writer.write(&batch) {
-                    set_error(&format!("arrow ipc write failed: {e}"));
-                    return ThetaDataDxFlatFileBytes {
-                        data: ptr::null(),
-                        len: 0,
-                    };
-                }
-                if let Err(e) = writer.finish() {
-                    set_error(&format!("arrow ipc finish failed: {e}"));
-                    return ThetaDataDxFlatFileBytes {
-                        data: ptr::null(),
-                        len: 0,
-                    };
                 }
             }
-            ThetaDataDxFlatFileBytes::from_vec(buf)
         }
     )
 }

--- a/ffi/src/streaming_batches_ipc.rs
+++ b/ffi/src/streaming_batches_ipc.rs
@@ -40,6 +40,30 @@ pub(crate) fn batch_to_ipc(batch: &RecordBatch) -> Result<Vec<u8>, String> {
     Ok(buf)
 }
 
+/// Serialise a [`RecordBatch`] as an Arrow IPC stream, without the row-count
+/// capacity seed [`batch_to_ipc`] applies. The streaming reader's seed is
+/// calibrated for the fixed 40-column streaming schema, so the per-tick and
+/// flat-file terminals (whose schemas differ) start from an empty buffer and
+/// let the writer grow it.
+///
+/// # Errors
+///
+/// Returns a human-readable message on an IPC writer / write / finish failure.
+pub(crate) fn bytes_from_batch(batch: &RecordBatch) -> Result<Vec<u8>, String> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(std::io::Cursor::new(&mut buf), &batch.schema())
+            .map_err(|e| format!("arrow ipc writer init failed: {e}"))?;
+        writer
+            .write(batch)
+            .map_err(|e| format!("arrow ipc write failed: {e}"))?;
+        writer
+            .finish()
+            .map_err(|e| format!("arrow ipc finish failed: {e}"))?;
+    }
+    Ok(buf)
+}
+
 /// Serialise just a schema as a schema-only Arrow IPC stream (no batches),
 /// so a reader can report its fixed schema before the first batch.
 ///

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -365,11 +365,22 @@ impl ThetaDataDxArrowBytes {
         if buf.is_empty() {
             return Self::EMPTY;
         }
-        let boxed = buf.into_boxed_slice();
-        let len = boxed.len();
-        let data = Box::into_raw(boxed) as *const u8;
+        let (data, len) = box_buf(buf);
         Self { data, len }
     }
+}
+
+/// Leak a non-empty byte buffer as a raw `(ptr, len)` pair owned by the
+/// caller. The pointer comes from `Box::into_raw` on a `Box<[u8]>`, so the
+/// matching free path is `Box::from_raw(slice_from_raw_parts_mut(ptr, len))`.
+/// Shared by [`ThetaDataDxArrowBytes::from_vec`] and
+/// `ThetaDataDxFlatFileBytes::from_vec` (each keeps its own empty-sentinel guard
+/// and distinct `#[repr(C)]` name).
+pub(crate) fn box_buf(buf: Vec<u8>) -> (*const u8, usize) {
+    let boxed = buf.into_boxed_slice();
+    let len = boxed.len();
+    let data = Box::into_raw(boxed) as *const u8;
+    (data, len)
 }
 
 /// Serialise a `&[$tick]` to Arrow IPC bytes through the shared
@@ -409,28 +420,13 @@ macro_rules! tick_array_to_arrow_ipc {
                         return ThetaDataDxArrowBytes::EMPTY;
                     }
                 };
-                let mut buf: Vec<u8> = Vec::new();
-                {
-                    let mut writer = match arrow_ipc::writer::StreamWriter::try_new(
-                        std::io::Cursor::new(&mut buf),
-                        &batch.schema(),
-                    ) {
-                        Ok(w) => w,
-                        Err(e) => {
-                            crate::error::set_error(&format!("arrow ipc writer init failed: {e}"));
-                            return ThetaDataDxArrowBytes::EMPTY;
-                        }
-                    };
-                    if let Err(e) = writer.write(&batch) {
-                        crate::error::set_error(&format!("arrow ipc write failed: {e}"));
-                        return ThetaDataDxArrowBytes::EMPTY;
-                    }
-                    if let Err(e) = writer.finish() {
-                        crate::error::set_error(&format!("arrow ipc finish failed: {e}"));
-                        return ThetaDataDxArrowBytes::EMPTY;
+                match crate::streaming_batches_ipc::bytes_from_batch(&batch) {
+                    Ok(buf) => ThetaDataDxArrowBytes::from_vec(buf),
+                    Err(e) => {
+                        crate::error::set_error(&e);
+                        ThetaDataDxArrowBytes::EMPTY
                     }
                 }
-                ThetaDataDxArrowBytes::from_vec(buf)
             })
         }
     };


### PR DESCRIPTION
Four hand-written shrinks in the FFI + core crates, behaviour unchanged.

- The 18 `tick_array_to_arrow_ipc!` expansions and `thetadatadx_flatfile_rows_to_arrow_ipc` each reimplemented the IPC StreamWriter init/write/finish block. Extracted `streaming_batches_ipc::bytes_from_batch(&RecordBatch)` and call it from all of them. Both call sites already started from a bare `Vec::new()`, so no pre-sizing was dropped; `batch_to_ipc` keeps its row-count seed, which is calibrated for the fixed 40-column streaming schema and would mis-size the differently-shaped per-tick / flat-file schemas.
- `ThetaDataDxArrowBytes::from_vec` and `ThetaDataDxFlatFileBytes::from_vec` shared a 4-line raw-buffer leak. Extracted `types::box_buf(Vec<u8>) -> (*const u8, usize)`; both structs stay distinct (their `#[repr(C)]` names are ABI surface).
- `set_error_string_only` had one non-test caller (`set_error_from`). Inlined the three-line body and deleted the helper.
- `fpss/ring.rs` carried four `check_ring_size` tests duplicating `util/ring.rs` verbatim (where the function lives); deleted them and the now-unused test-only `RingSizeError` import.

Net -51 lines. No new `#[allow]`.

Gates: `cargo check -p thetadatadx-ffi` + `-p thetadatadx` (default, `--no-default-features`, `--features arrow,polars,frames,config-file,__internal`); `clippy --workspace --all-targets --locked -D warnings`; `fmt --check`; `generate_sdk_surfaces --check` + `generate_docs_site --check`; `check_binding_parity.py`; `cargo test -p thetadatadx-ffi --lib` (91 passed) + `-p thetadatadx --lib` (1014 passed). All clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)