### PR TITLE
refactor(server): drop dead flatfile path-rejection + dedup error/validation/ws constants

### DIFF
--- a/tools/mcp/src/flatfile_tools.rs
+++ b/tools/mcp/src/flatfile_tools.rs
@@ -242,13 +242,6 @@ fn parse_format(value: Option<&str>) -> Result<FlatFileFormat, String> {
     }
 }
 
-fn arg_str(args: &Value, key: &str) -> Result<String, String> {
-    args.get(key)
-        .and_then(sonic_rs::JsonValueTrait::as_str)
-        .map(ToString::to_string)
-        .ok_or_else(|| format!("missing required string argument: {key}"))
-}
-
 fn arg_str_opt(args: &Value, key: &str) -> Option<String> {
     args.get(key)
         .and_then(sonic_rs::JsonValueTrait::as_str)
@@ -288,11 +281,11 @@ pub(crate) async fn try_execute_flatfile_tool(
     args: &Value,
 ) -> Option<Result<Value, ToolError>> {
     let (sec_type, req_type) = if name == "thetadatadx_flatfile_request" {
-        let sec_str = match arg_str(args, "sec_type") {
+        let sec_str = match crate::arg_str(args, "sec_type") {
             Ok(s) => s,
             Err(e) => return Some(Err(ToolError::InvalidParams(e))),
         };
-        let req_str = match arg_str(args, "req_type") {
+        let req_str = match crate::arg_str(args, "req_type") {
             Ok(s) => s,
             Err(e) => return Some(Err(ToolError::InvalidParams(e))),
         };
@@ -321,7 +314,7 @@ pub(crate) async fn try_execute_flatfile_tool(
         ))));
     }
 
-    let date = match arg_str(args, "date") {
+    let date = match crate::arg_str(args, "date") {
         Ok(d) => d,
         Err(e) => return Some(Err(ToolError::InvalidParams(e))),
     };

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -44,9 +44,9 @@ const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2024-11-05"];
 // ═══════════════════════════════════════════════════════════════════════════
 
 /// Validated JSON-RPC 2.0 request (built from raw JSON, not via Deserialize).
+/// The `jsonrpc` version is validated to be `"2.0"` during parsing and then
+/// dropped — nothing downstream re-reads it.
 struct JsonRpcRequest {
-    /// Already validated to be "2.0" during parsing.
-    _jsonrpc: String,
     id: Option<Value>,
     method: String,
     params: Value,
@@ -141,17 +141,13 @@ fn parse_jsonrpc_request(line: &str) -> Result<JsonRpcRequest, JsonRpcResponse> 
                 -32600,
                 "Invalid request: missing or non-string 'jsonrpc' field".into(),
             )
-        })?
-        .to_string();
+        })?;
 
     if jsonrpc != "2.0" {
         return Err(JsonRpcResponse::error(
             id_for_error.clone(),
             -32600,
-            format!(
-                "Invalid request: unsupported JSON-RPC version '{}', expected '2.0'",
-                jsonrpc
-            ),
+            format!("Invalid request: unsupported JSON-RPC version '{jsonrpc}', expected '2.0'"),
         ));
     }
 
@@ -192,12 +188,7 @@ fn parse_jsonrpc_request(line: &str) -> Result<JsonRpcRequest, JsonRpcResponse> 
         ));
     }
 
-    Ok(JsonRpcRequest {
-        _jsonrpc: jsonrpc,
-        id,
-        method,
-        params,
-    })
+    Ok(JsonRpcRequest { id, method, params })
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tools/server/src/flatfile_routes.rs
+++ b/tools/server/src/flatfile_routes.rs
@@ -34,11 +34,11 @@
 use std::path::PathBuf;
 
 use axum::body::Body;
-use axum::extract::rejection::{JsonRejection, PathRejection, QueryRejection};
+use axum::extract::rejection::{JsonRejection, QueryRejection};
 use axum::extract::{FromRequest, FromRequestParts, Path, Query, Request, State};
 use axum::http::request::Parts;
 use axum::http::{header, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use axum::routing::{get, post};
 use axum::Router;
 use serde::Deserialize;
@@ -47,7 +47,7 @@ use thetadatadx::flatfiles::{
 };
 use tokio_util::io::ReaderStream;
 
-use crate::format;
+use crate::handler::error_response;
 use crate::state::AppState;
 
 /// Query parameters for the convenience flat-file route
@@ -162,60 +162,6 @@ fn query_rejection_response(rejection: &QueryRejection) -> Response {
     error_response(rejection.status(), "bad_request", &rejection.body_text())
 }
 
-// ── Path extractor with a canonical-envelope rejection ───────────────────
-
-/// `axum::Path` wrapper whose extraction failure renders the server's
-/// canonical error envelope instead of axum's default plain-text 400.
-///
-/// The `{sec_type}/{req_type}` segments deserialize to `String`, which
-/// cannot fail on a UTF-8-valid path that the router already matched, so
-/// this rejection is not reachable from untrusted input in practice. It
-/// is wired through the same envelope helper anyway so that the GET route
-/// has no remaining extractor that could answer with a non-canonical body,
-/// matching the defensiveness of the POST `FlatfileJson` path.
-pub(crate) struct FlatfilePath<T>(pub(crate) T);
-
-impl<S, T> FromRequestParts<S> for FlatfilePath<T>
-where
-    axum::extract::Path<T>: FromRequestParts<S, Rejection = PathRejection>,
-    S: Send + Sync,
-{
-    type Rejection = Response;
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
-            Ok(Path(value)) => Ok(Self(value)),
-            Err(rejection) => Err(path_rejection_response(&rejection)),
-        }
-    }
-}
-
-/// Map a `PathRejection` onto the canonical error envelope.
-fn path_rejection_response(rejection: &PathRejection) -> Response {
-    error_response(rejection.status(), "bad_request", &rejection.body_text())
-}
-
-// ── Wire-friendly error response ─────────────────────────────────────────
-
-fn error_response(status: StatusCode, error_type: &str, msg: &str) -> Response {
-    let mut body = format::error_envelope(error_type, msg);
-    let json_bytes =
-        thetadatadx::json_canon::canonicalize_and_serialize(&mut body).unwrap_or_else(|err| {
-            tracing::error!(error = %err, "flatfile error envelope serialise failed");
-            format!(
-                "{{\"header\":{{\"error_type\":\"serialization_error\",\
-                 \"error_msg\":\"flatfile error envelope failed: {err}\"}},\
-                 \"response\":[]}}"
-            )
-        });
-    (
-        status,
-        [(header::CONTENT_TYPE, crate::handler::JSON_CONTENT_TYPE)],
-        json_bytes,
-    )
-        .into_response()
-}
-
 // ── Enum parsing ─────────────────────────────────────────────────────────
 
 fn parse_sec_type(s: &str) -> Result<SecType, String> {
@@ -281,7 +227,9 @@ fn content_type_for(format: FlatFileFormat) -> &'static str {
 
 async fn handle_get(
     state: State<AppState>,
-    FlatfilePath((sec_type_s, req_type_s)): FlatfilePath<(String, String)>,
+    // Router-matched UTF-8 path segments deserialize to `String` infallibly,
+    // so plain `Path` never rejects here — no custom envelope wrapper needed.
+    Path((sec_type_s, req_type_s)): Path<(String, String)>,
     FlatfileQueryExtractor(params): FlatfileQueryExtractor<FlatfileQuery>,
 ) -> Response {
     let sec_type = match parse_sec_type(&sec_type_s) {

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -87,12 +87,12 @@ use crate::state::AppState;
 /// timeout (the future drops, releasing both permits). The full model is
 /// documented in `docs-site/docs/server/http.md` under "Concurrency
 /// model".
-const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
+pub(crate) const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
 
 /// Max request body size. 64 KB comfortably covers any realistic query
 /// string + headers for this API; anything larger is DoS or a broken
 /// client.
-const BODY_LIMIT_BYTES: usize = 64 * 1024;
+pub(crate) const BODY_LIMIT_BYTES: usize = 64 * 1024;
 
 /// Fallback general per-IP quota applied only when the operator opts into
 /// rate limiting by setting one of the two rate-limit env vars but not the

--- a/tools/server/src/validation.rs
+++ b/tools/server/src/validation.rs
@@ -69,22 +69,25 @@ pub const MAX_GENERIC_LEN: usize = 64;
 /// observed length so error responses are actionable.
 #[derive(Debug, Clone)]
 pub struct ValidationError {
-    pub field: &'static str,
+    /// `Cow` so a registry-declared `&'static str` name is borrowed for free,
+    /// while a non-registry query-param name (`validate_query_param`) is kept
+    /// owned without a 19-arm literal-identity round-trip.
+    pub field: std::borrow::Cow<'static, str>,
     pub message: String,
 }
 
 impl ValidationError {
-    fn too_long(field: &'static str, observed: usize, limit: usize) -> Self {
+    fn too_long(field: &str, observed: usize, limit: usize) -> Self {
         Self {
-            field,
             message: format!("'{field}' exceeds maximum length of {limit} bytes (got {observed})"),
+            field: std::borrow::Cow::Owned(field.to_owned()),
         }
     }
 
-    fn invalid_content(field: &'static str, detail: &str) -> Self {
+    fn invalid_content(field: &str, detail: &str) -> Self {
         Self {
-            field,
             message: format!("'{field}' {detail}"),
+            field: std::borrow::Cow::Owned(field.to_owned()),
         }
     }
 }
@@ -129,7 +132,7 @@ impl std::error::Error for ValidationError {}
 /// # Errors
 /// Returns `ValidationError::invalid_content` when `value` contains any
 /// character for which `char::is_control` is true.
-pub fn ensure_no_control_chars(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn ensure_no_control_chars(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.chars().any(|c| c.is_control()) {
         return Err(ValidationError::invalid_content(
             field,
@@ -152,7 +155,7 @@ pub fn ensure_no_control_chars(value: &str, field: &'static str) -> Result<(), V
 /// # Errors
 /// Returns `ValidationError::invalid_content` when `value` contains `/`,
 /// `\`, or the `..` parent reference.
-pub fn ensure_no_path_separators(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn ensure_no_path_separators(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.contains('/') || value.contains('\\') || value.contains("..") {
         return Err(ValidationError::invalid_content(
             field,
@@ -174,7 +177,7 @@ pub fn ensure_no_path_separators(value: &str, field: &'static str) -> Result<(),
 /// # Errors
 /// Returns a `ValidationError` when `value` is empty, exceeds
 /// [`MAX_SYMBOL_LEN`], or contains control characters.
-pub fn validate_symbol(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_symbol(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.is_empty() {
         return Err(ValidationError::invalid_content(field, "must be non-empty"));
     }
@@ -194,7 +197,7 @@ pub fn validate_symbol(value: &str, field: &'static str) -> Result<(), Validatio
 /// # Errors
 /// Returns a `ValidationError` when `value` exceeds [`MAX_SYMBOLS_LEN`] or
 /// contains control characters.
-pub fn validate_symbols_list(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_symbols_list(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_SYMBOLS_LEN {
         return Err(ValidationError::too_long(
             field,
@@ -214,7 +217,7 @@ pub fn validate_symbols_list(value: &str, field: &'static str) -> Result<(), Val
 /// Returns a `ValidationError` when `value` exceeds [`MAX_DATE_LEN`],
 /// contains control characters, or contains a filesystem path separator
 /// (the date is interpolated into a flatfile artefact path downstream).
-pub fn validate_date(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_date(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_DATE_LEN {
         return Err(ValidationError::too_long(field, value.len(), MAX_DATE_LEN));
     }
@@ -228,7 +231,7 @@ pub fn validate_date(value: &str, field: &'static str) -> Result<(), ValidationE
 /// # Errors
 /// Returns a `ValidationError` when `value` exceeds [`MAX_STRIKE_LEN`] or
 /// contains control characters.
-pub fn validate_strike(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_strike(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_STRIKE_LEN {
         return Err(ValidationError::too_long(
             field,
@@ -245,7 +248,7 @@ pub fn validate_strike(value: &str, field: &'static str) -> Result<(), Validatio
 /// # Errors
 /// Returns a `ValidationError` when `value` is empty, exceeds
 /// [`MAX_RIGHT_LEN`], or contains control characters.
-pub fn validate_right(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_right(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.is_empty() {
         return Err(ValidationError::invalid_content(field, "must be non-empty"));
     }
@@ -261,7 +264,7 @@ pub fn validate_right(value: &str, field: &'static str) -> Result<(), Validation
 /// # Errors
 /// Returns a `ValidationError` when `value` exceeds [`MAX_INTERVAL_LEN`] or
 /// contains control characters.
-pub fn validate_interval(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_interval(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_INTERVAL_LEN {
         return Err(ValidationError::too_long(
             field,
@@ -278,7 +281,7 @@ pub fn validate_interval(value: &str, field: &'static str) -> Result<(), Validat
 /// # Errors
 /// Returns a `ValidationError` when `value` exceeds [`MAX_VENUE_LEN`] or
 /// contains control characters.
-pub fn validate_venue(value: &str, field: &'static str) -> Result<(), ValidationError> {
+pub fn validate_venue(value: &str, field: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_VENUE_LEN {
         return Err(ValidationError::too_long(field, value.len(), MAX_VENUE_LEN));
     }
@@ -310,7 +313,7 @@ pub fn validate_generic_named(value: &str, param_name: &str) -> Result<(), Valid
     if value.len() > MAX_GENERIC_LEN {
         let safe_name: String = sanitize_param_name(param_name);
         return Err(ValidationError {
-            field: "parameter",
+            field: std::borrow::Cow::Borrowed("parameter"),
             message: format!(
                 "'{safe_name}' exceeds maximum length of {MAX_GENERIC_LEN} bytes \
                  (got {observed})",
@@ -323,7 +326,7 @@ pub fn validate_generic_named(value: &str, param_name: &str) -> Result<(), Valid
     if value.chars().any(|c| c.is_control()) {
         let safe_name: String = sanitize_param_name(param_name);
         return Err(ValidationError {
-            field: "parameter",
+            field: std::borrow::Cow::Borrowed("parameter"),
             message: format!("'{safe_name}' contains control characters"),
         });
     }
@@ -394,46 +397,15 @@ pub fn validate_param_value(param: &ParamMeta, value: &str) -> Result<(), Valida
 /// the param routes to (length-cap or control-character rejection).
 pub fn validate_query_param(name: &str, value: &str) -> Result<(), ValidationError> {
     match name {
-        "root" | "symbol" | "ticker" => validate_symbol(value, static_name(name)),
-        "roots" | "symbols" | "tickers" => validate_symbols_list(value, static_name(name)),
-        "exp" | "expiration" | "expiry" => validate_date(value, static_name(name)),
-        "date" | "start_date" | "end_date" | "trade_date" => {
-            validate_date(value, static_name(name))
-        }
-        "strike" => validate_strike(value, static_name(name)),
-        "right" => validate_right(value, static_name(name)),
-        "ivl" | "interval" => validate_interval(value, static_name(name)),
-        "venue" | "exchange" => validate_venue(value, static_name(name)),
+        "root" | "symbol" | "ticker" => validate_symbol(value, name),
+        "roots" | "symbols" | "tickers" => validate_symbols_list(value, name),
+        "exp" | "expiration" | "expiry" => validate_date(value, name),
+        "date" | "start_date" | "end_date" | "trade_date" => validate_date(value, name),
+        "strike" => validate_strike(value, name),
+        "right" => validate_right(value, name),
+        "ivl" | "interval" => validate_interval(value, name),
+        "venue" | "exchange" => validate_venue(value, name),
         _ => validate_generic_named(value, name),
-    }
-}
-
-/// Pick a `'static` label for an error message. We only ever match on the
-/// known param names above, so returning a short static alias for each one
-/// keeps `ValidationError::field` allocation-free and avoids interning the
-/// caller's borrowed string.
-fn static_name(name: &str) -> &'static str {
-    match name {
-        "root" => "root",
-        "symbol" => "symbol",
-        "ticker" => "ticker",
-        "roots" => "roots",
-        "symbols" => "symbols",
-        "tickers" => "tickers",
-        "exp" => "exp",
-        "expiration" => "expiration",
-        "expiry" => "expiry",
-        "date" => "date",
-        "start_date" => "start_date",
-        "end_date" => "end_date",
-        "trade_date" => "trade_date",
-        "strike" => "strike",
-        "right" => "right",
-        "ivl" => "ivl",
-        "interval" => "interval",
-        "venue" => "venue",
-        "exchange" => "exchange",
-        _ => "parameter",
     }
 }
 
@@ -595,7 +567,7 @@ mod tests {
     #[test]
     fn endpoint_error_conversion_preserves_message() {
         let v = ValidationError {
-            field: "root",
+            field: std::borrow::Cow::Borrowed("root"),
             message: "bad root".to_string(),
         };
         let ee: EndpointError = v.into();

--- a/tools/server/src/ws/mod.rs
+++ b/tools/server/src/ws/mod.rs
@@ -48,27 +48,21 @@ use crate::state::AppState;
 pub use broadcast::start_fpss_bridge;
 pub use format::json_serialize_failure_count;
 
-/// Mirrors `router::GLOBAL_CONCURRENCY_LIMIT` — single constant would cross
-/// the module boundary gratuitously. 256 is chosen for the same reason:
-/// enough headroom for bursty clients, tight enough to shed pressure at
-/// the edge before it hits tokio task slots.
-const WS_CONCURRENCY_LIMIT: usize = 256;
-
-/// Mirrors `router::BODY_LIMIT_BYTES`. The WS upgrade request itself is
-/// small; this cap prevents a malicious upgrade handshake from pushing a
-/// multi-MB body through the axum extractor chain.
-const WS_BODY_LIMIT_BYTES: usize = 64 * 1024;
+// The WS router shares the HTTP router's admission caps verbatim so the two
+// surfaces shed pressure identically; import the originals rather than mirror
+// their values.
+use crate::router::{BODY_LIMIT_BYTES, GLOBAL_CONCURRENCY_LIMIT};
 
 /// Build the WebSocket router (single route: `/v1/events`).
 ///
 /// Applies the same hardening layers as `router::build`:
 ///
 /// 1. `ConcurrencyLimitLayer` caps in-flight WS upgrades to
-///    [`WS_CONCURRENCY_LIMIT`]; the single-client invariant is still
+///    [`GLOBAL_CONCURRENCY_LIMIT`]; the single-client invariant is still
 ///    enforced downstream via `state.try_acquire_ws`, but this stops
 ///    attackers from queueing thousands of blocked upgrades.
 /// 2. `DefaultBodyLimit` caps the upgrade request body at
-///    [`WS_BODY_LIMIT_BYTES`].
+///    [`BODY_LIMIT_BYTES`].
 /// 3. `GovernorLayer` keyed on the peer connect-info IP enforces the
 ///    operator's tuned `(per_second, burst)` pair — only when `rate_limit`
 ///    is `Some` (the operator opted in via the rate-limit env vars; see
@@ -79,8 +73,8 @@ const WS_BODY_LIMIT_BYTES: usize = 64 * 1024;
 pub fn router(state: AppState, rate_limit: Option<crate::router::RateLimit>) -> Router {
     let mut app = Router::new()
         .route("/v1/events", get(upgrade::ws_upgrade))
-        .layer(ConcurrencyLimitLayer::new(WS_CONCURRENCY_LIMIT))
-        .layer(DefaultBodyLimit::max(WS_BODY_LIMIT_BYTES));
+        .layer(ConcurrencyLimitLayer::new(GLOBAL_CONCURRENCY_LIMIT))
+        .layer(DefaultBodyLimit::max(BODY_LIMIT_BYTES));
 
     if let Some((per_second, burst_size)) = rate_limit {
         let governor = Arc::new(


### PR DESCRIPTION
Seven over-engineering shrinks across the REST server and MCP binaries, each behavior-preserving and proven by the existing tests.

## Cuts

1. **`flatfile_routes.rs` — `FlatfilePath<T>` + `path_rejection_response`.** The wrapper existed only to map a `PathRejection` onto the canonical envelope, but the two GET routes match two `String` path segments and axum cannot reject `Path<(String, String)>` on a router-matched UTF-8 path (no segment-count mismatch is possible, no UTF-8 decode can fail). Re-verified there is no untrusted-input route reaching the rejection. Replaced with plain `axum::Path`.
2. **`flatfile_routes.rs` — local `error_response`.** Byte-for-byte the same envelope builder as the `pub(crate)` `handler::error_response`. Deleted the local copy and import the shared one.
3. **`validation.rs` — `static_name` 19-arm identity match.** The arms mapped each known param name back to its own identical `'static` literal purely to satisfy the `field: &'static str` type. Changed `ValidationError.field` to `Cow<'static, str>`, dropped the match, and let `validate_query_param` pass the borrowed name straight through. Error messages are unchanged.
4. **`mcp/main.rs` — `_jsonrpc: String`.** Set during parse, never read (the `"2.0"` check uses a separate local). Removed the field and its allocation; the version is now validated as a borrowed `&str`.
5. **`mcp/flatfile_tools.rs` — local `arg_str`.** Duplicate of the crate-root `arg_str`. Routed the three call sites through `crate::arg_str`.
6. **`ws/mod.rs` — `WS_CONCURRENCY_LIMIT` / `WS_BODY_LIMIT_BYTES`.** Literal mirrors of `router::GLOBAL_CONCURRENCY_LIMIT` / `router::BODY_LIMIT_BYTES` (the comments said so). Made the originals `pub(crate)` and import them.

**Left as-is:** the T2-TRACE `parse_sec_type` / `parse_req_type` / `parse_format` triplet duplicated between the MCP and server flatfile modules. The core crate exports the enums and `flat_file_serves` but no public string-to-enum parser (no `FromStr` / `TryFrom`). These are structural per-binary input-acceptance shims for two separate binaries; adding a public core parser to dedup two ~10-line functions would grow the published API surface for negligible gain. `CredentialSource` / `select_credential_source` / `env_var_present` likewise left (structural).

Net: 6 files, +52 / -154.

## Gates (both standalone crates)

- `cargo check` — server + mcp: pass
- `cargo clippy --all-targets -- -D warnings` — server + mcp: pass
- `cargo fmt --check` — server + mcp: clean
- `cargo test` — server 183 + 2, mcp 31 + 1: all pass
- `check_docs_consistency.py`: ok

No new `#[allow]`. No dependency-graph change, so the standalone `Cargo.lock`s are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)