### PR TITLE
refactor(cpp): drop test-only grpc-kind taxonomy + dedup ffi-array helpers; align greeks field order

### DIFF
--- a/ffi/src/utility.rs
+++ b/ffi/src/utility.rs
@@ -13,6 +13,11 @@ use crate::streaming::ThetaDataDxContract;
 // ═══════════════════════════════════════════════════════════════════════
 
 /// All 23 Black-Scholes Greeks + IV as a typed C struct.
+///
+/// Field order mirrors [`thetadatadx::greeks::GreeksResult`] one-for-one so the
+/// `From` conversion is a field-by-field move and the hand-written C header
+/// (`sdks/cpp/include/thetadatadx.h`) reproduces the same offsets. All fields
+/// are `f64`, so the layout carries no padding to track.
 #[repr(C)]
 pub struct ThetaDataDxGreeksResult {
     /// Black-Scholes theoretical option value.
@@ -27,10 +32,10 @@ pub struct ThetaDataDxGreeksResult {
     pub vega: f64,
     /// Sensitivity to the risk-free rate.
     pub rho: f64,
-    /// Sensitivity of value to the dividend yield.
-    pub epsilon: f64,
-    /// Elasticity: percentage change in value per percentage change in spot.
-    pub lambda: f64,
+    /// Implied volatility recovered from the option price.
+    pub iv: f64,
+    /// Relative residual of the IV solve (`(value - price) / price`), clamped to `[-100.0, 100.0]`.
+    pub iv_error: f64,
     /// Sensitivity of delta to volatility.
     pub vanna: f64,
     /// Sensitivity of delta to time.
@@ -49,10 +54,6 @@ pub struct ThetaDataDxGreeksResult {
     pub color: f64,
     /// Sensitivity of vomma to volatility.
     pub ultima: f64,
-    /// Implied volatility recovered from the option price.
-    pub iv: f64,
-    /// Relative residual of the IV solve (`(value - price) / price`), clamped to `[-100.0, 100.0]`.
-    pub iv_error: f64,
     /// Black-Scholes `d1` term.
     pub d1: f64,
     /// Black-Scholes `d2` term.
@@ -61,6 +62,65 @@ pub struct ThetaDataDxGreeksResult {
     pub dual_delta: f64,
     /// Sensitivity of dual delta to the strike.
     pub dual_gamma: f64,
+    /// Sensitivity of value to the dividend yield.
+    pub epsilon: f64,
+    /// Elasticity: percentage change in value per percentage change in spot.
+    pub lambda: f64,
+}
+
+impl From<thetadatadx::greeks::GreeksResult> for ThetaDataDxGreeksResult {
+    fn from(g: thetadatadx::greeks::GreeksResult) -> Self {
+        let thetadatadx::greeks::GreeksResult {
+            value,
+            delta,
+            gamma,
+            theta,
+            vega,
+            rho,
+            iv,
+            iv_error,
+            vanna,
+            charm,
+            vomma,
+            veta,
+            vera,
+            speed,
+            zomma,
+            color,
+            ultima,
+            d1,
+            d2,
+            dual_delta,
+            dual_gamma,
+            epsilon,
+            lambda,
+        } = g;
+        Self {
+            value,
+            delta,
+            gamma,
+            theta,
+            vega,
+            rho,
+            iv,
+            iv_error,
+            vanna,
+            charm,
+            vomma,
+            veta,
+            vera,
+            speed,
+            zomma,
+            color,
+            ultima,
+            d1,
+            d2,
+            dual_delta,
+            dual_gamma,
+            epsilon,
+            lambda,
+        }
+    }
 }
 
 /// Compute all 23 Black-Scholes Greeks + IV.
@@ -102,32 +162,7 @@ pub unsafe extern "C" fn thetadatadx_all_greeks(
                 return std::ptr::null_mut();
             }
         };
-        let result = ThetaDataDxGreeksResult {
-            value: g.value,
-            delta: g.delta,
-            gamma: g.gamma,
-            theta: g.theta,
-            vega: g.vega,
-            rho: g.rho,
-            epsilon: g.epsilon,
-            lambda: g.lambda,
-            vanna: g.vanna,
-            charm: g.charm,
-            vomma: g.vomma,
-            veta: g.veta,
-            vera: g.vera,
-            speed: g.speed,
-            zomma: g.zomma,
-            color: g.color,
-            ultima: g.ultima,
-            iv: g.iv,
-            iv_error: g.iv_error,
-            d1: g.d1,
-            d2: g.d2,
-            dual_delta: g.dual_delta,
-            dual_gamma: g.dual_gamma,
-        };
-        Box::into_raw(Box::new(result))
+        Box::into_raw(Box::new(ThetaDataDxGreeksResult::from(g)))
     })
 }
 

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -757,8 +757,8 @@ typedef struct {
     double theta;
     double vega;
     double rho;
-    double epsilon;
-    double lambda;
+    double iv;
+    double iv_error;
     double vanna;
     double charm;
     double vomma;
@@ -768,12 +768,12 @@ typedef struct {
     double zomma;
     double color;
     double ultima;
-    double iv;
-    double iv_error;
     double d1;
     double d2;
     double dual_delta;
     double dual_gamma;
+    double epsilon;
+    double lambda;
 } ThetaDataDxGreeksResult;
 
 /* ── Subscription types (active_subscriptions) ── */

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -247,7 +247,7 @@ struct GreeksResult {
 // bindings by name. Python additionally ships two back-compat aliases
 // (`NoDataFoundError` / `TimeoutError`) that have no C++ equivalent.
 //
-// The dispatcher [`detail::throw_for_grpc_kind`] reads
+// The dispatcher [`detail::throw_for_code`] reads
 // `thetadatadx_last_error_code()` (typed discriminant set inside the FFI
 // boundary) to pick the right leaf without parsing the formatted
 // message. Throw sites that emit a plain
@@ -255,28 +255,6 @@ struct GreeksResult {
 // every leaf derives from `ThetaDataError` (a `std::runtime_error`):
 // a generic `catch (const std::runtime_error&)` observes both the
 // typed leaves and any plain-`runtime_error` site unchanged.
-
-/// gRPC canonical status kind. Enum values match the gRPC wire codes
-/// one-for-one (RFC 5234) so pattern-matching is portable across bindings.
-enum class GrpcStatusKind : uint32_t {
-    Ok = 0,
-    Cancelled = 1,
-    Unknown = 2,
-    InvalidArgument = 3,
-    DeadlineExceeded = 4,
-    NotFound = 5,
-    AlreadyExists = 6,
-    PermissionDenied = 7,
-    ResourceExhausted = 8,
-    FailedPrecondition = 9,
-    Aborted = 10,
-    OutOfRange = 11,
-    Unimplemented = 12,
-    Internal = 13,
-    Unavailable = 14,
-    DataLoss = 15,
-    Unauthenticated = 16,
-};
 
 /// Root of the typed exception hierarchy; every FFI failure surfaces as this
 /// class or one of its leaves. Derives from `std::runtime_error` so generic
@@ -466,32 +444,18 @@ inline std::optional<double> last_ffi_retry_after_seconds() {
     }
 }
 
-/// Dispatcher keyed on the canonical gRPC kind. Used in tests that
-/// want to verify the routing without actually round-tripping through
-/// the FFI; production wrappers go through [`throw_for_code`] which
-/// reads `thetadatadx_last_error_code()` directly.
-[[noreturn]] inline void throw_for_grpc_kind(GrpcStatusKind kind, const std::string& message) {
-    switch (kind) {
-        case GrpcStatusKind::Unauthenticated:
-            throw AuthenticationError("thetadatadx: " + message);
-        case GrpcStatusKind::PermissionDenied:
-            throw SubscriptionError("thetadatadx: " + message);
-        case GrpcStatusKind::ResourceExhausted:
-            throw RateLimitError("thetadatadx: " + message);
-        case GrpcStatusKind::NotFound:
-            throw NotFoundError("thetadatadx: " + message);
-        case GrpcStatusKind::DeadlineExceeded:
-            throw DeadlineExceededError("thetadatadx: " + message);
-        case GrpcStatusKind::Unavailable:
-            throw UnavailableError("thetadatadx: " + message);
-        default:
-            throw ThetaDataError("thetadatadx: " + message);
-    }
-}
-
-static std::string last_ffi_error() {
+// Snapshot the thread-local FFI error string. With `raw == false` an empty
+// slot reads as the `"unknown error"` placeholder (the throw path always has
+// a message to surface); with `raw == true` it reads as `""` so the array
+// helpers can distinguish success-empty from failure-empty (a timeout on a
+// list endpoint returns the same `{nullptr, 0}` sentinel as a successful
+// empty result). Generated `_with_options` callers MUST
+// `thetadatadx_clear_error()` before invoking the FFI so a stale error from a
+// prior call isn't picked up by the `raw` read.
+static std::string last_ffi_error(bool raw = false) {
     const char* err = thetadatadx_last_error();
-    return err ? std::string(err) : "unknown error";
+    if (err) return std::string(err);
+    return raw ? std::string() : std::string("unknown error");
 }
 
 /// Combined read-and-throw helper: snapshot the thread-local error
@@ -515,16 +479,9 @@ static std::string last_ffi_error() {
     throw_for_code(THETADATADX_ERR_CONFIG, message);
 }
 
-// Raw variant: returns "" when the FFI error slot is empty. Used by
-// post-call disambiguation in check_array helpers — distinguishes
-// success-empty from failure-empty (e.g. timeout on a list endpoint
-// returns the same `{nullptr, 0}` sentinel as a successful empty result).
-// Generated `_with_options` callers MUST `thetadatadx_clear_error()` before
-// invoking the FFI so a stale error from a prior call isn't picked up.
-static std::string last_ffi_error_raw() {
-    const char* err = thetadatadx_last_error();
-    return err ? std::string(err) : std::string();
-}
+// Empty slot reads as "" (vs the `"unknown error"` placeholder) for the
+// post-call success-empty / failure-empty disambiguation in the array helpers.
+static std::string last_ffi_error_raw() { return last_ffi_error(true); }
 
 template<typename T>
 std::vector<T> to_vector(const T* data, size_t len) {
@@ -532,40 +489,14 @@ std::vector<T> to_vector(const T* data, size_t len) {
     return std::vector<T>(data, data + len);
 }
 
-inline std::vector<std::string> string_array_to_vector(ThetaDataDxStringArray arr) {
-    std::vector<std::string> result;
-    if (arr.data != nullptr && arr.len > 0) {
-        result.reserve(arr.len);
-        for (size_t i = 0; i < arr.len; ++i) {
-            result.emplace_back(arr.data[i] ? arr.data[i] : "");
-        }
-    }
-    thetadatadx_string_array_free(arr);
-    return result;
-}
-
-// Convert a ThetaDataDxStringArray to vector<string>, throwing on FFI error.
+// Convert an FFI array to `vector<T>`, throwing on FFI error.
 //
-// Empty array is ambiguous: success-with-zero-results AND failure (e.g.
-// timeout on a list endpoint) both return `{nullptr, 0}`. Disambiguate by
-// reading `thetadatadx_last_error()` after the call. Generated wrappers
-// `thetadatadx_clear_error()` before the FFI call so a stale error from a prior
-// call isn't misattributed.
-inline std::vector<std::string> check_string_array(ThetaDataDxStringArray arr) {
-    const std::string err = last_ffi_error_raw();
-    if (!err.empty()) {
-        const int32_t code = thetadatadx_last_error_code();
-        thetadatadx_string_array_free(arr);
-        throw_for_code(code, err);
-    }
-    return string_array_to_vector(arr);
-}
-
-// Convert a typed tick array to vector<T> by passing in the converter and
-// the FFI-array free fn. Throws on FFI error so callers don't mistake a
-// timed-out tick endpoint for "no rows". Same contract as
-// check_string_array — `thetadatadx_clear_error()` MUST have been called before
-// the FFI invocation.
+// `convert` maps the array to rows (it must NOT free — this helper owns the
+// free); `free_fn` releases the FFI allocation on every exit path. An empty
+// array is ambiguous: success-with-zero-results AND failure (e.g. timeout on
+// a list endpoint) both return the `{nullptr, 0}` sentinel, so the error slot
+// is consulted first. Generated wrappers `thetadatadx_clear_error()` before the
+// FFI call so a stale error from a prior call isn't misattributed.
 template<typename T, typename Arr, typename Convert, typename Free>
 std::vector<T> check_tick_array(Arr arr, Convert convert, Free free_fn) {
     const std::string err = last_ffi_error_raw();
@@ -577,6 +508,22 @@ std::vector<T> check_tick_array(Arr arr, Convert convert, Free free_fn) {
     auto result = convert(arr);
     free_fn(arr);
     return result;
+}
+
+// Pure converter (no free): the `Convert` callback for a `ThetaDataDxStringArray`.
+inline std::vector<std::string> string_array_to_vector(ThetaDataDxStringArray arr) {
+    std::vector<std::string> result;
+    if (arr.data != nullptr && arr.len > 0) {
+        result.reserve(arr.len);
+        for (size_t i = 0; i < arr.len; ++i) {
+            result.emplace_back(arr.data[i] ? arr.data[i] : "");
+        }
+    }
+    return result;
+}
+
+inline std::vector<std::string> check_string_array(ThetaDataDxStringArray arr) {
+    return check_tick_array<std::string>(arr, string_array_to_vector, thetadatadx_string_array_free);
 }
 
 inline std::vector<Subscription> subscription_array_to_vector(ThetaDataDxSubscriptionArray* arr) {

--- a/sdks/cpp/src/thetadatadx.cpp
+++ b/sdks/cpp/src/thetadatadx.cpp
@@ -8,10 +8,6 @@
 
 #include "thetadatadx.hpp"
 
-#include <chrono>
-#include <stdexcept>
-#include <sstream>
-#include <thread>
 #include <utility>
 
 namespace thetadatadx {
@@ -60,26 +56,37 @@ static std::vector<const char*> string_ptrs(const std::vector<std::string>& item
 // comment above the member declarations in the header.
 //
 // The body raises the shutdown signal early so the consumer thread starts
-// quiescing before the deleter polls the drain flag. If the drain barrier
-// inside `thetadatadx_streaming_free` times out, the FFI logs a `tracing::error!` and
-// proceeds with destruction. We mirror the move-assign rescue path here:
-// detach `callback_` storage to a helper thread for an extra 30 s grace
-// window so user code never observes a synchronous UAF on destructor exit.
+// quiescing before the deleter polls the drain flag. On drain timeout (rare,
+// a wedged user callback) the consumer may still be firing through
+// `callback_`'s storage, so we MUST NOT let the storage drop synchronously.
+// We mirror `StreamingClient::operator=`'s rescue path exactly: hand BOTH the
+// retired handle and callback storage to a reclaimer that polls the same
+// drain barrier and releases them (handle first, then storage) only once the
+// consumer is confirmed quiesced, with the bounded `kReclaimQuiescenceCap` so
+// a wedged callback cannot leak — never a guessed wall-clock window.
 StreamingClient::~StreamingClient() {
     if (handle_) {
         thetadatadx_streaming_shutdown(handle_.get());
         int drained = thetadatadx_streaming_await_drain(handle_.get(), 5000);
         if (drained == 0) {
-            // Drain timed out: the consumer may still be firing through
-            // `callback_`'s storage. Detach the storage onto a helper
-            // thread for a 30 s grace window so destruction happens off
-            // the destructor path, then let `handle_`'s deleter run
-            // (its own drain barrier will observe `drained == 1` since
-            // we already polled it to timeout).
-            std::thread([cb = std::move(callback_)]() mutable {
-                std::this_thread::sleep_for(std::chrono::seconds(30));
-                // `cb` destructs here, off the destructor path.
-            }).detach();
+            const ThetaDataDxStreamHandle* raw = handle_.get();
+            detail::reclaim_after_drain(
+                [raw]() {
+                    return thetadatadx_streaming_await_drain(
+                               raw,
+                               static_cast<uint64_t>(
+                                   detail::kReclaimPollStep.count())) == 1;
+                },
+                [retired_handle = std::move(handle_),
+                 retired_cb = std::move(callback_)]() mutable {
+                    // Free the handle first so its internal drain barrier
+                    // still observes a live `ctx`, then drop the storage.
+                    // Mirrors the handle-before-callback member invariant.
+                    retired_handle.reset();
+                    retired_cb.reset();
+                });
+            // `handle_` and `callback_` are now empty; the reclaimer owns
+            // the retired session.
         }
     }
 }

--- a/sdks/cpp/tests/error_taxonomy.cpp
+++ b/sdks/cpp/tests/error_taxonomy.cpp
@@ -1,11 +1,10 @@
 // Typed-error hierarchy tests for the C++ SDK.
 //
 // The C++ surface exposes a `ThetaDataError` base plus a leaf class
-// per `GrpcStatusKind` + `AuthErrorKind` discriminator, so callers
-// `catch` a typed exception instead of substring-matching a generic
-// `std::runtime_error` reason string. The hierarchy mirrors the
-// Python / TypeScript leaf set so the cross-binding contract stays
-// uniform.
+// per typed `THETADATADX_ERR_*` discriminant, so callers `catch` a typed
+// exception instead of substring-matching a generic `std::runtime_error`
+// reason string. The hierarchy mirrors the Python / TypeScript leaf set
+// so the cross-binding contract stays uniform.
 
 #include <chrono>
 #include <stdexcept>
@@ -122,43 +121,52 @@ TEST_CASE("RateLimitError carries the server retry_after as a typed value",
     REQUIRE_FALSE(legacy.retry_after().has_value());
 }
 
-TEST_CASE("classify_grpc_kind routes every canonical gRPC status to the right leaf",
+TEST_CASE("throw_for_code routes every typed discriminant to the right leaf",
           "[errors][offline]") {
-    // Dispatch table test for `thetadatadx::detail::throw_for_grpc_kind` —
-    // the seam every generated FFI wrapper hits when
-    // `thetadatadx_get_last_error_code()` returns a typed discriminant. The
-    // routing must match the Python leaf set one-for-one so a Python
-    // user porting `except thetadatadx.SubscriptionError` to C++
-    // gets `catch (const thetadatadx::SubscriptionError&)` and the same
-    // semantics.
-    using K = thetadatadx::GrpcStatusKind;
-
-    auto throws_as = [](K kind, auto check) {
+    // Dispatch table test for `thetadatadx::detail::throw_for_code` — the seam
+    // every generated FFI wrapper hits when `thetadatadx_last_error_code()`
+    // returns a typed discriminant. The routing must match the Python leaf
+    // set one-for-one so a Python user porting `except
+    // thetadatadx.SubscriptionError` to C++ gets `catch (const
+    // thetadatadx::SubscriptionError&)` and the same semantics.
+    auto throws_as = [](int32_t code, auto check) {
         try {
-            thetadatadx::detail::throw_for_grpc_kind(kind, "test");
-            FAIL("throw_for_grpc_kind must throw");
+            thetadatadx::detail::throw_for_code(code, "test");
+            FAIL("throw_for_code must throw");
         } catch (const thetadatadx::ThetaDataError& e) {
             check(e);
         }
     };
 
-    throws_as(K::PermissionDenied, [](const thetadatadx::ThetaDataError& e) {
+    throws_as(THETADATADX_ERR_SUBSCRIPTION, [](const thetadatadx::ThetaDataError& e) {
         REQUIRE(dynamic_cast<const thetadatadx::SubscriptionError*>(&e) != nullptr);
     });
-    throws_as(K::ResourceExhausted, [](const thetadatadx::ThetaDataError& e) {
+    throws_as(THETADATADX_ERR_RATE_LIMIT, [](const thetadatadx::ThetaDataError& e) {
         REQUIRE(dynamic_cast<const thetadatadx::RateLimitError*>(&e) != nullptr);
     });
-    throws_as(K::Unauthenticated, [](const thetadatadx::ThetaDataError& e) {
+    throws_as(THETADATADX_ERR_AUTHENTICATION, [](const thetadatadx::ThetaDataError& e) {
         REQUIRE(dynamic_cast<const thetadatadx::AuthenticationError*>(&e) != nullptr);
     });
-    throws_as(K::NotFound, [](const thetadatadx::ThetaDataError& e) {
+    throws_as(THETADATADX_ERR_INVALID_CREDENTIALS, [](const thetadatadx::ThetaDataError& e) {
+        REQUIRE(dynamic_cast<const thetadatadx::InvalidCredentialsError*>(&e) != nullptr);
+    });
+    throws_as(THETADATADX_ERR_NOT_FOUND, [](const thetadatadx::ThetaDataError& e) {
         REQUIRE(dynamic_cast<const thetadatadx::NotFoundError*>(&e) != nullptr);
     });
-    throws_as(K::DeadlineExceeded, [](const thetadatadx::ThetaDataError& e) {
+    throws_as(THETADATADX_ERR_DEADLINE_EXCEEDED, [](const thetadatadx::ThetaDataError& e) {
         REQUIRE(dynamic_cast<const thetadatadx::DeadlineExceededError*>(&e) != nullptr);
     });
-    throws_as(K::Unavailable, [](const thetadatadx::ThetaDataError& e) {
+    throws_as(THETADATADX_ERR_UNAVAILABLE, [](const thetadatadx::ThetaDataError& e) {
         REQUIRE(dynamic_cast<const thetadatadx::UnavailableError*>(&e) != nullptr);
+    });
+    throws_as(THETADATADX_ERR_NETWORK, [](const thetadatadx::ThetaDataError& e) {
+        REQUIRE(dynamic_cast<const thetadatadx::NetworkError*>(&e) != nullptr);
+    });
+    throws_as(THETADATADX_ERR_SCHEMA_MISMATCH, [](const thetadatadx::ThetaDataError& e) {
+        REQUIRE(dynamic_cast<const thetadatadx::SchemaMismatchError*>(&e) != nullptr);
+    });
+    throws_as(THETADATADX_ERR_STREAM, [](const thetadatadx::ThetaDataError& e) {
+        REQUIRE(dynamic_cast<const thetadatadx::StreamError*>(&e) != nullptr);
     });
 }
 


### PR DESCRIPTION
Hand-written C++ SDK shrinks plus a cross-binding Greeks field-order alignment. No behavior change; every cut is proven against the C++ test harness and the Rust gates.

## C++ shrinks (`sdks/cpp`)

- **Drop test-only gRPC taxonomy.** `GrpcStatusKind` and `throw_for_grpc_kind` had a single user (the taxonomy test); production routes through `throw_for_code` keyed on `thetadatadx_last_error_code()`. Removed both and rewrote the test to exercise `throw_for_code` across every leaf (now covers all 10 routed discriminants, up from 6).
- **Dedup the array helpers.** `check_string_array` now delegates to the already-generic `check_tick_array` template (previously dead code) with `string_array_to_vector` reduced to a pure converter. `subscription_array_to_vector` is left as-is: it keys off a null-pointer sentinel rather than the error-string contract the template uses, so folding it would add branches, not remove them.
- **Merge the error-slot readers.** `last_ffi_error` / `last_ffi_error_raw` collapse behind a `raw` flag; the raw reader stays as a one-line delegate so the ~95 generated callers are untouched.
- **Destructor reclaim.** `~StreamingClient` replaces a blind 30 s detached `sleep_for` with the `reclaim_after_drain` poll the move-assign path already uses, so the retired session is released the moment the consumer is confirmed quiesced (bounded by the same cap), never after a guessed window.

## Greeks field-order alignment (cross-binding, ABI-checked)

`ThetaDataDxGreeksResult` was a field-reordered mirror of `thetadatadx::greeks::GreeksResult`. Reordered the FFI struct and the hand-written C header in lockstep to match the core order, then replaced the 23-line manual copy with `From` (the call site is now `g.into()`). All 23 fields are `f64`, so the reorder is offset-neutral; the FFI struct, the C header, and the core struct are now byte-for-byte identical layouts. The C++ `GreeksResult` already matched core order, and the generated `utilities.cpp.inc` reads fields by name, so `generate_sdk_surfaces --check` stays green with no regeneration.

The four FlatFiles convenience accessors flagged for deletion were kept: they are a deliberate, test-backed cross-binding parity set (present and symmetric across Python, TypeScript, Rust, and C++, enrolled in `parity.toml`). Deleting only the C++ ones fails `check_binding_parity.py`; deleting them everywhere is a separate cross-binding change. Left intact.

## Gates

C++ harness builds clean; 68/68 offline tests pass (arrow + error-taxonomy + utilities + lifecycle). `cargo check`/`clippy --all-targets -D warnings`/`fmt --check` on the FFI crate, `cargo test -p thetadatadx-ffi --lib` (91/91), `check_binding_parity.py`, `generate_sdk_surfaces --check`, and `generate_docs_site --check` all green. No new `#[allow]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)