### PR TITLE
refactor(typescript): move tsc to devDependencies + dedup normalize/connect/error/validate helpers

### DIFF
--- a/sdks/typescript/__tests__/config_reconnect.test.mjs
+++ b/sdks/typescript/__tests__/config_reconnect.test.mjs
@@ -157,26 +157,21 @@ describe('Config.setReconnectWaitMs / setReconnectWaitRateLimitedMs', () => {
 });
 
 describe('Config.setWorkerThreads', () => {
-  it('default workerThreads is the None (auto) sentinel', () => {
+  it('default workerThreads is the null (auto) sentinel', () => {
     const cfg = Config.production();
-    const got = cfg.workerThreads;
-    assert.equal(got.hasValue, false, 'default must be None');
-    assert.equal(got.n, 0);
+    assert.equal(cfg.workerThreads, null, 'default must be the unset sentinel');
   });
 
-  it('round-trip preserves Some(0) and explicit pinned counts', () => {
+  it('round-trip preserves an explicit 0 and pinned counts', () => {
     const cfg = Config.production();
     for (const n of [0, 1, 2, 4, 8, 16, 64]) {
-      cfg.setWorkerThreads(true, n);
-      const got = cfg.workerThreads;
-      assert.equal(got.hasValue, true);
-      assert.equal(got.n, n);
+      cfg.setWorkerThreads(n);
+      // An explicit 0 must survive as 0, distinct from the null (auto) sentinel.
+      assert.equal(cfg.workerThreads, n);
     }
-    // Reset to None.
-    cfg.setWorkerThreads(false, 999);
-    const got = cfg.workerThreads;
-    assert.equal(got.hasValue, false);
-    assert.equal(got.n, 0);
+    // Reset to the auto sentinel.
+    cfg.setWorkerThreads(null);
+    assert.equal(cfg.workerThreads, null);
   });
 });
 

--- a/sdks/typescript/__tests__/streaming_batches.test.mjs
+++ b/sdks/typescript/__tests__/streaming_batches.test.mjs
@@ -34,6 +34,9 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const pkg = require('../streaming-session.js');
+// `wrapStreamViewBatches` is internal: imported from its module directly
+// (not via the package's public surface), with `RecordBatchStream` injected.
+const { wrapStreamViewBatches } = require('../record_batch_forwarder.js');
 const dts = readFileSync(resolve(__dirname, '..', 'streaming-session.d.ts'), 'utf8');
 
 // A synthetic single-batch Arrow IPC stream, built with apache-arrow so the
@@ -103,7 +106,7 @@ describe('streaming RecordBatch reader', () => {
       calls.push({ thisValue: this, args });
       return handle;
     }
-    const forwarder = pkg.wrapStreamViewBatches(nativeBatches);
+    const forwarder = wrapStreamViewBatches(nativeBatches, pkg.RecordBatchStream);
 
     const options = { batchSize: 256, lingerMs: 5, backpressure: 'dropOldest', capacity: 8 };
     const receiver = { tag: 'streamView' };
@@ -129,7 +132,7 @@ describe('streaming RecordBatch reader', () => {
       calls.push(args);
       return fakeHandle(0);
     }
-    const forwarder = pkg.wrapStreamViewBatches(nativeBatches);
+    const forwarder = wrapStreamViewBatches(nativeBatches, pkg.RecordBatchStream);
     const reader = await forwarder.call({}, undefined);
     // Calling with an explicit `undefined` still forwards one arg; the
     // documented no-arg form forwards none. Cover the no-arg form here.

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -169,10 +169,9 @@ export declare class Config {
    */
   setStreamingRingSize(n: bigint): void
   /**
-   * Set the async worker-thread count for embedded runtimes.
-   * `hasValue=false` defers to the default sizing; `hasValue=true`
-   * pins worker count to `n` (with `n=0` preserved verbatim rather
-   * than treated as unset).
+   * Set the async worker-thread count for embedded runtimes. `null`
+   * (or omitted) defers to the default sizing; a number pins the worker
+   * count (with `0` preserved verbatim rather than treated as unset).
    *
    * The async worker pool is process-global: it is built once, from the
    * config of the first client connected in the process. This setting
@@ -180,12 +179,12 @@ export declare class Config {
    * created; clients connected later share the already-built pool, so
    * setting it on a subsequent config has no effect.
    */
-  setWorkerThreads(hasValue: boolean, n: number): void
+  setWorkerThreads(n?: number | undefined | null): void
   /**
-   * Current `workerThreads` setting as `{ hasValue, n }`.
-   * `hasValue=false` encodes the unset (auto) sentinel.
+   * Current `workerThreads` setting, or `null` for the unset (auto)
+   * sentinel. An explicit `0` is preserved verbatim.
    */
-  get workerThreads(): WorkerThreadsSetting
+  get workerThreads(): number | null
   /**
    * Target historical environment carried by this configuration:
    * `"PROD"` for the production cluster or `"STAGE"` for staging. The
@@ -6087,16 +6086,6 @@ export declare const enum Venue {
 export declare const enum Version {
   Latest = 'latest',
   V1 = '1'
-}
-
-/**
- * `(hasValue, n)` shape for the worker-threads setting. `hasValue=false`
- * encodes the unset sentinel; `hasValue=true` carries the explicit
- * worker count (with `n=0` preserved verbatim).
- */
-export interface WorkerThreadsSetting {
-  hasValue: boolean
-  n: number
 }
 
 // `Contract` is the public name for the fluent contract builder; it

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -8,13 +8,11 @@
       "name": "thetadatadx",
       "version": "13.0.0-rc.5",
       "license": "Apache-2.0",
-      "dependencies": {
-        "typescript": "6.0.3"
-      },
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
         "@types/node": "26.0.0",
-        "apache-arrow": "21.1.0"
+        "apache-arrow": "21.1.0",
+        "typescript": "6.0.3"
       },
       "engines": {
         "node": ">= 20"
@@ -2115,6 +2113,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -29,7 +29,8 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
     "@types/node": "26.0.0",
-    "apache-arrow": "21.1.0"
+    "apache-arrow": "21.1.0",
+    "typescript": "6.0.3"
   },
   "optionalDependencies": {
     "thetadatadx-darwin-arm64": "13.0.0-rc.5",
@@ -43,9 +44,7 @@
     "index.js",
     "index.d.ts",
     "streaming-session.js",
-    "streaming-session.d.ts"
-  ],
-  "dependencies": {
-    "typescript": "6.0.3"
-  }
+    "streaming-session.d.ts",
+    "record_batch_forwarder.js"
+  ]
 }

--- a/sdks/typescript/record_batch_forwarder.js
+++ b/sdks/typescript/record_batch_forwarder.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Internal forwarder for `StreamView.prototype.batches`. Not part of the
+// public API: `streaming-session.js` installs it onto the native prototype
+// and the test suite imports it from here to drive the real
+// options-object -> native call shape against a stub native method (no live
+// server). `RecordBatchStream` is injected rather than required to keep this
+// free of a circular dependency on `streaming-session.js`.
+//
+// The native `batches(options?)` takes ONE object argument; the wrap forwards
+// the caller's single options object straight through (no positional
+// explosion) and re-wraps the returned native handle in a `RecordBatchStream`.
+function wrapStreamViewBatches(nativeBatches, RecordBatchStream) {
+  return async function batches(...args) {
+    const handle = await nativeBatches.apply(this, args);
+    return new RecordBatchStream(handle);
+  };
+}
+
+module.exports = { wrapStreamViewBatches };

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -3,16 +3,6 @@ use std::sync::{Arc, Mutex};
 
 use thetadatadx::config;
 
-/// `(hasValue, n)` shape for the worker-threads setting. `hasValue=false`
-/// encodes the unset sentinel; `hasValue=true` carries the explicit
-/// worker count (with `n=0` preserved verbatim).
-#[napi(object)]
-#[derive(Clone, Copy)]
-pub struct WorkerThreadsSetting {
-    pub has_value: bool,
-    pub n: u32,
-}
-
 /// `(reason, attempt)` argument object handed to the JS reconnect
 /// callback registered via `Config.setReconnectCallback`. `reason` is
 /// the integer disconnect code; `attempt` is the
@@ -270,10 +260,9 @@ impl Config {
         Ok(())
     }
 
-    /// Set the async worker-thread count for embedded runtimes.
-    /// `hasValue=false` defers to the default sizing; `hasValue=true`
-    /// pins worker count to `n` (with `n=0` preserved verbatim rather
-    /// than treated as unset).
+    /// Set the async worker-thread count for embedded runtimes. `null`
+    /// (or omitted) defers to the default sizing; a number pins the worker
+    /// count (with `0` preserved verbatim rather than treated as unset).
     ///
     /// The async worker pool is process-global: it is built once, from the
     /// config of the first client connected in the process. This setting
@@ -281,33 +270,27 @@ impl Config {
     /// created; clients connected later share the already-built pool, so
     /// setting it on a subsequent config has no effect.
     #[napi(js_name = "setWorkerThreads")]
-    pub fn set_worker_threads(&self, has_value: bool, n: u32) -> napi::Result<()> {
+    pub fn set_worker_threads(&self, n: Option<u32>) -> napi::Result<()> {
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.runtime.tokio_worker_threads = if has_value { Some(n as usize) } else { None };
+        guard.runtime.tokio_worker_threads = n.map(|n| n as usize);
         Ok(())
     }
 
-    /// Current `workerThreads` setting as `{ hasValue, n }`.
-    /// `hasValue=false` encodes the unset (auto) sentinel.
+    /// Current `workerThreads` setting, or `null` for the unset (auto)
+    /// sentinel. An explicit `0` is preserved verbatim.
     #[napi(getter, js_name = "workerThreads")]
-    pub fn worker_threads(&self) -> napi::Result<WorkerThreadsSetting> {
+    pub fn worker_threads(&self) -> napi::Result<Option<u32>> {
         let guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(match guard.runtime.tokio_worker_threads {
-            Some(n) => WorkerThreadsSetting {
-                has_value: true,
-                n: u32::try_from(n).unwrap_or(u32::MAX),
-            },
-            None => WorkerThreadsSetting {
-                has_value: false,
-                n: 0,
-            },
-        })
+        Ok(guard
+            .runtime
+            .tokio_worker_threads
+            .map(|n| u32::try_from(n).unwrap_or(u32::MAX)))
     }
 
     // `retry.initial_delay` / `retry.max_delay` (ms) getters, the

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -74,13 +74,21 @@ pub(crate) fn to_napi_err(e: thetadatadx::Error) -> napi::Error {
     napi::Error::from_reason(format!("{prefix} {e}"))
 }
 
+/// Build a napi error whose `reason` carries the `[ClassName] ...` prefix
+/// the JS shim keys on to re-throw the matching typed subclass. The
+/// per-class wrappers below ([`invalid_parameter_err`], [`config_option_err`])
+/// name their class so the call sites read intent.
+fn typed_napi_err(class: &str, message: impl std::fmt::Display) -> napi::Error {
+    napi::Error::from_reason(format!("[{class}] {message}"))
+}
+
 /// Build an `InvalidParameterError`-typed napi error for user-input
 /// validation that fails before reaching the core client. The JS shim
 /// keys on the `[ClassName]` prefix to re-throw the typed subclass, so
 /// TypeScript callers branch on `instanceof InvalidParameterError`
 /// exactly as Python callers catch the parity `ValueError`.
 pub(crate) fn invalid_parameter_err(message: impl std::fmt::Display) -> napi::Error {
-    napi::Error::from_reason(format!("[InvalidParameterError] {message}"))
+    typed_napi_err("InvalidParameterError", message)
 }
 
 /// Project the core's active full-subscription set into the cross-binding
@@ -215,6 +223,30 @@ impl Credentials {
     }
 }
 
+/// Load credentials from a two-line file, seed the process-global runtime
+/// from `cfg`, and run the connect handshake off the libuv thread,
+/// returning the shared client handle.
+///
+/// Shared by the `connectFromFile` factory on both the unified [`Client`]
+/// and the historical-only [`HistoricalClient`]: the connect core is
+/// identical (`thetadatadx::Client::connect` opens the historical channel
+/// and Nexus, never streaming until a streaming method is called); the two
+/// factories differ only in the napi handle they wrap around the returned
+/// `Arc`.
+pub(crate) async fn connect_historical_from_file_core(
+    path: String,
+    cfg: config::DirectConfig,
+) -> napi::Result<Arc<thetadatadx::Client>> {
+    let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
+    let rt = runtime_from_config(&cfg.runtime);
+    let client = rt
+        .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("connect task failed to complete: {e}")))?
+        .map_err(to_napi_err)?;
+    Ok(Arc::new(client))
+}
+
 /// Snapshot an optional [`Config`] handle into an owned [`DirectConfig`],
 /// falling back to the production default when none is supplied. The
 /// snapshot decouples the client from later mutations of the `Config`
@@ -233,7 +265,7 @@ pub(crate) fn config_or_production(config: Option<&Config>) -> config::DirectCon
 /// shim re-throws as a typed `ConfigError`, so the failure surfaces the
 /// same branded class the other bindings raise.
 fn config_option_err(message: impl AsRef<str>) -> napi::Error {
-    napi::Error::from_reason(format!("[ConfigError] {}", message.as_ref()))
+    typed_napi_err("ConfigError", message.as_ref())
 }
 
 /// Inline authentication + environment for [`Client::connectWith`].
@@ -365,65 +397,20 @@ impl ClientConnectOptions {
     }
 }
 
-/// Validate a JavaScript `timeoutMs` deadline and convert it to the
-/// integer millisecond domain the Python, C++, and C ABI bindings take.
+/// Guard that a JS `number` (IEEE-754 double) carrying an integer query
+/// parameter is a non-negative whole number within `[0, max]`, returning
+/// it unchanged on success so the caller can cast to its integer domain.
 ///
-/// `timeoutMs` rides in the options object as a JS `number` (an IEEE-754
-/// double). The integer-typed bindings cannot represent a fractional,
-/// negative, or non-finite deadline, so this binding rejects the same
-/// inputs rather than coercing them: an `as u64` cast would silently
-/// rewrite `NaN` and a negative value to `0` (an instant deadline),
-/// `Infinity` to `u64::MAX` (a multi-century deadline), and a fractional
-/// value to its truncation — each the opposite of a caller's intent. A
-/// rejected value surfaces as `InvalidParameterError`, the typed class
-/// the Python binding raises (`ValueError`) for the identical input, so
-/// a caller's `catch (e instanceof InvalidParameterError)` branch ports
-/// across bindings.
-pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
-    if !timeout_ms.is_finite() {
-        return Err(invalid_parameter_err(format!(
-            "timeoutMs must be a non-negative integer number of milliseconds; got {timeout_ms}"
-        )));
-    }
-    if timeout_ms < 0.0 {
-        return Err(invalid_parameter_err(format!(
-            "timeoutMs must be non-negative; got {timeout_ms}"
-        )));
-    }
-    if timeout_ms.fract() != 0.0 {
-        return Err(invalid_parameter_err(format!(
-            "timeoutMs must be a whole number of milliseconds; got {timeout_ms}"
-        )));
-    }
-    if timeout_ms > u64::MAX as f64 {
-        return Err(invalid_parameter_err(format!(
-            "timeoutMs exceeds the representable millisecond range; got {timeout_ms}"
-        )));
-    }
-    Ok(timeout_ms as u64)
-}
-
-/// Validate an optional non-negative integer query parameter and convert
-/// it to the `i32` domain the core request builders take, leaving an
-/// omitted value (`None`) untouched.
-///
-/// The bounded integer filters (`maxDte`, `strikeRange` — days-to-expiry
-/// and strike windows that are counts, never negative) ride in the options
-/// object as JS `number`s (IEEE-754 doubles). Typing the napi field as
-/// `i32` would route the value through V8's `ToInt32`, which silently
-/// wraps a hostile or oversized input — `3e9` becomes a negative count,
-/// `NaN`/`Infinity` become `0`, and a fractional value is truncated — each
-/// the opposite of a caller's intent. Taking the field as `f64` and
-/// validating here rejects those inputs with `InvalidParameterError`
-/// (the typed class the Python binding raises as `ValueError` for the
-/// identical input) rather than coercing them, so a caller's
-/// `catch (e instanceof InvalidParameterError)` branch ports across
-/// bindings. `param` names the camelCase key in the rejection message.
-pub(crate) fn validate_optional_nonneg_i32(
-    param: &str,
-    value: Option<f64>,
-) -> napi::Result<Option<i32>> {
-    let Some(value) = value else { return Ok(None) };
+/// The integer-typed bindings (Python / C++ / C ABI) cannot represent a
+/// non-finite, negative, or fractional value, and a bare `as`-cast would
+/// silently rewrite a hostile or oversized input (`NaN`/`Infinity` → `0`
+/// or the type max, a fractional value → its truncation, an out-of-range
+/// magnitude → a wrapped value) — each the opposite of a caller's intent.
+/// A rejected value surfaces as `InvalidParameterError`, the typed class
+/// the Python binding raises (`ValueError`) for the identical input, so a
+/// caller's `catch (e instanceof InvalidParameterError)` branch ports
+/// across bindings. `param` names the camelCase key in the message.
+fn validate_nonneg_whole(param: &str, value: f64, max: f64) -> napi::Result<f64> {
     if !value.is_finite() {
         return Err(invalid_parameter_err(format!(
             "{param} must be a non-negative whole number; got {value}"
@@ -439,12 +426,32 @@ pub(crate) fn validate_optional_nonneg_i32(
             "{param} must be a whole number; got {value}"
         )));
     }
-    if value > i32::MAX as f64 {
+    if value > max {
         return Err(invalid_parameter_err(format!(
             "{param} exceeds the representable range; got {value}"
         )));
     }
-    Ok(Some(value as i32))
+    Ok(value)
+}
+
+/// Validate a JavaScript `timeoutMs` deadline and convert it to the
+/// integer millisecond domain the Python, C++, and C ABI bindings take.
+pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
+    Ok(validate_nonneg_whole("timeoutMs", timeout_ms, u64::MAX as f64)? as u64)
+}
+
+/// Validate an optional non-negative integer query parameter (the bounded
+/// integer filters `maxDte` / `strikeRange` — counts, never negative) and
+/// convert it to the `i32` domain the core request builders take, leaving
+/// an omitted value (`None`) untouched.
+pub(crate) fn validate_optional_nonneg_i32(
+    param: &str,
+    value: Option<f64>,
+) -> napi::Result<Option<i32>> {
+    let Some(value) = value else { return Ok(None) };
+    Ok(Some(
+        validate_nonneg_whole(param, value, i32::MAX as f64)? as i32
+    ))
 }
 
 /// Run an endpoint round-trip off the runtime's execution thread and
@@ -556,18 +563,22 @@ fn normalize_symbols(symbols: Either<String, Vec<String>>) -> Vec<String> {
     }
 }
 
-fn normalize_date(value: Either<String, chrono::DateTime<chrono::Utc>>) -> String {
+/// A `String` passes through verbatim (the caller supplied a wire-format
+/// literal); a `DateTime` is rendered with `fmt` (`"%Y%m%d"` for dates,
+/// `"%H:%M:%S"` for times).
+fn normalize_dt(value: Either<String, chrono::DateTime<chrono::Utc>>, fmt: &str) -> String {
     match value {
         Either::A(value) => value,
-        Either::B(value) => value.format("%Y%m%d").to_string(),
+        Either::B(value) => value.format(fmt).to_string(),
     }
 }
 
+fn normalize_date(value: Either<String, chrono::DateTime<chrono::Utc>>) -> String {
+    normalize_dt(value, "%Y%m%d")
+}
+
 fn normalize_time(value: Either<String, chrono::DateTime<chrono::Utc>>) -> String {
-    match value {
-        Either::A(value) => value,
-        Either::B(value) => value.format("%H:%M:%S").to_string(),
-    }
+    normalize_dt(value, "%H:%M:%S")
 }
 
 fn normalize_optional_date(
@@ -831,16 +842,9 @@ impl Client {
     /// method returns a `Promise<Client>`.
     #[napi(js_name = "connectFromFile")]
     pub async fn connect_from_file(path: String, config: Option<&Config>) -> napi::Result<Client> {
-        let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let cfg = config_or_production(config);
-        let rt = runtime_from_config(&cfg.runtime);
-        let client = rt
-            .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("connect task failed to complete: {e}")))?
-            .map_err(to_napi_err)?;
+        let client = connect_historical_from_file_core(path, config_or_production(config)).await?;
         Ok(Client {
-            client: Arc::new(client),
+            client,
             callback: Arc::new(Mutex::new(None)),
         })
     }
@@ -1134,17 +1138,8 @@ impl HistoricalClient {
         path: String,
         config: Option<&Config>,
     ) -> napi::Result<HistoricalClient> {
-        let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let cfg = config_or_production(config);
-        let rt = runtime_from_config(&cfg.runtime);
-        let client = rt
-            .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("connect task failed to complete: {e}")))?
-            .map_err(to_napi_err)?;
-        Ok(HistoricalClient {
-            client: Arc::new(client),
-        })
+        let client = connect_historical_from_file_core(path, config_or_production(config)).await?;
+        Ok(HistoricalClient { client })
     }
 }
 
@@ -1166,7 +1161,7 @@ include!("_generated/streaming_methods.rs");
 // surface for historical pool sizing, retry policy, reconnect policy,
 // and flat-file backoff.
 mod config_class;
-pub use config_class::{Config, WorkerThreadsSetting};
+pub use config_class::Config;
 
 // Hand-written FLATFILES bindings — dynamic schema, see module docs.
 mod flatfile_methods;

--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -25,6 +25,7 @@
 'use strict';
 
 const native = require('./index.js');
+const { wrapStreamViewBatches } = require('./record_batch_forwarder.js');
 
 // ── Typed error hierarchy ─────────────────────────────────────────────
 //
@@ -537,23 +538,16 @@ for (const name of Object.getOwnPropertyNames(native)) {
 // values plus `close()` / `Symbol.asyncDispose`. Done here, after the
 // generic typed-error wrapping above, so the handle's errors still
 // reclassify. The native method stays `async`, so the patched method
-// awaits and re-wraps.
-//
-// The wrap is a named function (not an inline closure) so the test suite
-// can drive this exact forwarding logic against a stub native method —
-// proving the single options object reaches `batches(options)` verbatim,
-// with no positional explosion, and the native handle is re-wrapped — on
-// the real code path rather than a reimplementation that could drift.
-function wrapStreamViewBatches(nativeBatches) {
-  return async function batches(...args) {
-    const handle = await nativeBatches.apply(this, args);
-    return new RecordBatchStream(handle);
-  };
-}
+// awaits and re-wraps. The forwarder lives in `record_batch_forwarder.js`
+// (internal, not exported) so the test suite drives the real call shape
+// against a stub native method rather than a reimplementation.
 if (native.StreamView && native.StreamView.prototype) {
   const nativeBatches = native.StreamView.prototype.batches;
   if (typeof nativeBatches === 'function') {
-    native.StreamView.prototype.batches = wrapStreamViewBatches(nativeBatches);
+    native.StreamView.prototype.batches = wrapStreamViewBatches(
+      nativeBatches,
+      RecordBatchStream,
+    );
   }
 }
 
@@ -587,10 +581,6 @@ module.exports = Object.assign({}, native, exportedClasses, exportedFreeFns, {
   StreamingSession,
   // The JS-side columnar reader returned by `client.stream.batches(...)`.
   RecordBatchStream,
-  // The forwarder installed onto `StreamView.prototype.batches`. Exported
-  // so the test suite can drive the real options-object -> native call shape
-  // and the handle re-wrap against a stub native method (no live server).
-  wrapStreamViewBatches,
   // The documented `Contract` name resolves to the same static-wrapped
   // export as `ContractRef`, so `Contract.option(...)` reclassifies too.
   Contract: exportedClasses.ContractRef ?? native.ContractRef,


### PR DESCRIPTION
Lazy-pass shrinks for the TypeScript SDK. Every cut is internal or a parity alignment; the only public-surface change is the worker-threads setting (covered below). All gates green and the generated `.d.ts` is unchanged by the Rust dedups.

## Cuts

1. `typescript` moves from `dependencies` to `devDependencies`. It is a type-only tool with zero runtime usage in the package, so production installs no longer pull it (~100 MB off every install). `package-lock.json` re-resolved.
2. The four `normalize_date` / `normalize_time` / `normalize_optional_date` / `normalize_optional_time` helpers fold onto one `normalize_dt(value, fmt)`; the date/time wrappers pick the format and the optional wrappers `.map`. The four entry-point names stay (generated callers reference them).
3. The two `connectFromFile` factory bodies (unified `Client` and `HistoricalClient`) fold onto one `connect_historical_from_file_core(path, cfg)`; each factory just wraps the returned handle.
4. `config_option_err` / `invalid_parameter_err` route through one `typed_napi_err(class, msg)` builder; both wrappers stay so call sites read intent.
5. `validate_timeout_ms` / `validate_optional_nonneg_i32` share one `validate_nonneg_whole(param, value, max)` guard. The reject class (`InvalidParameterError`), the accepted set, and the bounds are unchanged; the timeout reject message adopts the shared generic wording (no test asserts the old body text).
6. The internal `StreamView.batches` forwarder moves into `record_batch_forwarder.js` and leaves the public `module.exports`. The test imports it from that module directly with `RecordBatchStream` injected, so it still drives the real call shape against a stub native method.
7. The `WorkerThreadsSetting{ hasValue, n }` object is replaced by a plain `Option<u32>`. napi-rs maps `Option<u32>` to `number | undefined | null` (the same shape `consumerCpu` already uses) and decodes by JS type, so an explicit `0` round-trips as `0` rather than collapsing to the unset sentinel. This matches the Python SDK's bare `worker_threads` optional and drops a public interface from the type surface. The `setWorkerThreads` / `workerThreads` names are unchanged, so cross-binding setter/getter parity is preserved.

## Gates

`cargo check`, `cargo clippy --all-targets -D warnings`, and `cargo fmt --check` clean. `npm run build` (napi release + codegen) passes. Rust unit tests 17/17 and `npm test` 202/202 pass. `check_binding_parity.py` reports clean with matched setter/getter counts across all four bindings. The generated `index.js` is unchanged and `index.d.ts` changes are confined to the worker-threads type (cut 7); the dedups (cuts 2-5) produce no surface diff. No new `#[allow]`; the standalone `Cargo.lock` is untouched (no dependency-graph change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)