### PR TITLE
fix(server): restore canonical error envelope for malformed flatfile path segments

### DIFF
--- a/docs-site/docs/migration/v12-to-v13.md
+++ b/docs-site/docs/migration/v12-to-v13.md
@@ -419,8 +419,8 @@ config.set_tokio_worker_threads(4)            config.worker_threads = 4
 
 ```ts
 // v12                                   // v13
-config.setTokioWorkerThreadsExplicit(true, 4);   config.setWorkerThreads(true, 4);
-config.tokioWorkerThreads;                        config.workerThreads;   // WorkerThreadsSetting { hasValue, n }
+config.setTokioWorkerThreadsExplicit(true, 4);   config.setWorkerThreads(4);
+config.tokioWorkerThreads;                        config.workerThreads;   // number | null
 ```
 
 ```cpp

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -563,7 +563,7 @@ mod tests {
     }
 
     #[test]
-    fn set_error_string_only_defaults_to_other_code() {
+    fn set_error_defaults_to_other_code() {
         // Plain `set_error` is used by sites that surface a
         // non-thetadatadx error (e.g. UTF-8 parse failures) — the
         // discriminator must default to `THETADATADX_ERR_OTHER` so the C++

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -410,10 +410,25 @@ impl ClientConnectOptions {
 /// the Python binding raises (`ValueError`) for the identical input, so a
 /// caller's `catch (e instanceof InvalidParameterError)` branch ports
 /// across bindings. `param` names the camelCase key in the message.
-fn validate_nonneg_whole(param: &str, value: f64, max: f64) -> napi::Result<f64> {
+///
+/// `unit` carries the singular unit noun (e.g. `"millisecond"`) when the
+/// value has a physical unit, so the rejection names it
+/// ("...integer number of milliseconds", "...representable millisecond
+/// range"); `None` keeps the unit-free "...whole number" / "...representable
+/// range" wording for a bare count.
+fn validate_nonneg_whole(
+    param: &str,
+    value: f64,
+    max: f64,
+    unit: Option<&str>,
+) -> napi::Result<f64> {
     if !value.is_finite() {
+        let detail = match unit {
+            Some(u) => format!("a non-negative integer number of {u}s"),
+            None => "a non-negative whole number".to_string(),
+        };
         return Err(invalid_parameter_err(format!(
-            "{param} must be a non-negative whole number; got {value}"
+            "{param} must be {detail}; got {value}"
         )));
     }
     if value < 0.0 {
@@ -422,13 +437,21 @@ fn validate_nonneg_whole(param: &str, value: f64, max: f64) -> napi::Result<f64>
         )));
     }
     if value.fract() != 0.0 {
+        let detail = match unit {
+            Some(u) => format!("a whole number of {u}s"),
+            None => "a whole number".to_string(),
+        };
         return Err(invalid_parameter_err(format!(
-            "{param} must be a whole number; got {value}"
+            "{param} must be {detail}; got {value}"
         )));
     }
     if value > max {
+        let range = match unit {
+            Some(u) => format!("the representable {u} range"),
+            None => "the representable range".to_string(),
+        };
         return Err(invalid_parameter_err(format!(
-            "{param} exceeds the representable range; got {value}"
+            "{param} exceeds {range}; got {value}"
         )));
     }
     Ok(value)
@@ -437,7 +460,12 @@ fn validate_nonneg_whole(param: &str, value: f64, max: f64) -> napi::Result<f64>
 /// Validate a JavaScript `timeoutMs` deadline and convert it to the
 /// integer millisecond domain the Python, C++, and C ABI bindings take.
 pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
-    Ok(validate_nonneg_whole("timeoutMs", timeout_ms, u64::MAX as f64)? as u64)
+    Ok(validate_nonneg_whole(
+        "timeoutMs",
+        timeout_ms,
+        u64::MAX as f64,
+        Some("millisecond"),
+    )? as u64)
 }
 
 /// Validate an optional non-negative integer query parameter (the bounded
@@ -450,7 +478,7 @@ pub(crate) fn validate_optional_nonneg_i32(
 ) -> napi::Result<Option<i32>> {
     let Some(value) = value else { return Ok(None) };
     Ok(Some(
-        validate_nonneg_whole(param, value, i32::MAX as f64)? as i32
+        validate_nonneg_whole(param, value, i32::MAX as f64, None)? as i32,
     ))
 }
 

--- a/tools/server/src/flatfile_routes.rs
+++ b/tools/server/src/flatfile_routes.rs
@@ -34,7 +34,7 @@
 use std::path::PathBuf;
 
 use axum::body::Body;
-use axum::extract::rejection::{JsonRejection, QueryRejection};
+use axum::extract::rejection::{JsonRejection, PathRejection, QueryRejection};
 use axum::extract::{FromRequest, FromRequestParts, Path, Query, Request, State};
 use axum::http::request::Parts;
 use axum::http::{header, StatusCode};
@@ -162,6 +162,18 @@ fn query_rejection_response(rejection: &QueryRejection) -> Response {
     error_response(rejection.status(), "bad_request", &rejection.body_text())
 }
 
+/// Map a `PathRejection` onto the canonical error envelope.
+///
+/// The brace route matches a non-UTF-8 percent-encoded segment (`%ff`);
+/// `Path::<(String, String)>` then fails `decode_utf8()` and rejects.
+/// Without this the GET path answers axum's default plain-text 400
+/// (`Invalid UTF-8 in \`sec_type\``), diverging from the
+/// `{"header":{"error_type":...},"response":[]}` envelope the query and
+/// POST siblings return — the contract clients drive retry / backoff off.
+fn path_rejection_response(rejection: &PathRejection) -> Response {
+    error_response(rejection.status(), "bad_request", &rejection.body_text())
+}
+
 // ── Enum parsing ─────────────────────────────────────────────────────────
 
 fn parse_sec_type(s: &str) -> Result<SecType, String> {
@@ -227,11 +239,18 @@ fn content_type_for(format: FlatFileFormat) -> &'static str {
 
 async fn handle_get(
     state: State<AppState>,
-    // Router-matched UTF-8 path segments deserialize to `String` infallibly,
-    // so plain `Path` never rejects here — no custom envelope wrapper needed.
-    Path((sec_type_s, req_type_s)): Path<(String, String)>,
+    // A non-UTF-8 percent-encoded segment (`%ff`) matches the brace route but
+    // fails `Path`'s `decode_utf8()`, so the rejection is reachable. Take the
+    // `Result` and route the failure through `error_response` so it answers
+    // the canonical JSON envelope, matching the query/POST siblings — instead
+    // of axum's default plain-text 400.
+    path: Result<Path<(String, String)>, PathRejection>,
     FlatfileQueryExtractor(params): FlatfileQueryExtractor<FlatfileQuery>,
 ) -> Response {
+    let Path((sec_type_s, req_type_s)) = match path {
+        Ok(p) => p,
+        Err(rej) => return path_rejection_response(&rej),
+    };
     let sec_type = match parse_sec_type(&sec_type_s) {
         Ok(v) => v,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, "bad_request", &e),
@@ -899,6 +918,89 @@ mod tests {
             Some(0),
             "the error envelope's response array must be empty"
         );
+    }
+
+    /// A non-UTF-8 percent-encoded path segment (`%ff`) matches the brace
+    /// route and reaches `Path::<(String, String)>`, whose `decode_utf8()`
+    /// fails. Both GET flat-file routes must answer the canonical JSON
+    /// envelope (`{"header":{"error_type":"bad_request",...},"response":[]}`,
+    /// `Content-Type: application/json`, 400) rather than axum's default
+    /// plain-text 400, matching the query/POST siblings.
+    ///
+    /// Driven through a stateless probe router that mounts the same two
+    /// brace-route patterns over the same `path_rejection_response` mapping
+    /// the live `handle_get` uses, so the reachability chain (route match →
+    /// `Path` reject → envelope) is exercised end-to-end without a live
+    /// client.
+    #[tokio::test]
+    async fn malformed_path_segment_returns_canonical_envelope_on_both_get_routes() {
+        use axum::body::to_bytes;
+        use axum::routing::get;
+        use sonic_rs::{JsonContainerTrait, JsonValueTrait};
+        use tower::ServiceExt;
+
+        async fn probe(path: Result<Path<(String, String)>, PathRejection>) -> Response {
+            match path {
+                Ok(_) => error_response(StatusCode::OK, "ok", ""),
+                Err(rej) => path_rejection_response(&rej),
+            }
+        }
+
+        let app: Router = Router::new()
+            .route("/v3/{sec_type}/flat_file/{req_type}", get(probe))
+            .route("/v3/flatfile/{sec_type}/{req_type}", get(probe));
+
+        // `%ff` decodes to the byte 0xFF, which is not valid UTF-8, so the
+        // `Path` deserialize rejects after the route matches.
+        for uri in ["/v3/flatfile/%ff/quote", "/v3/option/flat_file/%ff"] {
+            let request = axum::http::Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            let response = app.clone().oneshot(request).await.expect("router responds");
+
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "a non-UTF-8 path segment is a client fault (400): {uri}"
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok()),
+                Some(crate::handler::JSON_CONTENT_TYPE),
+                "the rejection must be served as JSON, not plain text: {uri}"
+            );
+
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let value: sonic_rs::Value = sonic_rs::from_slice(&body).unwrap_or_else(|e| {
+                panic!("rejection body must be the JSON envelope ({uri}): {e}")
+            });
+
+            let envelope_header = value.get("header").expect("envelope must carry a header");
+            assert_eq!(
+                envelope_header.get("error_type").as_str(),
+                Some("bad_request"),
+                "clients drive retry off header.error_type: {uri}"
+            );
+            assert!(
+                envelope_header
+                    .get("error_msg")
+                    .as_str()
+                    .is_some_and(|m| !m.is_empty()),
+                "the envelope must carry a non-empty diagnostic error_msg: {uri}"
+            );
+            assert_eq!(
+                value
+                    .get("response")
+                    .and_then(|r| r.as_array())
+                    .map(sonic_rs::Array::len),
+                Some(0),
+                "the error envelope's response array must be empty: {uri}"
+            );
+        }
     }
 
     // Regression: concurrent identical requests must never share a


### PR DESCRIPTION
## A1 [HIGH] — canonical error envelope for malformed flatfile path segments

A non-UTF-8 percent-encoded path segment reaches the GET flat-file handler and is not unreachable: `GET /v3/flatfile/%ff/quote` and `GET /v3/option/flat_file/%ff` match the brace route, `Path::<(String, String)>::from_request_parts` percent-decodes `%ff` to the byte `0xFF`, `decode_utf8()` fails, and the handler — taking `Path` by value — let axum answer its default plain-text 400 (`Invalid UTF-8 in \`sec_type\``, `Content-Type: text/plain`) instead of the canonical JSON envelope the rest of the surface uses.

The fix takes the path as `Result<Path<(String, String)>, PathRejection>` in the single shared `handle_get` (so both GET routes are covered by one change) and routes the rejection through `error_response` via a `path_rejection_response` helper that mirrors the existing `json_rejection_response` / `query_rejection_response` siblings. No `FlatfilePath` wrapper type is reintroduced.

A regression test drives a `%ff` segment through both brace-route patterns and asserts the canonical envelope. Observed bodies:

- `/v3/flatfile/%ff/quote` -> `{"header":{"error_type":"bad_request","error_msg":"Invalid URL: Invalid UTF-8 in \`sec_type\`"},"response":[]}`
- `/v3/option/flat_file/%ff` -> `{"header":{"error_msg":"Invalid URL: Invalid UTF-8 in \`req_type\`","error_type":"bad_request"},"response":[]}`

Both now carry `Content-Type: application/json` and status 400.

## B4 [LOW] — restore "of milliseconds" message specificity

`validate_nonneg_whole` in the TypeScript binding gained an optional unit-noun parameter so the `timeoutMs` rejections regain "integer number of milliseconds" / "whole number of milliseconds" / "representable millisecond range", while the bounded-count caller (`maxDte` / `strikeRange`) keeps its unit-free wording. Accept/reject set, bounds, and the `InvalidParameterError` class are unchanged.

## B5 [LOW] — stale migration doc

`docs-site/docs/migration/v12-to-v13.md` updated from the removed `setWorkerThreads(true, 4)` / `WorkerThreadsSetting { hasValue, n }` to the shipped `setWorkerThreads(4)` and `workerThreads; // number | null`.

## Cosmetic — stale test name

`ffi/src/error.rs` test renamed `set_error_string_only_defaults_to_other_code` -> `set_error_defaults_to_other_code` to reflect that it exercises `set_error`. No behavior change.

## Gates

cargo check (server + ffi), clippy on server and `--workspace --all-targets --locked -D warnings`, fmt --check (workspace + server + ts + ffi), server test suite incl the new `%ff` regression test (184 passed), `cargo test -p thetadatadx-ffi --lib` (91 passed), TypeScript `npm run build` + `npm test` (202 passed), `check_docs_consistency.py`, `check_binding_parity.py`, `generate_sdk_surfaces --check`, and `generate_docs_site --check` all pass. No new `#[allow]`; dep graph unchanged (no lockfile churn).