### PR TITLE
refactor(typescript): drop unreachable StreamingSession proxy branch

### DIFF
--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -317,16 +317,6 @@ class StreamingSession {
         if (WRAPPER_OWN.has(prop) || prop === Symbol.asyncDispose) {
           return Reflect.get(target, prop, receiver);
         }
-        if (prop in target && typeof target[prop] !== 'undefined') {
-          // Methods explicitly defined on this class (none today
-          // beyond the dispose symbol; future hand-written shortcuts
-          // would land here).
-          const own = Reflect.get(target, prop, receiver);
-          if (typeof own === 'function') {
-            return own.bind(target);
-          }
-          return own;
-        }
         const client = target._client;
         // The unified client's streaming surface (subscribe, diagnostics,
         // lifecycle) moved onto the `client.stream` sub-namespace view.


### PR DESCRIPTION
The StreamingSession Proxy `get` trap had a reserved branch for hand-written session methods that can never populate: `WRAPPER_OWN` (`_client`, `constructor`) and `Symbol.asyncDispose` already return at the preceding guard, the only own prop is `_client`, and `sdks/parity.toml` pins StreamingSession to carry no hand-written methods by design (pure `__getattr__`/Proxy forwarding). Removing the dead branch leaves the forwarding path unchanged.

napi build passes and the full TS suite stays green (202/202), including the asyncdispose proxy/forwarding tests that prove method forwarding still works without the branch. No `.d.ts` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)