### PR TITLE
refactor(cpp): route Stream::active_subscriptions through the shared array converter

### DIFF
--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -1946,23 +1946,7 @@ public:
     /// Snapshot the currently-active per-contract subscriptions. Throws on
     /// FFI error.
     std::vector<Subscription> active_subscriptions() const {
-        ThetaDataDxSubscriptionArray* arr = thetadatadx_client_active_subscriptions(handle_.get());
-        if (arr == nullptr) {
-            detail::throw_last_ffi_error();
-        }
-        std::vector<Subscription> out;
-        if (arr->data != nullptr && arr->len > 0) {
-            out.reserve(arr->len);
-            for (size_t i = 0; i < arr->len; ++i) {
-                const ThetaDataDxSubscription& s = arr->data[i];
-                out.push_back(Subscription{
-                    s.kind ? std::string(s.kind) : std::string(),
-                    s.contract ? std::string(s.contract) : std::string(),
-                });
-            }
-        }
-        thetadatadx_subscription_array_free(arr);
-        return out;
+        return detail::subscription_array_to_vector(thetadatadx_client_active_subscriptions(handle_.get()));
     }
 
     /// Cumulative count of user-callback failures contained by the


### PR DESCRIPTION
Stream::active_subscriptions hand-inlined the same reserve/loop/free that detail::subscription_array_to_vector already implements and that StreamingClient::active_subscriptions already routes through. Replacing the inlined body with a call to the converter folds the null-guard, null-safe field construction, and the single subscription_array_free into one place. The converter takes the array pointer and does its own null check, so the differing FFI source (client vs streaming) is irrelevant and the Subscription target is identical. The two FullSubscription sites are left alone: different target struct, no shared converter.

Output is byte-identical to the deleted loop: same vector contents, single free of the same pointer, same throw on a null array, verified against the prior inlined logic.

Gates: C++ Catch2 harness rebuilt, ctest 68/68 offline green (live-creds tests skipped); cargo check -p thetadatadx-ffi clean; check_binding_parity.py clean; generate_sdk_surfaces --check no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)