### PR TITLE
docs(streaming): use next_blocking for synchronous pulls in the guide

### DIFF
--- a/docs-site/docs/streaming/index.md
+++ b/docs-site/docs/streaming/index.md
@@ -186,7 +186,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
 }
 ```
 
-`build()` returns a `RecordBatchStream` that implements `futures::Stream`; call `.blocking()` for a synchronous `Iterator` instead. Dropping it (or `close()`) tears the session down.
+`build()` returns a `RecordBatchStream` that implements `futures::Stream`; call `.next_blocking()` to pull batches synchronously (one per call) instead. Dropping it (or `close()`) tears the session down.
 
 </template>
 


### PR DESCRIPTION
Wave-4 re-sweep #994 removed `RecordBatchStream::blocking()`; the hand-written streaming guide still pointed users at it. Repoint to `next_blocking()` (the kept synchronous pull, one batch per call). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)