### PR TITLE
fix(cpp): ref-qualify async historical methods to reject dangling temporary-view calls

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/cpp.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/cpp.rs
@@ -241,9 +241,18 @@ fn render_cpp_async_overload(
     );
     out.push_str("    /// outlive that object. Call on a named `HistoricalClient` (or chain the\n");
     out.push_str("    /// result), never on the temporary returned by `client.historical()`.\n");
+    out.push_str("    ///\n");
+    out.push_str("    /// Lvalue-only: the `&&` overload is deleted, so calling this on a\n");
     writeln!(
         out,
-        "    std::future<std::vector<{row}>> {async_name}({}) const {{",
+        "    /// temporary view (e.g. `client.historical().{async_name}(...)`) is a"
+    )
+    .unwrap();
+    out.push_str("    /// compile error. The detached task borrows the view, which would die\n");
+    out.push_str("    /// at the end of the full expression; bind the view to a variable first.\n");
+    writeln!(
+        out,
+        "    std::future<std::vector<{row}>> {async_name}({}) const& {{",
         decls.join(", ")
     )
     .unwrap();
@@ -262,6 +271,17 @@ fn render_cpp_async_overload(
     .unwrap();
     out.push_str("        });\n");
     out.push_str("    }\n\n");
+
+    // Reject the dangling temporary-view call at compile time: deleting the
+    // rvalue overload turns `client.historical().<name>_async(...)` — a future
+    // that would outlive the temporary `Historical` it borrows — into a hard
+    // error, while named-lvalue clients still resolve to the `const&` overload.
+    writeln!(
+        out,
+        "    std::future<std::vector<{row}>> {async_name}({}) && = delete;\n",
+        decls.join(", ")
+    )
+    .unwrap();
     out
 }
 

--- a/sdks/cpp/include/historical.hpp.inc
+++ b/sdks/cpp/include/historical.hpp.inc
@@ -6,11 +6,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> stock_list_symbols_async(EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_list_symbols_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> stock_list_symbols_async(EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, options = std::move(options)]() {
             return this->stock_list_symbols(options);
         });
     }
+
+    std::future<std::vector<std::string>> stock_list_symbols_async(EndpointRequestOptions options = {}) && = delete;
 
     /// List available dates for a stock by request type (EOD, TRADE, QUOTE, etc.).
     std::vector<std::string> stock_list_dates(const std::string& request_type, const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -18,11 +25,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> stock_list_dates_async(std::string request_type, std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_list_dates_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> stock_list_dates_async(std::string request_type, std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, request_type = std::move(request_type), symbol = std::move(symbol), options = std::move(options)]() {
             return this->stock_list_dates(request_type, symbol, options);
         });
     }
+
+    std::future<std::vector<std::string>> stock_list_dates_async(std::string request_type, std::string symbol, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest OHLC snapshot for one or more stocks.
     std::vector<OhlcTick> stock_snapshot_ohlc(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -32,20 +46,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->stock_snapshot_ohlc(symbol, options);
         });
     }
 
+    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->stock_snapshot_ohlc(symbols, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest trade snapshot for one or more stocks.
     std::vector<TradeTick> stock_snapshot_trade(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -55,20 +83,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->stock_snapshot_trade(symbol, options);
         });
     }
 
+    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->stock_snapshot_trade(symbols, options);
         });
     }
+
+    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
     std::vector<QuoteTick> stock_snapshot_quote(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -78,20 +120,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->stock_snapshot_quote(symbol, options);
         });
     }
 
+    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->stock_snapshot_quote(symbols, options);
         });
     }
+
+    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest market value snapshot for one or more stocks.
     std::vector<MarketValueTick> stock_snapshot_market_value(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -101,20 +157,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_market_value_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->stock_snapshot_market_value(symbol, options);
         });
     }
 
+    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_snapshot_market_value_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->stock_snapshot_market_value(symbols, options);
         });
     }
+
+    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
     std::vector<EodTick> stock_history_eod(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -122,11 +192,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<EodTick>> stock_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_history_eod_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<EodTick>> stock_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->stock_history_eod(symbol, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<EodTick>> stock_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars for a stock on a single date.
     std::vector<OhlcTick> stock_history_ohlc(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -134,11 +211,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> stock_history_ohlc_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_history_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> stock_history_ohlc_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
             return this->stock_history_ohlc(symbol, date, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> stock_history_ohlc_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all trades for a stock on a given date.
     std::vector<TradeTick> stock_history_trade(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -146,11 +230,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> stock_history_trade_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_history_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> stock_history_trade_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
             return this->stock_history_trade(symbol, date, options);
         });
     }
+
+    std::future<std::vector<TradeTick>> stock_history_trade_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
     std::vector<QuoteTick> stock_history_quote(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -158,11 +249,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> stock_history_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_history_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> stock_history_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
             return this->stock_history_quote(symbol, date, options);
         });
     }
+
+    std::future<std::vector<QuoteTick>> stock_history_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     std::vector<TradeQuoteTick> stock_history_trade_quote(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -170,11 +268,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeQuoteTick>> stock_history_trade_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_history_trade_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeQuoteTick>> stock_history_trade_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
             return this->stock_history_trade_quote(symbol, date, options);
         });
     }
+
+    std::future<std::vector<TradeQuoteTick>> stock_history_trade_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the trade at a specific time of day across a date range.
     std::vector<TradeTick> stock_at_time_trade(const std::string& symbol, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
@@ -182,11 +287,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> stock_at_time_trade_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_at_time_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> stock_at_time_trade_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
             return this->stock_at_time_trade(symbol, start_date, end_date, time_of_day, options);
         });
     }
+
+    std::future<std::vector<TradeTick>> stock_at_time_trade_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the quote at a specific time of day across a date range.
     std::vector<QuoteTick> stock_at_time_quote(const std::string& symbol, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
@@ -194,11 +306,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> stock_at_time_quote_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_at_time_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> stock_at_time_quote_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
             return this->stock_at_time_quote(symbol, start_date, end_date, time_of_day, options);
         });
     }
+
+    std::future<std::vector<QuoteTick>> stock_at_time_quote_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// List all available option underlying symbols.
     std::vector<std::string> option_list_symbols(const EndpointRequestOptions& options = {}) const;
@@ -206,11 +325,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> option_list_symbols_async(EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_list_symbols_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> option_list_symbols_async(EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, options = std::move(options)]() {
             return this->option_list_symbols(options);
         });
     }
+
+    std::future<std::vector<std::string>> option_list_symbols_async(EndpointRequestOptions options = {}) && = delete;
 
     /// List available dates for an option contract by request type.
     std::vector<std::string> option_list_dates(const std::string& request_type, const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -218,11 +344,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> option_list_dates_async(std::string request_type, std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_list_dates_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> option_list_dates_async(std::string request_type, std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, request_type = std::move(request_type), symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_list_dates(request_type, symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<std::string>> option_list_dates_async(std::string request_type, std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// List available expiration dates for an option underlying.
     std::vector<std::string> option_list_expirations(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -230,11 +363,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> option_list_expirations_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_list_expirations_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> option_list_expirations_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->option_list_expirations(symbol, options);
         });
     }
+
+    std::future<std::vector<std::string>> option_list_expirations_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
 
     /// List available strike prices for an option at a given expiration.
     std::vector<std::string> option_list_strikes(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -242,11 +382,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> option_list_strikes_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_list_strikes_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> option_list_strikes_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_list_strikes(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<std::string>> option_list_strikes_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// List all option contracts traded or quoted on a given date, optionally filtered to a symbol.
     std::vector<OptionContract> option_list_contracts(const std::string& request_type, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -254,11 +401,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OptionContract>> option_list_contracts_async(std::string request_type, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_list_contracts_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OptionContract>> option_list_contracts_async(std::string request_type, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, request_type = std::move(request_type), date = std::move(date), options = std::move(options)]() {
             return this->option_list_contracts(request_type, date, options);
         });
     }
+
+    std::future<std::vector<OptionContract>> option_list_contracts_async(std::string request_type, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest OHLC snapshot for an option contract.
     std::vector<OhlcTick> option_snapshot_ohlc(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -266,11 +420,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> option_snapshot_ohlc_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> option_snapshot_ohlc_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_ohlc(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> option_snapshot_ohlc_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest trade snapshot for an option contract.
     std::vector<TradeTick> option_snapshot_trade(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -278,11 +439,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> option_snapshot_trade_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> option_snapshot_trade_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_trade(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<TradeTick>> option_snapshot_trade_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest NBBO quote snapshot for an option contract.
     std::vector<QuoteTick> option_snapshot_quote(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -290,11 +458,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> option_snapshot_quote_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> option_snapshot_quote_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_quote(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<QuoteTick>> option_snapshot_quote_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest open interest snapshot for an option contract.
     std::vector<OpenInterestTick> option_snapshot_open_interest(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -302,11 +477,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OpenInterestTick>> option_snapshot_open_interest_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_open_interest_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OpenInterestTick>> option_snapshot_open_interest_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_open_interest(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<OpenInterestTick>> option_snapshot_open_interest_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest market value snapshot for an option contract.
     std::vector<MarketValueTick> option_snapshot_market_value(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -314,11 +496,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<MarketValueTick>> option_snapshot_market_value_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_market_value_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<MarketValueTick>> option_snapshot_market_value_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_market_value(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<MarketValueTick>> option_snapshot_market_value_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get implied volatility snapshot for an option contract (from ThetaData server).
     std::vector<IvTick> option_snapshot_greeks_implied_volatility(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -326,11 +515,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<IvTick>> option_snapshot_greeks_implied_volatility_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_greeks_implied_volatility_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<IvTick>> option_snapshot_greeks_implied_volatility_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_greeks_implied_volatility(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<IvTick>> option_snapshot_greeks_implied_volatility_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     std::vector<GreeksAllTick> option_snapshot_greeks_all(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -338,11 +534,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksAllTick>> option_snapshot_greeks_all_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_greeks_all_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksAllTick>> option_snapshot_greeks_all_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_greeks_all(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<GreeksAllTick>> option_snapshot_greeks_all_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     std::vector<GreeksFirstOrderTick> option_snapshot_greeks_first_order(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -350,11 +553,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksFirstOrderTick>> option_snapshot_greeks_first_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_greeks_first_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksFirstOrderTick>> option_snapshot_greeks_first_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_greeks_first_order(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<GreeksFirstOrderTick>> option_snapshot_greeks_first_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     std::vector<GreeksSecondOrderTick> option_snapshot_greeks_second_order(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -362,11 +572,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksSecondOrderTick>> option_snapshot_greeks_second_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_greeks_second_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksSecondOrderTick>> option_snapshot_greeks_second_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_greeks_second_order(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<GreeksSecondOrderTick>> option_snapshot_greeks_second_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     std::vector<GreeksThirdOrderTick> option_snapshot_greeks_third_order(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
@@ -374,11 +591,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksThirdOrderTick>> option_snapshot_greeks_third_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_snapshot_greeks_third_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksThirdOrderTick>> option_snapshot_greeks_third_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
             return this->option_snapshot_greeks_third_order(symbol, expiration, options);
         });
     }
+
+    std::future<std::vector<GreeksThirdOrderTick>> option_snapshot_greeks_third_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day option data for a contract over a date range.
     std::vector<EodTick> option_history_eod(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -386,11 +610,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<EodTick>> option_history_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_eod_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<EodTick>> option_history_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->option_history_eod(symbol, expiration, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<EodTick>> option_history_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars for an option contract.
     std::vector<OhlcTick> option_history_ohlc(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -398,11 +629,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> option_history_ohlc_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> option_history_ohlc_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_ohlc(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> option_history_ohlc_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all trades for an option contract on a given date.
     std::vector<TradeTick> option_history_trade(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -410,11 +648,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> option_history_trade_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> option_history_trade_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeTick>> option_history_trade_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch NBBO quotes for an option contract on a given date.
     std::vector<QuoteTick> option_history_quote(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -422,11 +667,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> option_history_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> option_history_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_quote(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<QuoteTick>> option_history_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch combined trade + quote ticks for an option contract.
     std::vector<TradeQuoteTick> option_history_trade_quote(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -434,11 +686,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeQuoteTick>> option_history_trade_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeQuoteTick>> option_history_trade_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade_quote(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeQuoteTick>> option_history_trade_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch open interest history for an option contract.
     std::vector<OpenInterestTick> option_history_open_interest(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -446,11 +705,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OpenInterestTick>> option_history_open_interest_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_open_interest_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OpenInterestTick>> option_history_open_interest_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_open_interest(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<OpenInterestTick>> option_history_open_interest_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day Greeks history for an option contract.
     std::vector<GreeksEodTick> option_history_greeks_eod(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -458,11 +724,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksEodTick>> option_history_greeks_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_greeks_eod_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksEodTick>> option_history_greeks_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->option_history_greeks_eod(symbol, expiration, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<GreeksEodTick>> option_history_greeks_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
     std::vector<GreeksAllTick> option_history_greeks_all(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -470,11 +743,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksAllTick>> option_history_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_greeks_all_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksAllTick>> option_history_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_greeks_all(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<GreeksAllTick>> option_history_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all Greeks on each trade for an option contract.
     std::vector<TradeGreeksAllTick> option_history_trade_greeks_all(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -482,11 +762,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeGreeksAllTick>> option_history_trade_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_greeks_all_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeGreeksAllTick>> option_history_trade_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade_greeks_all(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeGreeksAllTick>> option_history_trade_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch first-order Greeks history (intraday, sampled by interval).
     std::vector<GreeksFirstOrderTick> option_history_greeks_first_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -494,11 +781,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksFirstOrderTick>> option_history_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_greeks_first_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksFirstOrderTick>> option_history_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_greeks_first_order(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<GreeksFirstOrderTick>> option_history_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch first-order Greeks on each trade for an option contract.
     std::vector<TradeGreeksFirstOrderTick> option_history_trade_greeks_first_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -506,11 +800,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeGreeksFirstOrderTick>> option_history_trade_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_greeks_first_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeGreeksFirstOrderTick>> option_history_trade_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade_greeks_first_order(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeGreeksFirstOrderTick>> option_history_trade_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch second-order Greeks history (intraday, sampled by interval).
     std::vector<GreeksSecondOrderTick> option_history_greeks_second_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -518,11 +819,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksSecondOrderTick>> option_history_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_greeks_second_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksSecondOrderTick>> option_history_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_greeks_second_order(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<GreeksSecondOrderTick>> option_history_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch second-order Greeks on each trade for an option contract.
     std::vector<TradeGreeksSecondOrderTick> option_history_trade_greeks_second_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -530,11 +838,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeGreeksSecondOrderTick>> option_history_trade_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_greeks_second_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeGreeksSecondOrderTick>> option_history_trade_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade_greeks_second_order(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeGreeksSecondOrderTick>> option_history_trade_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch third-order Greeks history (intraday, sampled by interval).
     std::vector<GreeksThirdOrderTick> option_history_greeks_third_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -542,11 +857,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<GreeksThirdOrderTick>> option_history_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_greeks_third_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<GreeksThirdOrderTick>> option_history_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_greeks_third_order(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<GreeksThirdOrderTick>> option_history_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch third-order Greeks on each trade for an option contract.
     std::vector<TradeGreeksThirdOrderTick> option_history_trade_greeks_third_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -554,11 +876,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeGreeksThirdOrderTick>> option_history_trade_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_greeks_third_order_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeGreeksThirdOrderTick>> option_history_trade_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade_greeks_third_order(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeGreeksThirdOrderTick>> option_history_trade_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch implied volatility history (intraday, sampled by interval).
     std::vector<IvTick> option_history_greeks_implied_volatility(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -566,11 +895,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<IvTick>> option_history_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_greeks_implied_volatility_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<IvTick>> option_history_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_greeks_implied_volatility(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<IvTick>> option_history_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch implied volatility on each trade for an option contract.
     std::vector<TradeGreeksImpliedVolatilityTick> option_history_trade_greeks_implied_volatility(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -578,11 +914,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeGreeksImpliedVolatilityTick>> option_history_trade_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_history_trade_greeks_implied_volatility_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeGreeksImpliedVolatilityTick>> option_history_trade_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
             return this->option_history_trade_greeks_implied_volatility(symbol, expiration, date, options);
         });
     }
+
+    std::future<std::vector<TradeGreeksImpliedVolatilityTick>> option_history_trade_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the trade at a specific time of day across a date range for an option.
     std::vector<TradeTick> option_at_time_trade(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
@@ -590,11 +933,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<TradeTick>> option_at_time_trade_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_at_time_trade_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<TradeTick>> option_at_time_trade_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
             return this->option_at_time_trade(symbol, expiration, start_date, end_date, time_of_day, options);
         });
     }
+
+    std::future<std::vector<TradeTick>> option_at_time_trade_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the quote at a specific time of day across a date range for an option.
     std::vector<QuoteTick> option_at_time_quote(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
@@ -602,11 +952,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<QuoteTick>> option_at_time_quote_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().option_at_time_quote_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<QuoteTick>> option_at_time_quote_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
             return this->option_at_time_quote(symbol, expiration, start_date, end_date, time_of_day, options);
         });
     }
+
+    std::future<std::vector<QuoteTick>> option_at_time_quote_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// List all available index symbols.
     std::vector<std::string> index_list_symbols(const EndpointRequestOptions& options = {}) const;
@@ -614,11 +971,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> index_list_symbols_async(EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_list_symbols_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> index_list_symbols_async(EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, options = std::move(options)]() {
             return this->index_list_symbols(options);
         });
     }
+
+    std::future<std::vector<std::string>> index_list_symbols_async(EndpointRequestOptions options = {}) && = delete;
 
     /// List available dates for an index symbol.
     std::vector<std::string> index_list_dates(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -626,11 +990,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<std::string>> index_list_dates_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_list_dates_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<std::string>> index_list_dates_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->index_list_dates(symbol, options);
         });
     }
+
+    std::future<std::vector<std::string>> index_list_dates_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest OHLC snapshot for one or more indices.
     std::vector<OhlcTick> index_snapshot_ohlc(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -640,20 +1011,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_snapshot_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->index_snapshot_ohlc(symbol, options);
         });
     }
 
+    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_snapshot_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->index_snapshot_ohlc(symbols, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest price snapshot for one or more indices.
     std::vector<PriceTick> index_snapshot_price(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -663,20 +1048,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_snapshot_price_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->index_snapshot_price(symbol, options);
         });
     }
 
+    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_snapshot_price_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->index_snapshot_price(symbols, options);
         });
     }
+
+    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest market value snapshot for one or more indices.
     std::vector<MarketValueTick> index_snapshot_market_value(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
@@ -686,20 +1085,34 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_snapshot_market_value_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
             return this->index_snapshot_market_value(symbol, options);
         });
     }
 
+    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
+
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_snapshot_market_value_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
             return this->index_snapshot_market_value(symbols, options);
         });
     }
+
+    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day index data for a date range.
     std::vector<EodTick> index_history_eod(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -707,11 +1120,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<EodTick>> index_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_history_eod_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<EodTick>> index_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->index_history_eod(symbol, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<EodTick>> index_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars for an index.
     std::vector<OhlcTick> index_history_ohlc(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -719,11 +1139,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> index_history_ohlc_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_history_ohlc_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> index_history_ohlc_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->index_history_ohlc(symbol, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> index_history_ohlc_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday price history for an index.
     std::vector<PriceTick> index_history_price(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -731,11 +1158,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<PriceTick>> index_history_price_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_history_price_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<PriceTick>> index_history_price_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
             return this->index_history_price(symbol, date, options);
         });
     }
+
+    std::future<std::vector<PriceTick>> index_history_price_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the index price at a specific time of day across a date range.
     std::vector<IndexPriceAtTimeTick> index_at_time_price(const std::string& symbol, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
@@ -743,11 +1177,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<IndexPriceAtTimeTick>> index_at_time_price_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().index_at_time_price_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<IndexPriceAtTimeTick>> index_at_time_price_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
             return this->index_at_time_price(symbol, start_date, end_date, time_of_day, options);
         });
     }
+
+    std::future<std::vector<IndexPriceAtTimeTick>> index_at_time_price_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// Check whether the market is open today.
     std::vector<CalendarDay> calendar_open_today(const EndpointRequestOptions& options = {}) const;
@@ -755,11 +1196,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<CalendarDay>> calendar_open_today_async(EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().calendar_open_today_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<CalendarDay>> calendar_open_today_async(EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, options = std::move(options)]() {
             return this->calendar_open_today(options);
         });
     }
+
+    std::future<std::vector<CalendarDay>> calendar_open_today_async(EndpointRequestOptions options = {}) && = delete;
 
     /// Get calendar information for a specific date.
     std::vector<CalendarDay> calendar_on_date(const std::string& date, const EndpointRequestOptions& options = {}) const;
@@ -767,11 +1215,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<CalendarDay>> calendar_on_date_async(std::string date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().calendar_on_date_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<CalendarDay>> calendar_on_date_async(std::string date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, date = std::move(date), options = std::move(options)]() {
             return this->calendar_on_date(date, options);
         });
     }
+
+    std::future<std::vector<CalendarDay>> calendar_on_date_async(std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Get equity market holidays and early-close days for a year (vendor `year_holidays` endpoint — only non-standard days, not every trading day).
     std::vector<CalendarDay> calendar_year(const std::string& year, const EndpointRequestOptions& options = {}) const;
@@ -779,11 +1234,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<CalendarDay>> calendar_year_async(std::string year, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().calendar_year_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<CalendarDay>> calendar_year_async(std::string year, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, year = std::move(year), options = std::move(options)]() {
             return this->calendar_year(year, options);
         });
     }
+
+    std::future<std::vector<CalendarDay>> calendar_year_async(std::string year, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day interest rate history.
     std::vector<InterestRateTick> interest_rate_history_eod(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -791,11 +1253,18 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<InterestRateTick>> interest_rate_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().interest_rate_history_eod_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<InterestRateTick>> interest_rate_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->interest_rate_history_eod(symbol, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<InterestRateTick>> interest_rate_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
     std::vector<OhlcTick> stock_history_ohlc_range(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
@@ -803,9 +1272,16 @@
     /// \warning The future borrows the object it was called on; do not let it
     /// outlive that object. Call on a named `HistoricalClient` (or chain the
     /// result), never on the temporary returned by `client.historical()`.
-    std::future<std::vector<OhlcTick>> stock_history_ohlc_range_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+    ///
+    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
+    /// temporary view (e.g. `client.historical().stock_history_ohlc_range_async(...)`) is a
+    /// compile error. The detached task borrows the view, which would die
+    /// at the end of the full expression; bind the view to a variable first.
+    std::future<std::vector<OhlcTick>> stock_history_ohlc_range_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
         return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
             return this->stock_history_ohlc_range(symbol, start_date, end_date, options);
         });
     }
+
+    std::future<std::vector<OhlcTick>> stock_history_ohlc_range_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 

--- a/sdks/cpp/tests/history_async.cpp
+++ b/sdks/cpp/tests/history_async.cpp
@@ -25,6 +25,30 @@ std::string env_or_empty(const char* key) {
     return raw == nullptr ? std::string() : std::string(raw);
 }
 
+namespace detail {
+
+// Detects whether `<obj>.stock_list_symbols_async()` is well-formed for a given
+// value category of the object. The `_async` companions delete their rvalue
+// overload, so this is true for an lvalue object and false for an rvalue one.
+template <typename T, typename = void>
+struct async_lvalue : std::false_type {};
+template <typename T>
+struct async_lvalue<T, std::void_t<decltype(std::declval<T&>().stock_list_symbols_async())>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct async_rvalue : std::false_type {};
+template <typename T>
+struct async_rvalue<T, std::void_t<decltype(std::declval<T&&>().stock_list_symbols_async())>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool async_callable_on_lvalue = async_lvalue<T>::value;
+template <typename T>
+inline constexpr bool async_callable_on_rvalue = async_rvalue<T>::value;
+
+} // namespace detail
+
 } // namespace
 
 TEST_CASE("async query methods return std::future of the sync row type",
@@ -68,6 +92,19 @@ TEST_CASE("async query methods return std::future of the sync row type",
         decltype(std::declval<const Hist&>().stock_list_symbols_async(
             std::declval<thetadatadx::EndpointRequestOptions>()));
     STATIC_REQUIRE(std::is_same_v<ListRet, std::future<std::vector<std::string>>>);
+
+    // Dangling-temporary guard. The `_async` companions have their rvalue
+    // (`&&`) overload deleted, so they are callable on an lvalue view but NOT
+    // on an rvalue one. This makes the natural-looking
+    // `client.historical().foo_async(...)` — where the `Historical` view is a
+    // temporary that dies at the end of the full expression while the detached
+    // task still borrows it — a compile error rather than a use-after-free. A
+    // named `auto h = client.historical();` (an lvalue) keeps working.
+    STATIC_REQUIRE(detail::async_callable_on_lvalue<View>);
+    STATIC_REQUIRE_FALSE(detail::async_callable_on_rvalue<View>);
+    // Same guard on the dedicated historical client.
+    STATIC_REQUIRE(detail::async_callable_on_lvalue<Hist>);
+    STATIC_REQUIRE_FALSE(detail::async_callable_on_rvalue<Hist>);
 }
 
 TEST_CASE("async query resolves to the same rows as the blocking call",


### PR DESCRIPTION
The generated `<endpoint>_async` companions on the C++ historical surface captured a borrowed `this` into the `std::async` task. `Client::historical()` returns a non-owning `Historical` view by value, so the natural one-liner `client.historical().<name>_async(...)` materialized a temporary view, handed its borrow to a detached task, then destroyed the view at the end of the full expression — a use-after-free once the task ran.

The async-method emitter now deletes the rvalue (`&&`) overload of every `_async` companion, keeping the usable `const&` overload. Calling `_async` on the temporary view is now a compile error (`use of deleted function ... &&`), while named `Historical` / `HistoricalClient` / `Client` lvalues resolve to the `const&` overload and keep working. This mirrors the lvalue-only ref-qualification already on the `historical()` / `stream()` accessors one level up.

The async surface test gains a type-level guard (a `void_t` detector asserting the companion is callable on an lvalue object but not an rvalue one) on both the unified-client `Historical` view and the dedicated `HistoricalClient`. Generated header regenerated; surface-gen `--check`, binding parity, and `cargo check -p thetadatadx-ffi` are clean; the C++ Catch2 offline suite passes (320 assertions, 61 cases).