### PR TITLE
fix(typescript): validate numeric inputs at the napi boundary + fallible runtime + dispatcher failure state

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/config_accessors.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/config_accessors.rs
@@ -606,6 +606,24 @@ fn rust_lit(raw: &str) -> String {
     raw.replace('"', "\\\"")
 }
 
+/// The TypeScript `u32` setter validator for an accessor: the napi
+/// boundary takes the argument as `f64` (V8 `ToUint32` on a bare `u32`
+/// silently wraps `-1`/`2**32` and truncates `1.5`) and routes it through
+/// a finite/whole/range check. A burst-size or attempt-budget knob — a
+/// value the core rejects at `0` — additionally floors at `1`; every
+/// other `u32` knob (iteration counts, keepalive retries) allows `0`.
+///
+/// The `_attempts` suffix and the `replay_burst_size` field are the
+/// min-1 set; both spellings come straight off the field name so a new
+/// attempt-budget row inherits the floor without a per-row flag.
+fn ts_u32_validator(field: &str) -> &'static str {
+    if field.ends_with("_attempts") || field == "reconnect_replay_burst_size" {
+        "validate_u32_arg_min1"
+    } else {
+        "validate_u32_arg"
+    }
+}
+
 /// The Rust scalar type each abi maps to on the PyO3 surface.
 fn py_type(abi: &str) -> &'static str {
     match abi {
@@ -962,7 +980,19 @@ pub(super) fn render_typescript_config_accessors() -> Result<String, Box<dyn std
                             _ => "value".to_string(),
                         },
                     ),
-                    "u32" => ("u32", String::new(), param.to_string()),
+                    // `u32` arrives as `f64` and is validated at the napi
+                    // boundary; the attempt budgets here additionally floor
+                    // at 1 (see `ts_u32_validator`). The diagnostic names the
+                    // camelCase JS key, not the Rust param.
+                    "u32" => (
+                        "f64",
+                        format!(
+                            "        let value = crate::{}(\"{camel}\", {param})?;\n",
+                            ts_u32_validator(field),
+                            camel = to_camel_case(field),
+                        ),
+                        "value".to_string(),
+                    ),
                     other => panic!("config_surface: policy_limit abi '{other}'"),
                 };
                 write!(
@@ -1000,7 +1030,20 @@ pub(super) fn render_typescript_config_accessors() -> Result<String, Box<dyn std
                     ),
                     "value".to_string(),
                 ),
-                "u32" => ("u32".to_string(), String::new(), param.to_string()),
+                // `u32` arrives as `f64` and is validated at the napi
+                // boundary so a hostile `-1` / `1.5` / `2**32` is rejected
+                // rather than silently wrapped by V8 `ToUint32`. Attempt
+                // budgets additionally floor at 1 (`ts_u32_validator`); the
+                // diagnostic names the camelCase JS key.
+                "u32" => (
+                    "f64".to_string(),
+                    format!(
+                        "        let value = crate::{}(\"{camel}\", {param})?;\n",
+                        ts_u32_validator(field),
+                        camel = to_camel_case(field),
+                    ),
+                    "value".to_string(),
+                ),
                 "bool" => ("bool".to_string(), String::new(), param.to_string()),
                 other => panic!("config_surface: unmapped abi_type '{other}'"),
             };

--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -209,10 +209,17 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
             // `Promise<boolean>` on the JS side.
             writeln!(
                 out,
-                "    pub async fn {}(&self, timeout_ms: u32) -> napi::Result<bool> {{",
+                "    pub async fn {}(&self, timeout_ms: f64) -> napi::Result<bool> {{",
                 method.name,
             )
             .unwrap();
+            // `timeout_ms` arrives as `f64`: V8 `ToUint32` on a bare `u32`
+            // arg silently wraps a hostile `-1` / `2**32` and truncates a
+            // fractional value, so it is validated at the napi boundary
+            // (`0` is a legal "poll once" timeout, so the plain validator).
+            out.push_str(
+                "        let timeout_ms = crate::validate_u32_arg(\"timeoutMs\", timeout_ms)?;\n",
+            );
             // Clone the Arc<thetadatadx::Client> so the blocking
             // closure can outlive `&self` — `spawn_blocking` requires
             // `'static`. The polling itself is cheap (1 ms sleep loop)

--- a/sdks/typescript/__tests__/flatfiles_config.test.mjs
+++ b/sdks/typescript/__tests__/flatfiles_config.test.mjs
@@ -36,9 +36,23 @@ describe('Config.flatFiles* — defaults mirror FlatFilesConfig::production_defa
 describe('Config.setFlatfilesMaxAttempts', () => {
   it('round-trips through the setter across the documented u32 range', () => {
     const cfg = Config.production();
-    for (const n of [0, 1, 3, 5, 10, 100, 1_000]) {
+    // `1` disables retry; the documented valid range is `[1, 100]`, so the
+    // setter floors at 1 (validated at the napi boundary). `0` is rejected
+    // below rather than round-tripped.
+    for (const n of [1, 3, 5, 10, 100, 1_000]) {
       cfg.setFlatfilesMaxAttempts(n);
       assert.equal(cfg.flatfilesMaxAttempts, n);
+    }
+  });
+
+  it('rejects 0 and other hostile inputs at the napi boundary', () => {
+    const cfg = Config.production();
+    for (const bad of [0, -1, 1.5, 2 ** 32, Number.NaN]) {
+      assert.throws(
+        () => cfg.setFlatfilesMaxAttempts(bad),
+        /flatfilesMaxAttempts/,
+        `setFlatfilesMaxAttempts(${bad}) must reject, not silently rewrite via ToUint32`,
+      );
     }
   });
 });

--- a/sdks/typescript/__tests__/native_typed_errors.test.mjs
+++ b/sdks/typescript/__tests__/native_typed_errors.test.mjs
@@ -484,3 +484,159 @@ describe('non-negative integer query-param input-validation parity (native)', ()
     }
   });
 });
+
+describe('Config u32 setter input-validation parity (native)', () => {
+  // napi's bare `u32` argument binding is V8 `ToUint32`: it never
+  // rejects, it REWRITES — `-1` wraps to u32::MAX, `1.5` truncates to 1,
+  // `2**32` wraps to 0. Each rewrite is the opposite of the caller's
+  // intent. The `Config` u32 knobs take the argument as `number` and
+  // validate at the napi boundary, rejecting a negative / fractional /
+  // over-u32 value as `InvalidParameterError` (the same class Python's
+  // `ValueError` maps to for the identical input), and the burst-size /
+  // attempt-budget knobs additionally reject `0`. These setters are
+  // reachable without a connection.
+
+  // Knobs where `0` is NOT a legal value (a degenerate burst / budget
+  // the core rejects at connect): `0` must also throw.
+  const minOneSetters = [
+    'setReconnectReplayBurstSize',
+    'setRetryMaxAttempts',
+    'setFlatfilesMaxAttempts',
+    'setReconnectMaxAttempts',
+    'setReconnectMaxRateLimitedAttempts',
+    'setReconnectMaxServerRestartAttempts',
+  ];
+  // Knobs where `0` is a legal value (iteration counts / keepalive
+  // retries): `0` must be accepted; only the hostile shapes throw.
+  const zeroOkSetters = ['setStreamingKeepaliveRetries', 'setWaitSpinIters', 'setWaitYieldIters'];
+
+  const hostile = [
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['overflow (2**32)', 2 ** 32],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ];
+
+  for (const setter of [...minOneSetters, ...zeroOkSetters]) {
+    for (const [label, value] of hostile) {
+      it(`${setter} rejects ${label} as InvalidParameterError`, async () => {
+        const mod = await loadWrapped();
+        if (!mod) return;
+        const cfg = mod.Config.production();
+        assert.throws(
+          () => cfg[setter](value),
+          (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+          `a ${label} ${setter} value must reject, not wrap through ToUint32`,
+        );
+      });
+    }
+
+    it(`${setter} accepts a valid positive value`, async () => {
+      const mod = await loadWrapped();
+      if (!mod) return;
+      const cfg = mod.Config.production();
+      assert.doesNotThrow(() => cfg[setter](7), `a valid ${setter} value must be accepted`);
+    });
+  }
+
+  for (const setter of minOneSetters) {
+    it(`${setter} rejects 0 as InvalidParameterError`, async () => {
+      const mod = await loadWrapped();
+      if (!mod) return;
+      const cfg = mod.Config.production();
+      assert.throws(
+        () => cfg[setter](0),
+        (err) => err instanceof mod.InvalidParameterError,
+        `${setter} requires >= 1, so 0 must reject`,
+      );
+    });
+  }
+
+  for (const setter of zeroOkSetters) {
+    it(`${setter} accepts 0`, async () => {
+      const mod = await loadWrapped();
+      if (!mod) return;
+      const cfg = mod.Config.production();
+      assert.doesNotThrow(() => cfg[setter](0), `${setter} permits 0`);
+    });
+  }
+});
+
+describe('Config optional-u32 setter input-validation parity (native)', () => {
+  // `setWorkerThreads` / `setConsumerCpu` take `number | null`: `null`
+  // defers to the default (and `0` is a verbatim, valid choice), while a
+  // hostile number is rejected at the boundary rather than rewritten.
+  const optSetters = ['setWorkerThreads', 'setConsumerCpu'];
+  const hostile = [
+    ['negative', -1],
+    ['fractional', 2.5],
+    ['overflow (2**32)', 2 ** 32],
+  ];
+
+  for (const setter of optSetters) {
+    for (const [label, value] of hostile) {
+      it(`${setter} rejects ${label} as InvalidParameterError`, async () => {
+        const mod = await loadWrapped();
+        if (!mod) return;
+        const cfg = mod.Config.production();
+        assert.throws(
+          () => cfg[setter](value),
+          (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+          `a ${label} ${setter} value must reject`,
+        );
+      });
+    }
+
+    it(`${setter} accepts 0 and null`, async () => {
+      const mod = await loadWrapped();
+      if (!mod) return;
+      const cfg = mod.Config.production();
+      assert.doesNotThrow(() => cfg[setter](0), `${setter} permits 0 (verbatim count / core 0)`);
+      assert.doesNotThrow(() => cfg[setter](null), `${setter} permits null (default sizing)`);
+    });
+  }
+});
+
+describe('awaitDrain timeout input-validation parity (native)', () => {
+  // The standalone `StreamingClient.awaitDrain(timeoutMs)` took a bare
+  // `u32`, so a hostile `-1` / `1.5` / `2**32` was silently rewritten by
+  // ToUint32. It now takes `number` and validates at the boundary; `0`
+  // (poll once) stays valid. Reachable without a live session — with no
+  // retired generations the poll resolves immediately.
+  const hostile = [
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['overflow (2**32)', 2 ** 32],
+    ['NaN', Number.NaN],
+  ];
+
+  function streamingClient(mod) {
+    // Build an idle standalone client without connecting: the factory
+    // only snapshots params, the TLS connection is deferred.
+    const creds = mod.Credentials.fromApiKey('td1_example');
+    return mod.StreamingClient.connect(creds);
+  }
+
+  for (const [label, value] of hostile) {
+    it(`awaitDrain rejects ${label} as InvalidParameterError`, async () => {
+      const mod = await loadWrapped();
+      if (!mod) return;
+      const sc = streamingClient(mod);
+      await assert.rejects(
+        sc.awaitDrain(value),
+        (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+        `a ${label} awaitDrain timeout must reject, not wrap through ToUint32`,
+      );
+    });
+  }
+
+  it('awaitDrain accepts 0 (poll once) and a valid timeout', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+    const sc = streamingClient(mod);
+    // No retired generations, so both resolve true immediately.
+    assert.equal(await sc.awaitDrain(0), true, 'a 0ms poll-once drain must be valid');
+    assert.equal(await sc.awaitDrain(100), true, 'a valid timeout must be accepted');
+  });
+});

--- a/sdks/typescript/examples/flatfiles_trade_quotes_to_arrow.ts
+++ b/sdks/typescript/examples/flatfiles_trade_quotes_to_arrow.ts
@@ -11,29 +11,36 @@
 import { Client } from "thetadatadx";
 import { tableFromIPC } from "apache-arrow";
 
-const client = Client.connectFromFile("creds.txt");
+async function main(): Promise<void> {
+  const client = await Client.connectFromFile("creds.txt");
 
-// Whole-universe option trade-quotes for one trading day.
-const rows = client.flatFiles.optionTradeQuote("20260428");
-console.log(`option_trade_quote rows: ${rows.len()}`);
+  // Whole-universe option trade-quotes for one trading day.
+  const rows = client.flatFiles.optionTradeQuote("20260428");
+  console.log(`option_trade_quote rows: ${rows.len()}`);
 
-// Apache Arrow table -- one column per vendor field plus the contract
-// key columns (symbol, expiration, strike, right). Schema inferred
-// from the first row by `flatfiles::arrow::rows_to_arrow`.
-const ipc = rows.toArrowIpc();
-const table = tableFromIPC(ipc);
-console.log(table.schema.fields.map((f) => `${f.name}:${f.type}`).join(", "));
+  // Apache Arrow table -- one column per vendor field plus the contract
+  // key columns (symbol, expiration, strike, right). Schema inferred
+  // from the first row by `flatfiles::arrow::rows_to_arrow`.
+  const ipc = rows.toArrowIpc();
+  const table = tableFromIPC(ipc);
+  console.log(table.schema.fields.map((f) => `${f.name}:${f.type}`).join(", "));
 
-// Same path, dispatched dynamically.
-const oi = client.flatFiles.request("OPTION", "OPEN_INTEREST", "20260428");
-console.log(`open_interest rows: ${oi.len()}`);
+  // Same path, dispatched dynamically.
+  const oi = client.flatFiles.request("OPTION", "OPEN_INTEREST", "20260428");
+  console.log(`open_interest rows: ${oi.len()}`);
 
-// Drop raw vendor CSV bytes to disk without materialising rows.
-const path = client.flatFileToPath(
-  "OPTION",
-  "TRADE_QUOTE",
-  "20260428",
-  "/tmp/option-trade-quote",
-  "csv",
-);
-console.log(`raw vendor CSV at ${path}`);
+  // Drop raw vendor CSV bytes to disk without materialising rows.
+  const path = client.flatFileToPath(
+    "OPTION",
+    "TRADE_QUOTE",
+    "20260428",
+    "/tmp/option-trade-quote",
+    "csv",
+  );
+  console.log(`raw vendor CSV at ${path}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdks/typescript/examples/fluent_streaming_quote.ts
+++ b/sdks/typescript/examples/fluent_streaming_quote.ts
@@ -12,7 +12,7 @@
 import { Contract, SecType, Client } from "thetadatadx";
 
 async function main(): Promise<void> {
-  const client = Client.connectFromFile("creds.txt");
+  const client = await Client.connectFromFile("creds.txt");
 
   // Fluent contract-first construction.
   const stock = Contract.stock("AAPL");

--- a/sdks/typescript/examples/historical.ts
+++ b/sdks/typescript/examples/historical.ts
@@ -16,7 +16,7 @@
 import { Client } from "thetadatadx";
 
 async function main(): Promise<void> {
-  const client = Client.connectFromFile("creds.txt");
+  const client = await Client.connectFromFile("creds.txt");
 
   // End-of-day stock data.
   console.log("=== AAPL EOD (Jan-Mar 2024) ===");

--- a/sdks/typescript/src/_generated/config_accessors.rs
+++ b/sdks/typescript/src/_generated/config_accessors.rs
@@ -109,12 +109,13 @@ impl Config {
     /// burst flushed and followed by a jittered `replayPaceMs` pause.
     /// Minimum `1` (validated at connect). Default `50`.
     #[napi(js_name = "setReconnectReplayBurstSize")]
-    pub fn set_reconnect_replay_burst_size(&self, n: u32) -> napi::Result<()> {
+    pub fn set_reconnect_replay_burst_size(&self, n: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg_min1("reconnectReplayBurstSize", n)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.reconnect.replay_burst_size = n;
+        guard.reconnect.replay_burst_size = value;
         Ok(())
     }
 
@@ -310,12 +311,13 @@ impl Config {
     /// platform exposes the knob). Default `2`; validated to `[1, 10]`
     /// at connect.
     #[napi(js_name = "setStreamingKeepaliveRetries")]
-    pub fn set_streaming_keepalive_retries(&self, n: u32) -> napi::Result<()> {
+    pub fn set_streaming_keepalive_retries(&self, n: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg("streamingKeepaliveRetries", n)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.streaming.keepalive_retries = n;
+        guard.streaming.keepalive_retries = value;
         Ok(())
     }
 
@@ -420,12 +422,13 @@ impl Config {
     /// disables retry; higher values permit retries up to
     /// `maxAttempts - 1` after the initial call. Default `20`.
     #[napi(js_name = "setRetryMaxAttempts")]
-    pub fn set_retry_max_attempts(&self, n: u32) -> napi::Result<()> {
+    pub fn set_retry_max_attempts(&self, n: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg_min1("retryMaxAttempts", n)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.retry.max_attempts = n;
+        guard.retry.max_attempts = value;
         Ok(())
     }
 
@@ -491,12 +494,13 @@ impl Config {
     /// permit retries up to `maxAttempts - 1` after the initial call.
     /// Default `10`. Validated to the range `[1, 100]` at connect time.
     #[napi(js_name = "setFlatfilesMaxAttempts")]
-    pub fn set_flatfiles_max_attempts(&self, n: u32) -> napi::Result<()> {
+    pub fn set_flatfiles_max_attempts(&self, n: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg_min1("flatfilesMaxAttempts", n)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.flatfiles.max_attempts = n;
+        guard.flatfiles.max_attempts = value;
         Ok(())
     }
 
@@ -735,13 +739,14 @@ impl Config {
     /// auto-reconnect path. Default `30`. No effect unless the
     /// reconnect policy is `Auto`.
     #[napi(js_name = "setReconnectMaxAttempts")]
-    pub fn set_reconnect_max_attempts(&self, max_attempts: u32) -> napi::Result<()> {
+    pub fn set_reconnect_max_attempts(&self, max_attempts: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg_min1("reconnectMaxAttempts", max_attempts)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         if let config::ReconnectPolicy::Auto(ref mut limits) = guard.reconnect.policy {
-            limits.max_attempts = max_attempts;
+            limits.max_attempts = value;
         }
         Ok(())
     }
@@ -765,13 +770,14 @@ impl Config {
     /// budget for the auto-reconnect path. Default `100`. No effect
     /// unless the reconnect policy is `Auto`.
     #[napi(js_name = "setReconnectMaxRateLimitedAttempts")]
-    pub fn set_reconnect_max_rate_limited_attempts(&self, max_rate_limited_attempts: u32) -> napi::Result<()> {
+    pub fn set_reconnect_max_rate_limited_attempts(&self, max_rate_limited_attempts: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg_min1("reconnectMaxRateLimitedAttempts", max_rate_limited_attempts)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         if let config::ReconnectPolicy::Auto(ref mut limits) = guard.reconnect.policy {
-            limits.max_rate_limited_attempts = max_rate_limited_attempts;
+            limits.max_rate_limited_attempts = value;
         }
         Ok(())
     }
@@ -793,13 +799,14 @@ impl Config {
     /// Set the `ServerRestarting` reconnect attempt budget. Default
     /// `60`. No effect unless the reconnect policy is `Auto`.
     #[napi(js_name = "setReconnectMaxServerRestartAttempts")]
-    pub fn set_reconnect_max_server_restart_attempts(&self, n: u32) -> napi::Result<()> {
+    pub fn set_reconnect_max_server_restart_attempts(&self, n: f64) -> napi::Result<()> {
+        let value = crate::validate_u32_arg_min1("reconnectMaxServerRestartAttempts", n)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         if let config::ReconnectPolicy::Auto(ref mut limits) = guard.reconnect.policy {
-            limits.max_server_restart_attempts = n;
+            limits.max_server_restart_attempts = value;
         }
         Ok(())
     }

--- a/sdks/typescript/src/_generated/streaming_methods.rs
+++ b/sdks/typescript/src/_generated/streaming_methods.rs
@@ -270,7 +270,8 @@ impl StreamView {
 
     /// Block until the previous streaming session's consumer thread has finished firing the registered callback. Returns true if the drain completed within the timeout, false otherwise.
     #[napi(js_name = "awaitDrain")]
-    pub async fn await_drain(&self, timeout_ms: u32) -> napi::Result<bool> {
+    pub async fn await_drain(&self, timeout_ms: f64) -> napi::Result<bool> {
+        let timeout_ms = crate::validate_u32_arg("timeoutMs", timeout_ms)?;
         let client = self.client.clone();
         let timeout = std::time::Duration::from_millis(u64::from(timeout_ms));
         tokio::task::spawn_blocking(move || client.stream().await_drain(timeout))

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -270,7 +270,12 @@ impl Config {
     /// created; clients connected later share the already-built pool, so
     /// setting it on a subsequent config has no effect.
     #[napi(js_name = "setWorkerThreads")]
-    pub fn set_worker_threads(&self, n: Option<u32>) -> napi::Result<()> {
+    pub fn set_worker_threads(&self, n: Option<f64>) -> napi::Result<()> {
+        // `0` is a valid, verbatim choice here (the core clamps it to 1),
+        // so the plain `validate_optional_u32_arg` is used rather than the
+        // `>= 1` floor — but a fractional / negative / over-u32 value is
+        // still rejected instead of being silently rewritten by ToUint32.
+        let n = crate::validate_optional_u32_arg("workerThreads", n)?;
         let mut guard = self
             .inner
             .lock()
@@ -337,7 +342,8 @@ impl Config {
 
     /// Set the wait-strategy spin iteration count.
     #[napi(js_name = "setWaitSpinIters")]
-    pub fn set_wait_spin_iters(&self, iters: u32) -> napi::Result<()> {
+    pub fn set_wait_spin_iters(&self, iters: f64) -> napi::Result<()> {
+        let iters = crate::validate_u32_arg("waitSpinIters", iters)?;
         let mut guard = self
             .inner
             .lock()
@@ -358,7 +364,8 @@ impl Config {
 
     /// Set the wait-strategy yield iteration count.
     #[napi(js_name = "setWaitYieldIters")]
-    pub fn set_wait_yield_iters(&self, iters: u32) -> napi::Result<()> {
+    pub fn set_wait_yield_iters(&self, iters: f64) -> napi::Result<()> {
+        let iters = crate::validate_u32_arg("waitYieldIters", iters)?;
         let mut guard = self
             .inner
             .lock()
@@ -414,7 +421,10 @@ impl Config {
     /// deterministic, low-jitter delivery. An out-of-range or offline
     /// core is a best-effort no-op rather than an error.
     #[napi(js_name = "setConsumerCpu")]
-    pub fn set_consumer_cpu(&self, core: Option<u32>) -> napi::Result<()> {
+    pub fn set_consumer_cpu(&self, core: Option<f64>) -> napi::Result<()> {
+        // Core index `0` is valid (pin to CPU 0); only reject a
+        // non-finite / negative / fractional / over-u32 value.
+        let core = crate::validate_optional_u32_arg("consumerCpu", core)?;
         let mut guard = self
             .inner
             .lock()

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -81,6 +81,47 @@ const DISPATCHER_TEARDOWN_WAKE_GRACE: Duration = Duration::from_millis(250);
 /// Poll cadence for the grace window above.
 const DISPATCHER_TEARDOWN_POLL: Duration = Duration::from_millis(1);
 
+/// Extract a human-readable reason from a panic payload. The standard
+/// panic payload is `&str` or `String`; anything else falls back to a
+/// fixed string. Shared by the dispatcher thread's self-recording path
+/// and the teardown join's `Err(_)` path so both spell the reason the
+/// same way.
+fn panic_reason(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "dispatcher panicked with non-string payload".to_owned()
+    }
+}
+
+/// Record `Failed` from the dispatcher thread after a caught outer panic,
+/// but ONLY while the session slot still holds THIS thread's `Running`
+/// session.
+///
+/// Called from the dispatcher thread itself, so `std::thread::current()`
+/// is that dispatcher. A concurrent `stopStreaming` / `reconnect` may have
+/// already extracted the session (slot `Idle`, its own join about to
+/// record the panic) or installed a fresh one; in either case the panic
+/// belongs to the now-superseded old session and overwriting the slot
+/// would clobber a newer `JoinHandle` or falsely fail a healthy session.
+/// Matching the stored handle's thread id to the current thread is what
+/// pins the write to the un-superseded case.
+fn record_own_dispatcher_panic(session: &Mutex<DispatcherSession>, reason: String) {
+    let mut guard = session
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let is_own_running = matches!(
+        &*guard,
+        DispatcherSession::Running { handle, .. }
+            if handle.thread().id() == std::thread::current().id()
+    );
+    if is_own_running {
+        *guard = DispatcherSession::Failed { reason };
+    }
+}
+
 /// Join a dispatcher thread, firing its teardown wake hook only if it does not
 /// exit on its own within [`DISPATCHER_TEARDOWN_WAKE_GRACE`].
 ///
@@ -324,9 +365,15 @@ pub struct StreamingClient {
     /// stacked stop/start cycles can layer multiple in-flight ring
     /// consumers, and `awaitDrain` waits for all of them.
     prev_drained: Mutex<Vec<Arc<AtomicBool>>>,
-    /// Dispatcher thread lifecycle. Panic state is derived from
-    /// `JoinHandle::join()` returning `Err(_)`.
-    dispatcher: Mutex<DispatcherSession>,
+    /// Dispatcher thread lifecycle. Panic state is set two ways: a
+    /// teardown (`stopStreaming` / `Drop`) derives it from
+    /// `JoinHandle::join()` returning `Err(_)`, and the dispatcher thread
+    /// itself records `Failed` directly when its outer `catch_unwind`
+    /// catches an event-iteration panic, so `isStreaming()` /
+    /// `isAuthenticated()` fold to `false` the moment delivery dies even if
+    /// no teardown is ever called. Wrapped in `Arc` so the dispatcher
+    /// thread holds its own handle to publish that state.
+    dispatcher: Arc<Mutex<DispatcherSession>>,
 }
 
 impl Drop for StreamingClient {
@@ -419,7 +466,7 @@ impl StreamingClient {
         let dispatch_cb = Arc::clone(&callback);
 
         let params = self.params.clone();
-        let join_result = runtime()
+        let join_result = runtime()?
             .spawn_blocking(move || params.builder().build())
             .await;
         let build_result = match join_result {
@@ -468,24 +515,24 @@ impl StreamingClient {
         drop(callback);
 
         let dispatcher_client = Arc::clone(&client_arc);
+        // Hand the dispatcher thread its own handle to the session slot so
+        // it can publish `Failed` directly on a caught outer panic, rather
+        // than relying on a future teardown's `JoinHandle::join()` to
+        // observe the panic. Without this, an outer (non-callback) panic
+        // leaves the thread dead but the slot stuck on `Running`, so
+        // `isStreaming()` / `isAuthenticated()` keep reporting healthy
+        // after delivery has died.
+        let dispatcher_session = Arc::clone(&self.dispatcher);
         let dispatcher = std::thread::Builder::new()
             .name("thetadatadx-ts-fpss-dispatcher".into())
             .spawn(move || {
                 // `for_each_scoped` drives `poll_batch`, which wraps each
                 // callback invocation in its own `catch_unwind`; a panic in
                 // the per-event machinery here is caught by the outer guard
-                // and recorded as `Failed`. There is no GIL to bracket, so
-                // the scope is the identity closure — the wait between
-                // batches happens outside it as usual.
-                // A panic escaping the event-iteration machinery (NOT a
-                // user-callback panic — those are caught per-invocation
-                // inside `poll_batch`) ends the thread. `stopStreaming`
-                // observes it through `JoinHandle::join()` returning
-                // `Err(_)` and records `DispatcherSession::Failed`, which
-                // folds `isStreaming()` / `isAuthenticated()` back to
-                // `false`; that state is the observable signal, so no
-                // logging dependency is pulled into this binding crate.
-                let _outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                // below. There is no GIL to bracket, so the scope is the
+                // identity closure — the wait between batches happens
+                // outside it as usual.
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     dispatcher_client.for_each_scoped(
                         |event: &fpss::StreamEvent| {
                             // Convert the borrowed event to the typed napi
@@ -511,6 +558,26 @@ impl StreamingClient {
                         |drain| drain(),
                     );
                 }));
+                // A panic escaping the event-iteration machinery (NOT a
+                // user-callback panic — those are caught per-invocation
+                // inside `poll_batch`) ends the thread. Record `Failed` from
+                // here so the state flips even if no teardown is ever called.
+                // Write it ONLY while the slot still holds THIS thread's
+                // `Running` session: a concurrent `stopStreaming` /
+                // `reconnect` may have already taken the session out (leaving
+                // `Idle`, then joining) or installed a fresh session, and the
+                // panic belongs to the now-superseded old one — overwriting
+                // unconditionally would clobber a newer session's `JoinHandle`
+                // or falsely report a healthy live session as failed. The
+                // teardown's own `JoinHandle::join()` path still records the
+                // panic for the raced case. The lock is released the instant
+                // the guard drops; no user code runs under it.
+                if let Err(payload) = outcome {
+                    record_own_dispatcher_panic(
+                        &dispatcher_session,
+                        panic_reason(payload.as_ref()),
+                    );
+                }
             });
         match dispatcher {
             Ok(h) => {
@@ -567,8 +634,9 @@ impl StreamingClient {
         // Seed the process-global runtime from this client's runtime config
         // so `workerThreads` is honored when this is the first client in
         // the process, even though the streaming connection is opened lazily by
-        // `startStreaming`.
-        crate::runtime_from_config(&direct.runtime);
+        // `startStreaming`. A runtime-build failure surfaces here as a typed
+        // error rather than being deferred to the first `startStreaming`.
+        crate::runtime_from_config(&direct.runtime)?;
         let params = params_from_direct(&creds.inner, &direct)?;
         Ok(StreamingClient::from_params(params))
     }
@@ -587,8 +655,9 @@ impl StreamingClient {
         // Seed the process-global runtime from this client's runtime config
         // so `workerThreads` is honored when this is the first client in
         // the process, even though the streaming connection is opened lazily by
-        // `startStreaming`.
-        crate::runtime_from_config(&direct.runtime);
+        // `startStreaming`. A runtime-build failure surfaces here as a typed
+        // error rather than being deferred to the first `startStreaming`.
+        crate::runtime_from_config(&direct.runtime)?;
         let params = params_from_direct(&creds, &direct)?;
         Ok(StreamingClient::from_params(params))
     }
@@ -896,15 +965,14 @@ impl StreamingClient {
                         // `isAuthenticated()` report the failed state if
                         // streaming is restarted without re-checking. The
                         // `Failed` state is the observable signal; no
-                        // logging dependency is pulled into this crate.
-                        let reason = if let Some(s) = payload.downcast_ref::<&str>() {
-                            (*s).to_owned()
-                        } else if let Some(s) = payload.downcast_ref::<String>() {
-                            s.clone()
-                        } else {
-                            "dispatcher panicked with non-string payload".to_owned()
+                        // logging dependency is pulled into this crate. The
+                        // dispatcher thread may already have recorded `Failed`
+                        // itself; re-stating it here is harmless (the slot is
+                        // `Idle` after the extract above, so this is the sole
+                        // writer for the teardown-observed-panic case).
+                        *self.lock_dispatcher() = DispatcherSession::Failed {
+                            reason: panic_reason(payload.as_ref()),
                         };
-                        *self.lock_dispatcher() = DispatcherSession::Failed { reason };
                     }
                 }
             }
@@ -965,7 +1033,7 @@ impl StreamingClient {
                 "streaming not started -- call startStreaming(callback) first",
             ));
         };
-        runtime()
+        runtime()?
             .spawn_blocking(move || inner.restore_subscriptions(&per_contract, &full_stream))
             .await
             .map_err(|e| napi::Error::from_reason(format!("reconnect task panicked: {e}")))?
@@ -977,7 +1045,12 @@ impl StreamingClient {
     /// all retired generations have drained, `false` on timeout. Polls at
     /// 1 ms cadence on a worker so the Node event loop stays free.
     #[napi(js_name = "awaitDrain")]
-    pub async fn await_drain(&self, timeout_ms: u32) -> napi::Result<bool> {
+    pub async fn await_drain(&self, timeout_ms: f64) -> napi::Result<bool> {
+        // `timeout_ms` arrives as `f64`: a bare `u32` napi arg is V8
+        // `ToUint32`, which wraps a hostile `-1` / `2**32` and truncates a
+        // fractional value. Validate at the boundary (`0` is a legal
+        // "poll once" timeout, so the plain validator).
+        let timeout_ms = crate::validate_u32_arg("timeoutMs", timeout_ms)?;
         let timeout = Duration::from_millis(u64::from(timeout_ms));
         // Snapshot the retired-generation flags; the poll loop is a cheap
         // sleep loop that owns its own `Arc`s, so it can run on a blocking
@@ -987,7 +1060,7 @@ impl StreamingClient {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
-        let drained = runtime()
+        let drained = runtime()?
             .spawn_blocking(move || {
                 let deadline = Instant::now() + timeout;
                 let mut pending = flags;
@@ -1025,7 +1098,7 @@ impl StreamingClient {
             inner: Mutex::new(None),
             callback: Mutex::new(None),
             prev_drained: Mutex::new(Vec::new()),
-            dispatcher: Mutex::new(DispatcherSession::Idle),
+            dispatcher: Arc::new(Mutex::new(DispatcherSession::Idle)),
         }
     }
 }
@@ -1121,6 +1194,74 @@ mod tests {
 
         // The snapshot must build without panicking with every knob set.
         let _ = params.builder();
+    }
+}
+
+#[cfg(test)]
+mod dispatcher_panic_recording_tests {
+    //! The dispatcher thread records `Failed` on a caught outer panic so
+    //! `isStreaming()` / `isAuthenticated()` fold to `false` the moment
+    //! delivery dies — even if no teardown is ever called. The write is
+    //! gated to the un-superseded session (the slot still holds THIS
+    //! thread's `Running` handle), so a raced teardown / reconnect is not
+    //! clobbered. These tests drive the real `record_own_dispatcher_panic`
+    //! decision with real spawned threads (no napi `Env` needed).
+    use super::*;
+
+    /// A dispatcher thread whose own handle is the slot's `Running` session
+    /// records `Failed`. `installed` gates the record until the main thread
+    /// has stored the dispatcher's handle (so `current().id()` matches the
+    /// stored handle); `recorded` gates the assertion until the write lands.
+    #[test]
+    fn records_failed_when_slot_holds_own_running_session() {
+        let session: Arc<Mutex<DispatcherSession>> = Arc::new(Mutex::new(DispatcherSession::Idle));
+        let installed = Arc::new(std::sync::Barrier::new(2));
+        let recorded = Arc::new(std::sync::Barrier::new(2));
+
+        let dispatcher = std::thread::Builder::new()
+            .name("test-dispatcher-self-record".into())
+            .spawn({
+                let session = Arc::clone(&session);
+                let installed = Arc::clone(&installed);
+                let recorded = Arc::clone(&recorded);
+                move || {
+                    installed.wait();
+                    record_own_dispatcher_panic(&session, "boom".to_owned());
+                    recorded.wait();
+                }
+            })
+            .expect("spawn dispatcher");
+        *session.lock().unwrap() = DispatcherSession::Running {
+            handle: dispatcher,
+            on_teardown: None,
+            registers_drain_flag: true,
+        };
+        installed.wait();
+        recorded.wait();
+
+        let reason = match &*session
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        {
+            DispatcherSession::Failed { reason } => reason.clone(),
+            _ => panic!("expected the dispatcher self-record to flip the slot to Failed"),
+        };
+        assert_eq!(reason, "boom");
+    }
+
+    /// When the slot has been superseded (a teardown left it `Idle`), the
+    /// dispatcher thread does NOT overwrite it — the teardown's own join
+    /// owns the panic for that race.
+    #[test]
+    fn does_not_overwrite_a_superseded_idle_slot() {
+        let session: Arc<Mutex<DispatcherSession>> = Arc::new(Mutex::new(DispatcherSession::Idle));
+        // No `Running` session is installed for this thread, so the slot is
+        // not "own running" and must stay untouched.
+        record_own_dispatcher_panic(&session, "boom".to_owned());
+        assert!(
+            matches!(&*session.lock().unwrap(), DispatcherSession::Idle),
+            "a superseded (Idle) slot must not be clobbered by the dispatcher self-record",
+        );
     }
 }
 

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate napi_derive;
 
+use std::io;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use napi::Either;
@@ -19,31 +20,46 @@ use thetadatadx::fpss;
 /// connected in the process seeds it from that client's `config.runtime`
 /// via [`runtime_from_config`], so `Config.workerThreads` takes effect for
 /// the first client created in the process.
-static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+///
+/// The build is fallible — `build_runtime` returns an `io::Result` (it can
+/// fail when the OS refuses the worker threads or event loop). The result
+/// is memoised verbatim so a build failure surfaces as a typed error to
+/// the connect caller instead of aborting the process, and so a later
+/// connect re-observes the same outcome rather than racing a second build.
+static RT: OnceLock<io::Result<tokio::runtime::Runtime>> = OnceLock::new();
+
+/// Map a memoised runtime-build outcome to a borrowed runtime or a napi
+/// error. The stored `io::Error` is not `Clone`, so its message is copied
+/// into a fresh napi error on each failing call.
+fn runtime_result(
+    result: &'static io::Result<tokio::runtime::Runtime>,
+) -> napi::Result<&'static tokio::runtime::Runtime> {
+    result
+        .as_ref()
+        .map_err(|e| napi::Error::from_reason(format!("failed to create tokio runtime: {e}")))
+}
 
 /// Build (or return the already-built) process-global runtime, sizing the
 /// worker pool from the first client's [`thetadatadx::RuntimeConfig`].
 ///
 /// The first connect in the process seeds the pool from its
 /// `config.runtime`; later connects share the already-built runtime, so
-/// their `runtime` config is a no-op by design.
+/// their `runtime` config is a no-op by design. A build failure is
+/// returned as a napi error, never a panic.
 pub(crate) fn runtime_from_config(
     cfg: &thetadatadx::RuntimeConfig,
-) -> &'static tokio::runtime::Runtime {
-    RT.get_or_init(|| cfg.build_runtime().expect("failed to create tokio runtime"))
+) -> napi::Result<&'static tokio::runtime::Runtime> {
+    runtime_result(RT.get_or_init(|| cfg.build_runtime()))
 }
 
 /// Return the process-global runtime, building it with tokio default
 /// sizing if no client has seeded it from config yet.
 ///
 /// Connect functions seed the pool via [`runtime_from_config`]; every
-/// post-connect call resolves the already-built runtime here.
-pub(crate) fn runtime() -> &'static tokio::runtime::Runtime {
-    RT.get_or_init(|| {
-        thetadatadx::RuntimeConfig::default()
-            .build_runtime()
-            .expect("failed to create tokio runtime")
-    })
+/// post-connect call resolves the already-built runtime here. A build
+/// failure is returned as a napi error, never a panic.
+pub(crate) fn runtime() -> napi::Result<&'static tokio::runtime::Runtime> {
+    runtime_result(RT.get_or_init(|| thetadatadx::RuntimeConfig::default().build_runtime()))
 }
 
 /// Convert a `thetadatadx::Error` into a napi error whose `reason`
@@ -238,7 +254,7 @@ pub(crate) async fn connect_historical_from_file_core(
     cfg: config::DirectConfig,
 ) -> napi::Result<Arc<thetadatadx::Client>> {
     let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-    let rt = runtime_from_config(&cfg.runtime);
+    let rt = runtime_from_config(&cfg.runtime)?;
     let client = rt
         .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })
         .await
@@ -457,6 +473,44 @@ fn validate_nonneg_whole(
     Ok(value)
 }
 
+/// Validate a JS `number` carrying a `u32` domain knob (worker-thread
+/// count, CPU index, attempt budget, …) and narrow it to `u32`.
+///
+/// napi's bare `u32` argument binding is V8 `ToUint32`, which never
+/// rejects: `-1` wraps to `u32::MAX`, `1.5` truncates to `1`, `2**32`
+/// wraps to `0`. Every such rewrite is the opposite of the caller's
+/// intent and the integer-typed bindings (Python / C++ / C ABI) cannot
+/// express the value at all, so we take the argument as `f64` and reject
+/// a non-finite, negative, fractional, or over-`u32` value as
+/// `InvalidParameterError` — the typed class the Python binding raises
+/// (`ValueError`) for the identical input. `name` is the camelCase key.
+pub(crate) fn validate_u32_arg(name: &str, v: f64) -> napi::Result<u32> {
+    Ok(validate_nonneg_whole(name, v, u32::MAX as f64, None)? as u32)
+}
+
+/// Validate a `u32` domain knob that additionally requires `>= 1` (a
+/// burst size or attempt budget where `0` is a degenerate value the core
+/// rejects at connect). Layered on [`validate_u32_arg`] so the
+/// finite/whole/range checks stay in one place; only the extra `0` floor
+/// lives here.
+pub(crate) fn validate_u32_arg_min1(name: &str, v: f64) -> napi::Result<u32> {
+    let value = validate_u32_arg(name, v)?;
+    if value == 0 {
+        return Err(invalid_parameter_err(format!(
+            "{name} must be at least 1; got 0"
+        )));
+    }
+    Ok(value)
+}
+
+/// Validate an optional `u32` domain knob, leaving an omitted value
+/// (`None`) untouched. The pinned-CPU / worker-thread setters take this
+/// shape: `null` defers to the OS / default sizing, a number pins the
+/// value (with `0` a valid choice — verbatim worker/core count).
+pub(crate) fn validate_optional_u32_arg(name: &str, v: Option<f64>) -> napi::Result<Option<u32>> {
+    v.map(|v| validate_u32_arg(name, v)).transpose()
+}
+
 /// Validate a JavaScript `timeoutMs` deadline and convert it to the
 /// integer millisecond domain the Python, C++, and C ABI bindings take.
 pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
@@ -504,7 +558,7 @@ where
     F: std::future::Future<Output = Result<T, thetadatadx::Error>> + Send + 'static,
     T: Send + 'static,
 {
-    match runtime().spawn(fut).await {
+    match runtime()?.spawn(fut).await {
         Ok(inner) => inner.map_err(to_napi_err),
         Err(join_err) => Err(napi::Error::from_reason(format!(
             "endpoint task failed to complete: {join_err}"
@@ -847,7 +901,7 @@ impl Client {
         // spawning onto it, then run the connect handshake off the libuv
         // thread. The credentials are cloned so the spawned future owns
         // `'static` data and does not borrow the napi argument.
-        let rt = runtime_from_config(&cfg.runtime);
+        let rt = runtime_from_config(&cfg.runtime)?;
         let creds = creds.inner.clone();
         let client = rt
             .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })
@@ -901,7 +955,7 @@ impl Client {
     #[napi(js_name = "connectWith")]
     pub async fn connect_with(options: ClientConnectOptions) -> napi::Result<Client> {
         let (creds, cfg) = options.resolve()?;
-        let rt = runtime_from_config(&cfg.runtime);
+        let rt = runtime_from_config(&cfg.runtime)?;
         let client = rt
             .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })
             .await
@@ -1143,7 +1197,7 @@ impl HistoricalClient {
         config: Option<&Config>,
     ) -> napi::Result<HistoricalClient> {
         let cfg = config_or_production(config);
-        let rt = runtime_from_config(&cfg.runtime);
+        let rt = runtime_from_config(&cfg.runtime)?;
         let creds = creds.inner.clone();
         let client = rt
             .spawn(async move { thetadatadx::Client::connect(&creds, cfg).await })


### PR DESCRIPTION
Fixes four verified findings in the TypeScript binding.

## JS-boundary numeric validation

A bare napi `u32` argument is V8 `ToUint32`: it never rejects, it rewrites. `-1` wraps to `u32::MAX`, `1.5` truncates to `1`, `2**32` wraps to `0` — every rewrite the opposite of the caller's intent, and a value the integer-typed bindings (Python / C++ / C ABI) cannot express at all. Three layers now take the argument as a JS `number` and route it through a shared `validate_u32_arg` helper that rejects a non-finite, negative, fractional, or over-`u32` value as `InvalidParameterError` (the same class Python's `ValueError` maps to for the identical input): the config-accessor codegen template (the seven generated setters, regenerated), the hand-written `Config` setters (`setWorkerThreads`, `setWaitSpinIters`, `setWaitYieldIters`, `setConsumerCpu`), and both `awaitDrain` timeouts (the streaming codegen template and the standalone client). The burst-size and attempt-budget knobs additionally reject `0` (`validate_u32_arg_min1`), matching their documented `>= 1` connect-time validation; `0` stays valid where it is a verbatim choice (`consumerCpu`, `workerThreads`, iteration counts, the poll-once `awaitDrain`). The published `index.d.ts` is unchanged — napi maps both `u32` and `f64` to `number`, so the caller-facing surface and cross-binding parity are preserved.

## Fallible runtime

`build_runtime` returns an `io::Result` — it can fail when the OS refuses the worker pool — but the `OnceLock` seeded it with `.expect(...)`, aborting the process on a recoverable error. The `OnceLock` now memoises the `io::Result` and maps a build failure to a typed napi error returned from the connect call sites, never a panic.

## Dispatcher panic to failed state

The standalone streaming dispatcher's outer `catch_unwind` discarded its outcome, so an outer (non-callback) panic exited the thread cleanly and `DispatcherSession::Failed` was set only later, by a teardown's `JoinHandle::join()`. With no teardown, `isStreaming()` / `isAuthenticated()` kept reporting healthy after event delivery had died. The dispatcher thread now records `Failed` itself on a caught outer panic, gated to the un-superseded session (the slot still holds this thread's `Running` handle) so a raced teardown or reconnect is not clobbered. The separate per-callback panic isolation that increments `panicCount()` is unchanged.

## Examples

`connectFromFile` is `Promise`-returning; three examples missed the `await` (the flatfiles one is now wrapped in `async main()`).

## Gates

`cargo check` / `clippy --all-targets -D warnings` / `fmt --check` (TypeScript crate and the core crate carrying the codegen template) green; `npm run build` (regenerates the bindings) and `npm test` (279 passing, including the new validation matrix) green; the surface-generator `--check` confirms the regenerated `config_accessors.rs` and `streaming_methods.rs` match the template, and `check_binding_parity.py` is clean. No new `#[allow]`. No dependency-graph change, so no lockfile sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)