### PR TITLE
fix(streaming): publish dispatcher Failed state on outer panic so health checks reflect a dead loop

### DIFF
--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -199,7 +199,13 @@ pub struct ThetaDataDxStreamHandle {
     /// `reconnect` / `shutdown` / `free` path acquires this one lock,
     /// transitions the variant, and releases.  Dispatcher panic state
     /// is derived from `JoinHandle::join()` returning `Err(_)`.
-    dispatcher: Mutex<FfpssDispatcherSession>,
+    ///
+    /// Wrapped in `Arc` so the spawned dispatcher thread can hold an
+    /// owning handle to just this slot (not the whole `*const` handle,
+    /// whose lifetime it cannot express) and publish `Failed` from its own
+    /// catch-arm the instant an outer panic kills the event loop — see
+    /// [`publish_failed_if_current`].
+    dispatcher: Arc<Mutex<FfpssDispatcherSession>>,
 }
 
 /// Saved FPSS connection parameters for FFI-safe (re)connection.
@@ -1599,7 +1605,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_connect(
             callback: Mutex::new(None),
             state: AtomicU8::new(STREAM_STATE_FRESH),
             prev_drained: Mutex::new(Vec::new()),
-            dispatcher: Mutex::new(FfpssDispatcherSession::Idle),
+            dispatcher: Arc::new(Mutex::new(FfpssDispatcherSession::Idle)),
         }))
     })
 }
@@ -1738,6 +1744,7 @@ where
                 .store(STREAM_STATE_ACTIVE, AtomicOrdering::Relaxed);
 
             let dispatcher_client = std::sync::Arc::clone(&client_arc);
+            let dispatcher_slot = std::sync::Arc::clone(&handle.dispatcher);
             let spawn_result = std::thread::Builder::new()
                 .name("thetadatadx-ffi-fpss-dispatcher".into())
                 .spawn(move || {
@@ -1750,10 +1757,20 @@ where
                     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         dispatcher_client.for_each(|event| on_event(event));
                     }));
-                    if outcome.is_err() {
+                    if let Err(payload) = outcome {
+                        let reason = downcast_ffi_panic_payload(payload);
                         tracing::error!(
                             target: "thetadatadx::ffi",
+                            reason = %reason,
                             "thetadatadx-ffi-fpss-dispatcher panicked in event iteration machinery; handle transitioning to failed state",
+                        );
+                        // Publish `Failed` from this thread before it exits so
+                        // health checks reflect the dead loop immediately, not
+                        // only once teardown joins.
+                        publish_failed_if_current(
+                            &dispatcher_slot,
+                            std::thread::current().id(),
+                            reason,
                         );
                     }
                 });
@@ -2312,6 +2329,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
             *guard = Some(std::sync::Arc::clone(&new_client));
 
             let dispatcher_client = std::sync::Arc::clone(&new_client);
+            let dispatcher_slot = std::sync::Arc::clone(&handle.dispatcher);
             let spawn_result = std::thread::Builder::new()
                 .name("thetadatadx-ffi-fpss-dispatcher".into())
                 .spawn(move || {
@@ -2324,10 +2342,20 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
                     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         dispatcher_client.for_each(|event| cb.invoke(event));
                     }));
-                    if outcome.is_err() {
+                    if let Err(payload) = outcome {
+                        let reason = downcast_ffi_panic_payload(payload);
                         tracing::error!(
                             target: "thetadatadx::ffi",
+                            reason = %reason,
                             "thetadatadx-ffi-fpss-dispatcher panicked in event iteration machinery across reconnect; handle transitioning to failed state",
+                        );
+                        // Publish `Failed` from this thread before it exits so
+                        // health checks reflect the dead loop immediately, not
+                        // only once teardown joins.
+                        publish_failed_if_current(
+                            &dispatcher_slot,
+                            std::thread::current().id(),
+                            reason,
                         );
                     }
                 });
@@ -2512,6 +2540,40 @@ fn downcast_ffi_panic_payload(payload: Box<dyn std::any::Any + Send>) -> String 
         return s.clone();
     }
     "dispatcher panicked with non-string payload".to_owned()
+}
+
+/// Publish `Failed` from the dispatcher thread's OWN catch-arm after an outer
+/// panic in the event-iteration machinery, so `thetadatadx_streaming_is_streaming`
+/// / `_is_authenticated` report the dead loop immediately rather than only
+/// after teardown joins the corpse.
+///
+/// `dispatcher_thread_id` is the id of the thread the session's `JoinHandle`
+/// names; the caller passes its own [`std::thread::current`] id. The store
+/// happens ONLY when the slot still holds the matching `Running` session: the
+/// lock is dropped between spawning the dispatcher and a later
+/// `set_callback` / `reconnect`, so a fresh session (different thread id) or a
+/// teardown-extracted `Idle` may already occupy the slot. Overwriting either
+/// would clobber a live session's `JoinHandle` or resurrect a torn-down one.
+///
+/// Orthogonal to teardown: this is a mutate-UNDER-lock-then-RELEASE with no
+/// join and no drain wait held across the guard, exactly like the publish in
+/// [`join_extracted_session`]. The lock order is unchanged (this takes only
+/// `dispatcher`, never `inner`). When this wins the race against a concurrent
+/// teardown, the teardown's `extract` then yields the `Failed` variant — whose
+/// `let-else` skips the join — so the already-finished panicked thread is
+/// detached rather than reaped; the `_free` drain barrier still waits on the
+/// client's own drained flag, so quiescence is unaffected.
+fn publish_failed_if_current(
+    dispatcher: &Mutex<FfpssDispatcherSession>,
+    dispatcher_thread_id: std::thread::ThreadId,
+    reason: String,
+) {
+    let mut guard = dispatcher.lock_recover();
+    if let FfpssDispatcherSession::Running { handle, .. } = &*guard {
+        if handle.thread().id() == dispatcher_thread_id {
+            *guard = FfpssDispatcherSession::Failed { reason };
+        }
+    }
 }
 
 /// Milliseconds since the most recent inbound streaming frame of any
@@ -3306,7 +3368,7 @@ mod teardown_deadlock_tests {
             })),
             state: AtomicU8::new(STREAM_STATE_ACTIVE),
             prev_drained: Mutex::new(Vec::new()),
-            dispatcher: Mutex::new(session),
+            dispatcher: Arc::new(Mutex::new(session)),
         }
     }
 
@@ -3407,5 +3469,163 @@ mod teardown_deadlock_tests {
             "the re-entrant status read acquired the dispatcher lock before teardown \
              released it — the join was not lock-free",
         );
+    }
+}
+
+#[cfg(test)]
+mod health_on_outer_panic_tests {
+    //! An OUTER dispatcher panic (the event-iteration machinery, not a user
+    //! callback) must flip `thetadatadx_streaming_is_streaming` /
+    //! `_is_authenticated` to `0` IMMEDIATELY — from the dispatcher thread's
+    //! own catch-arm — rather than staying healthy until teardown joins the
+    //! dead thread. This pins [`super::publish_failed_if_current`], the catch-arm
+    //! publish both `set_callback` and `reconnect` spawns route through.
+
+    use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use super::{
+        publish_failed_if_current, FfiCallback, FfpssDispatcherSession, LockRecover,
+        StreamingConnectParams, ThetaDataDxStreamCallback, ThetaDataDxStreamEvent,
+        ThetaDataDxStreamHandle, STREAM_STATE_ACTIVE,
+    };
+    use std::ffi::c_void;
+    use thetadatadx::fpss::{HarnessPublishMode, StreamingClient};
+
+    extern "C" fn noop(_event: *const ThetaDataDxStreamEvent, _ctx: *mut c_void) {}
+
+    /// Build a handle whose `inner` holds a live harness `StreamingClient`
+    /// (`for_self_join_test` flips its `authenticated` flag `true`), so absent
+    /// a `Failed` dispatcher both status readers report healthy. The returned
+    /// `(handle, drained)` lets the caller shut the harness client down so its
+    /// consumer thread cannot outlive the test.
+    fn handle_with_live_client(
+        session: FfpssDispatcherSession,
+    ) -> (ThetaDataDxStreamHandle, Arc<AtomicBool>) {
+        // One idle harness event through a noop handler; the consumer parks on
+        // the ring afterwards and exits on the shutdown the test signals.
+        let client = StreamingClient::for_self_join_test(
+            1,
+            64,
+            HarnessPublishMode::BlockingPublish,
+            None,
+            |_event| {},
+        );
+        let drained = client.drained_flag();
+        let handle = ThetaDataDxStreamHandle {
+            inner: Arc::new(Mutex::new(Some(client))),
+            connect_params: StreamingConnectParams {
+                creds: thetadatadx::Credentials::api_key("test"),
+                streaming: thetadatadx::config::StreamingConfig::production_defaults(),
+                reconnect: thetadatadx::config::ReconnectConfig::production_defaults(),
+            },
+            callback: Mutex::new(Some(FfiCallback {
+                callback: noop as ThetaDataDxStreamCallback,
+                ctx: std::ptr::null_mut(),
+            })),
+            state: AtomicU8::new(STREAM_STATE_ACTIVE),
+            prev_drained: Mutex::new(Vec::new()),
+            dispatcher: Arc::new(Mutex::new(session)),
+        };
+        (handle, drained)
+    }
+
+    #[test]
+    fn outer_panic_flips_health_checks_to_failed_immediately() {
+        // A stand-in for the dispatcher thread whose `JoinHandle` the
+        // `Running` session carries. It parks until released, so the handle
+        // stays joinable while the test drives the catch-arm publish — the
+        // production catch-arm runs ON this thread, so the test passes this
+        // thread's id to `publish_failed_if_current`.
+        let release = Arc::new(AtomicBool::new(false));
+        let dispatcher_handle = {
+            let release = Arc::clone(&release);
+            std::thread::Builder::new()
+                .name("test-parked-dispatcher".into())
+                .spawn(move || {
+                    while !release.load(Ordering::Acquire) {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                })
+                .expect("spawn parked dispatcher")
+        };
+        let dispatcher_thread_id = dispatcher_handle.thread().id();
+
+        let (handle, drained) = handle_with_live_client(FfpssDispatcherSession::Running {
+            handle: dispatcher_handle,
+            on_teardown: None,
+            registers_drain_flag: true,
+        });
+
+        // The two C-ABI status readers, each wrapped once.
+        // SAFETY: `&handle` points at a live `ThetaDataDxStreamHandle` pinned on
+        // this stack for the whole test, never freed, so the is_streaming entry
+        // point's non-null / not-yet-freed precondition holds on every call.
+        let is_streaming = || unsafe { super::thetadatadx_streaming_is_streaming(&handle) };
+        // SAFETY: same stack-pinned, never-freed `&handle` as the reader above;
+        // the is_authenticated entry point shares the identical precondition.
+        let is_authenticated = || unsafe { super::thetadatadx_streaming_is_authenticated(&handle) };
+
+        // Healthy before the panic: live authenticated client, no `Failed`.
+        assert_eq!(
+            is_streaming(),
+            1,
+            "a live session with a Running dispatcher must report streaming",
+        );
+        assert_eq!(
+            is_authenticated(),
+            1,
+            "a live authenticated session must report authenticated before any panic",
+        );
+
+        // A non-matching thread id must NOT publish (models a fresh session
+        // installed by a concurrent reconnect in the lock-release window).
+        publish_failed_if_current(
+            &handle.dispatcher,
+            std::thread::current().id(),
+            "wrong-thread panic must not clobber".to_owned(),
+        );
+        assert_eq!(
+            is_streaming(),
+            1,
+            "publish_failed_if_current must not overwrite a session owned by a different thread",
+        );
+
+        // The dispatcher thread's own catch-arm publishes `Failed`.
+        publish_failed_if_current(
+            &handle.dispatcher,
+            dispatcher_thread_id,
+            "intentional outer-machinery panic".to_owned(),
+        );
+
+        // Both status readers now report the dead loop, with no teardown join.
+        assert_eq!(
+            is_streaming(),
+            0,
+            "is_streaming must return 0 immediately after an outer dispatcher panic",
+        );
+        assert_eq!(
+            is_authenticated(),
+            0,
+            "is_authenticated must return 0 immediately after an outer dispatcher panic",
+        );
+
+        // Release the parked stand-in (it self-terminates on the flag; the
+        // publish already detached its `JoinHandle` into the `Failed` variant),
+        // then shut the harness client down and wait for its consumer thread to
+        // drain so nothing outlives the test.
+        release.store(true, Ordering::Release);
+        if let Some(client) = handle.inner.lock_recover().take() {
+            client.shutdown();
+            drop(client);
+        }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !drained.load(Ordering::Acquire) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "harness client did not drain within 5 s",
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
     }
 }

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -93,6 +93,13 @@ tracing-subscriber = { version = "0.3.20", default-features = false, features = 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Re-declare the engine dep with `__test-helpers` so Rust unit tests can reach
+# the in-process FPSS harness (`StreamingClient::for_self_join_test`,
+# `HarnessPublishMode`) — gated out of the non-test build. Mirrors
+# `ffi/Cargo.toml`. Same `arrow` / `__internal` feature set as the runtime dep.
+[dev-dependencies]
+thetadatadx = { path = "../../crates/thetadatadx", features = ["arrow", "__internal", "__test-helpers"] }
+
 # Match the main workspace's strict bar. This crate is `[workspace.exclude]`d
 # in the root `Cargo.toml` (it has its own toolchain / feature footprint), so
 # it can't inherit via `[lints] workspace = true` — mirror the rules locally.

--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -171,7 +171,13 @@ pub(crate) struct StreamingClient {
     /// `dispatcher_handle: Mutex<Option<JoinHandle<()>>>` and
     /// `dispatcher_failed: Arc<AtomicBool>`. Panic state is derived
     /// from `JoinHandle::join()` returning `Err(_)`.
-    dispatcher: Mutex<thetadatadx::DispatcherSession>,
+    ///
+    /// Wrapped in `Arc` so the spawned dispatcher thread can hold an owning
+    /// handle to just this slot — the pyclass shell is not itself `Arc`-shared
+    /// across the spawn — and publish `Failed` from its own catch-arm the
+    /// instant an outer panic kills the event loop (see
+    /// [`publish_failed_if_current`]).
+    dispatcher: Arc<Mutex<thetadatadx::DispatcherSession>>,
 }
 
 impl Drop for StreamingClient {
@@ -253,6 +259,44 @@ impl StreamingClient {
     }
 }
 
+/// Downcast a thread-panic payload to a human-readable string.
+fn downcast_py_panic_payload(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        return (*s).to_owned();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "dispatcher panicked with non-string payload".to_owned()
+}
+
+/// Publish `Failed` from the dispatcher thread's OWN catch-arm after an outer
+/// panic in the event-iteration machinery, so `is_streaming` / `is_authenticated`
+/// report the dead loop immediately rather than only after teardown joins the
+/// corpse.
+///
+/// `dispatcher_thread_id` is the id of the thread the session's `JoinHandle`
+/// names; the caller passes its own [`std::thread::current`] id. The store
+/// happens ONLY when the slot still holds the matching `Running` session: a
+/// concurrent `stop_streaming` may have extracted it to `Idle`, or a fresh
+/// session (different thread id) may occupy it. Overwriting either would
+/// resurrect a torn-down session or clobber a live one's `JoinHandle`.
+///
+/// Orthogonal to teardown: a mutate-UNDER-lock-then-RELEASE with no join held
+/// across the guard, matching the publish in `stop_streaming`'s join path.
+fn publish_failed_if_current(
+    dispatcher: &Mutex<thetadatadx::DispatcherSession>,
+    dispatcher_thread_id: std::thread::ThreadId,
+    reason: String,
+) {
+    let mut guard = dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+    if let PyFpssDispatcherSession::Running { handle, .. } = &*guard {
+        if handle.thread().id() == dispatcher_thread_id {
+            *guard = PyFpssDispatcherSession::Failed { reason };
+        }
+    }
+}
+
 #[pymethods]
 impl StreamingClient {
     /// Allocate a standalone streaming handle.
@@ -288,7 +332,7 @@ impl StreamingClient {
             inner: Mutex::new(None),
             callback: Mutex::new(None),
             prev_drained: Mutex::new(Vec::new()),
-            dispatcher: Mutex::new(PyFpssDispatcherSession::Idle),
+            dispatcher: Arc::new(Mutex::new(PyFpssDispatcherSession::Idle)),
         })
     }
 
@@ -389,6 +433,7 @@ impl StreamingClient {
         // binding must increment the counter explicitly so `panic_count()`
         // reflects both Rust panics and Python exceptions.
         let panic_recorder = Arc::clone(&client_arc);
+        let dispatcher_slot = Arc::clone(&self.dispatcher);
         let dispatcher = std::thread::Builder::new()
             .name("thetadatadx-py-fpss-dispatcher".into())
             .spawn(move || {
@@ -440,10 +485,20 @@ impl StreamingClient {
                     dispatcher_client
                         .for_each_scoped(dispatch_one, |drain| Python::attach(|_py| drain()));
                 }));
-                if outcome.is_err() {
+                if let Err(payload) = outcome {
+                    let reason = downcast_py_panic_payload(payload);
                     tracing::error!(
                         target: "thetadatadx::python",
+                        reason = %reason,
                         "thetadatadx-py-fpss-dispatcher panicked in event iteration machinery; StreamingClient transitioning to failed state",
+                    );
+                    // Publish `Failed` from this thread before it exits so
+                    // health checks reflect the dead loop immediately, not only
+                    // once teardown joins.
+                    publish_failed_if_current(
+                        &dispatcher_slot,
+                        std::thread::current().id(),
+                        reason,
                     );
                 }
             });
@@ -758,13 +813,7 @@ impl StreamingClient {
                 if let PyFpssDispatcherSession::Running { handle, .. } = prev_session {
                     if handle.thread().id() != std::thread::current().id() {
                         if let Err(payload) = handle.join() {
-                            let reason = if let Some(s) = payload.downcast_ref::<&str>() {
-                                (*s).to_owned()
-                            } else if let Some(s) = payload.downcast_ref::<String>() {
-                                s.clone()
-                            } else {
-                                "dispatcher panicked with non-string payload".to_owned()
-                            };
+                            let reason = downcast_py_panic_payload(payload);
                             tracing::error!(
                                 target: "thetadatadx::python",
                                 reason = %reason,
@@ -1000,5 +1049,116 @@ mod tests {
 
         // The snapshot must build without panicking with every knob set.
         let _ = params.builder();
+    }
+
+    /// An OUTER dispatcher panic (the event-iteration machinery, not a user
+    /// callback) must flip `is_streaming()` / `is_authenticated()` to `false`
+    /// IMMEDIATELY — from the dispatcher thread's own catch-arm — rather than
+    /// staying healthy until teardown joins the dead thread. Pins
+    /// [`super::publish_failed_if_current`], the catch-arm publish
+    /// `start_streaming` routes through.
+    #[test]
+    fn outer_panic_flips_health_checks_to_failed_immediately() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use thetadatadx::fpss::HarnessPublishMode;
+
+        // A live harness client: `for_self_join_test` flips its `authenticated`
+        // flag `true`, so absent a `Failed` dispatcher both readers report
+        // healthy.
+        let client = RustStreamingClient::for_self_join_test(
+            1,
+            64,
+            HarnessPublishMode::BlockingPublish,
+            None,
+            |_event| {},
+        );
+        let drained = client.drained_flag();
+
+        // A stand-in for the dispatcher thread whose `JoinHandle` the `Running`
+        // session carries; it parks until released so the handle stays joinable
+        // while the test drives the catch-arm publish.
+        let release = Arc::new(AtomicBool::new(false));
+        let dispatcher_handle = {
+            let release = Arc::clone(&release);
+            std::thread::Builder::new()
+                .name("test-parked-dispatcher".into())
+                .spawn(move || {
+                    while !release.load(Ordering::Acquire) {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                })
+                .expect("spawn parked dispatcher")
+        };
+        let dispatcher_thread_id = dispatcher_handle.thread().id();
+
+        let creds = RustCredentials::new("user@example.com", "secret");
+        let config = DirectConfig::production();
+        let sc = StreamingClient {
+            params: FpssParams::from_config(&creds, &config),
+            inner: Mutex::new(Some(client)),
+            callback: Mutex::new(None),
+            prev_drained: Mutex::new(Vec::new()),
+            dispatcher: Arc::new(Mutex::new(PyFpssDispatcherSession::Running {
+                handle: dispatcher_handle,
+                on_teardown: None,
+                registers_drain_flag: true,
+            })),
+        };
+
+        // Healthy before the panic.
+        assert!(
+            sc.is_streaming(),
+            "a live Running session must report streaming"
+        );
+        assert!(
+            sc.is_authenticated(),
+            "a live authenticated session must report authenticated before any panic"
+        );
+
+        // A non-matching thread id must NOT publish (models a fresh session
+        // installed by a concurrent restart in the lock-release window).
+        publish_failed_if_current(
+            &sc.dispatcher,
+            std::thread::current().id(),
+            "wrong-thread panic must not clobber".to_owned(),
+        );
+        assert!(
+            sc.is_streaming(),
+            "publish_failed_if_current must not overwrite a session owned by a different thread"
+        );
+
+        // The dispatcher thread's own catch-arm publishes `Failed`.
+        publish_failed_if_current(
+            &sc.dispatcher,
+            dispatcher_thread_id,
+            "intentional outer-machinery panic".to_owned(),
+        );
+
+        // Both status readers now report the dead loop, with no teardown join.
+        assert!(
+            !sc.is_streaming(),
+            "is_streaming must return false immediately after an outer dispatcher panic"
+        );
+        assert!(
+            !sc.is_authenticated(),
+            "is_authenticated must return false immediately after an outer dispatcher panic"
+        );
+
+        // Release the parked stand-in (its handle was detached into `Failed`),
+        // shut the harness client down, and wait for its consumer to drain so
+        // nothing outlives the test.
+        release.store(true, Ordering::Release);
+        if let Some(client) = sc.inner.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            client.shutdown();
+            drop(client);
+        }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !drained.load(Ordering::Acquire) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "harness client did not drain within 5 s"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
     }
 }


### PR DESCRIPTION
## Problem

The standalone FPSS dispatcher (FFI `thetadatadx_streaming_*` and the Python `StreamingClient`) drives its event loop inside `std::panic::catch_unwind`. On an *outer* panic — one in the event-iteration machinery itself, not a user callback — the catch arm only emitted a `tracing::error!` and left the dispatcher session in the `Running` state. The health readers (`thetadatadx_streaming_is_streaming` / `_is_authenticated` in the FFI, `is_streaming()` / `is_authenticated()` in Python) therefore kept reporting a healthy session even though event delivery was dead, right up until the application tore the handle down and the teardown join observed the panic. A caller polling health after the loop died got a misleading signal.

## Fix

On a caught outer panic the dispatcher now publishes the `Failed` state from its own thread, before it exits, so the health readers reflect the dead loop immediately rather than only after teardown joins. The publish is a guarded mutate-under-lock-then-release: it takes the dispatcher lock, and overwrites the session with `Failed` only when the slot still holds *its own* still-installed `Running` session (matched by thread id). That guard keeps a concurrently-installed fresh session (a different thread, from `set_callback` / `reconnect`) and a teardown-extracted `Idle` slot from being clobbered, mirroring the existing publish-`Failed`-if-`Idle` discipline in the teardown join path.

The two readers already folded a `Failed` dispatcher back to a not-streaming / not-authenticated answer; this change is what finally makes that state observable at the moment of death.

## Why it does not regress teardown hardening

The change is orthogonal to the teardown join path:

- The catch-arm publish holds the dispatcher lock only for the state swap and releases it before the thread exits. It never holds the lock across a join or a drain wait.
- Lock order is unchanged: the catch arm takes only the dispatcher lock, never `inner`.
- The separate per-callback panic isolation (the inner `catch_unwind` that counts panics and keeps draining) is untouched.
- The dispatcher session is moved behind an `Arc` so the dispatcher thread can hold an owning handle to just that slot — the same shared-ownership shape the `inner` client slot already uses — rather than borrowing the whole handle across the thread boundary.

When the catch arm wins a race against a concurrent teardown, the teardown's extract then yields the `Failed` variant whose `let`-else skips the join, so the already-finished panicked thread is detached rather than reaped; the `_free` drain barrier still waits on the client's own drained flag, so quiescence is unaffected.

## Tests

- New FFI `health_on_outer_panic_tests`: a live (authenticated) harness-backed handle with a `Running` session reports streaming/authenticated, then the catch-arm publish flips both C-ABI readers to `0` with no teardown join; a non-matching thread id is proven not to clobber.
- New Python `outer_panic_flips_health_checks_to_failed_immediately`: same shape against `is_streaming()` / `is_authenticated()`.
- The teardown-deadlock watchdog (`teardown_does_not_deadlock_when_callback_re_enters_the_dispatcher_lock`) and the per-callback panic-count test (`fpss_client_panic_count_incremented_by_catch_unwind`) still pass unchanged.

## Gates

`cargo check` (FFI + workspace feature sets + Python), `clippy --workspace --all-targets --locked -D warnings` + Python clippy, `cargo fmt --check` (workspace + Python), `cargo doc --no-deps` (workspace + Python), FFI `--lib` tests (92 pass), Python Rust tests (55 pass) and the full `pytest` suite (437 pass / 28 skipped), plus the binding-parity, safety-comment-boilerplate, client-facing-vocab, no-re-framing, public-surface-leak, and lockfile-drift gates — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
