### PR TITLE
fix(typescript): reject lossy bigint in arrow reconstruct + await promise APIs in examples/docs

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/docs_render/streaming.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/docs_render/streaming.rs
@@ -400,7 +400,7 @@ fn typescript_tab(spec: &StreamSpec) -> String {
         other => panic!("no TypeScript callback template for event {other}"),
     };
     format!(
-        "```typescript\n{import}\n\nclient.stream.startStreaming((event) => {{\n  if (event.kind === '{kind}') {{\n    const e = event.{payload}!;\n    {print}\n  }}\n}});\n\nconst sub = {};\nclient.stream.subscribe(sub);\n\n// Remove this stream; the session stays open for other subscriptions.\nclient.stream.unsubscribe(sub);\n```\n",
+        "```typescript\n{import}\n\nawait client.stream.startStreaming((event) => {{\n  if (event.kind === '{kind}') {{\n    const e = event.{payload}!;\n    {print}\n  }}\n}});\n\nconst sub = {};\nclient.stream.subscribe(sub);\n\n// Remove this stream; the session stays open for other subscriptions.\nclient.stream.unsubscribe(sub);\n```\n",
         spec.ts_sub
     )
 }

--- a/crates/thetadatadx/build_support_bin/ticks/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/typescript.rs
@@ -22,6 +22,27 @@ use super::schema::{render_for_type, Schema, TickTypeDef};
 use super::sorted_type_names;
 use super::tdbe_structs::timestamp_accessor_fields;
 
+/// Emitted `BigInt -> i64` decoder for the Arrow-IPC reconstruct path. The
+/// sibling of `config_class::bigint_to_u64`: `get_i64`'s `lossless` flag is
+/// `false` when the JS `bigint` magnitude does not fit `i64`, so this rejects
+/// such a value (with the column name in the diagnostic) instead of letting
+/// the wrapped low bits truncate silently into the destination. The
+/// `[InvalidParameterError]` prefix routes it to the typed JS subclass.
+const BIGINT_TO_I64_HELPER: &str = "\
+/// Decode an `i64` from a JS `bigint` Arrow column, rejecting a magnitude that
+/// does not fit `i64` rather than truncating its wrapped low bits.
+fn bigint_to_i64(name: &str, v: &BigInt) -> napi::Result<i64> {
+    let (value, lossless) = v.get_i64();
+    if lossless {
+        Ok(value)
+    } else {
+        Err(crate::invalid_parameter_err(format!(
+            \"{name}: BigInt magnitude must fit in i64\"
+        )))
+    }
+}
+";
+
 /// Renders `sdks/typescript/src/_generated/tick_classes.rs` — the `#[napi(object)]` struct, `Vec` factory, and Arrow-IPC terminal per tick type for the TypeScript binding.
 pub(super) fn render_ts_tick_classes(schema: &Schema) -> String {
     let mut out = String::new();
@@ -52,6 +73,17 @@ pub(super) fn render_ts_tick_classes(schema: &Schema) -> String {
     for type_name in sorted_type_names(schema) {
         let def = &schema.types[type_name];
         out.push_str(&render_ts_tick_class_factory(schema, type_name, def));
+        out.push('\n');
+    }
+    // Checked `BigInt -> i64` decoder for the Arrow-IPC reconstruct path
+    // below — only emitted when a tick column is `i64` / `eod_num64`, so a
+    // schema with no such column carries no unused helper.
+    if schema.types.values().any(|def| {
+        def.columns
+            .iter()
+            .any(|col| ts_column_needs_bigint(col.r#type.as_str()))
+    }) {
+        out.push_str(BIGINT_TO_I64_HELPER);
         out.push('\n');
     }
     // Arrow-IPC terminals: one `#[napi] <tick>ToArrowIpc(rows) -> Buffer`
@@ -96,12 +128,13 @@ fn render_ts_tick_arrow_ipc(type_name: &str, def: &TickTypeDef) -> Option<String
         "pub fn {fn_name}(rows: Vec<{type_name}>) -> napi::Result<napi::bindgen_prelude::Buffer> {{"
     )
     .unwrap();
-    // Logical-enum columns (`right` / `calendar_status`) reject invalid
-    // input with `return Err(..)`; when the type carries one the
-    // reconstruct closure is fallible and its results are collected into a
-    // `napi::Result<Vec<..>>` and `?`-propagated. Types without such a
-    // column keep the infallible `.map(..).collect()` so a build that adds
-    // no validation pays no wrapping.
+    // A reconstruct can fail on a too-wide `i64` `BigInt` (`bigint_to_i64`)
+    // or an out-of-vocabulary logical-enum string (`right` /
+    // `calendar_status`); when the type carries either, the closure is
+    // fallible and its results are collected into a `napi::Result<Vec<..>>`
+    // and `?`-propagated. Types with neither keep the infallible
+    // `.map(..).collect()` so a build that adds no validation pays no
+    // wrapping.
     let fallible = ts_arrow_reconstruct_is_fallible(def);
     writeln!(out, "    let owned: Vec<tick::{type_name}> = rows").unwrap();
     out.push_str("        .into_iter()\n");
@@ -187,8 +220,13 @@ fn render_ts_tick_arrow_ipc(type_name: &str, def: &TickTypeDef) -> Option<String
 /// closure (see [`render_ts_tick_arrow_ipc`]).
 fn ts_arrow_reconstruct_expr(column_type: &str, field: &str) -> String {
     match column_type {
-        // i64 columns cross from JS as `BigInt`; `get_i64` yields the value.
-        "i64" | "eod_num64" => format!("{{ let (v, _) = r.{field}.get_i64(); v }}"),
+        // i64 columns cross from JS as `BigInt`. Reject a magnitude outside
+        // `i64` (e.g. `2n ** 100n`) on the `lossless` flag rather than
+        // silently truncating the wrapped low bits into the destination —
+        // the same guard the config setters apply via `bigint_to_u64`. Runs
+        // inside the fallible closure (`ts_arrow_reconstruct_is_fallible`
+        // returns `true` for any i64 column).
+        "i64" | "eod_num64" => format!("bigint_to_i64(\"{field}\", &r.{field})?"),
         // The logical right char arrives as a one-character string; only
         // `"C"` / `"P"` (and empty → NUL) are accepted, matching Python.
         "right" => format!(
@@ -205,19 +243,22 @@ fn ts_arrow_reconstruct_expr(column_type: &str, field: &str) -> String {
     }
 }
 
-/// `true` when a tick type's Arrow-IPC reconstruction validates at least one
-/// inbound string and so emits `return Err(..)`: either a logical-enum column
-/// (`right` / `calendar_status`) or the appended contract-identity `right`
+/// `true` when a tick type's Arrow-IPC reconstruction can fail and so emits
+/// `?` / `return Err(..)`: an `i64` / `eod_num64` column (rejects a `BigInt`
+/// magnitude outside `i64` via `bigint_to_i64`), a logical-enum column
+/// (`right` / `calendar_status`), or the appended contract-identity `right`
 /// (present whenever `def.contract_id`). Such a reconstruct must run inside a
-/// fallible closure; types without any validated field keep the infallible
+/// fallible closure; types without any fallible field keep the infallible
 /// `.map(..).collect()` form so a build that adds no validation pays no
 /// wrapping.
 fn ts_arrow_reconstruct_is_fallible(def: &TickTypeDef) -> bool {
     def.contract_id
-        || def
-            .columns
-            .iter()
-            .any(|column| matches!(column.r#type.as_str(), "right" | "calendar_status"))
+        || def.columns.iter().any(|column| {
+            matches!(
+                column.r#type.as_str(),
+                "i64" | "eod_num64" | "right" | "calendar_status"
+            )
+        })
 }
 
 fn render_ts_tick_class_struct(type_name: &str, def: &TickTypeDef) -> String {

--- a/docs-site/docs/streaming/indices/market-value.md
+++ b/docs-site/docs/streaming/indices/market-value.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'market_value') {
     const e = event.marketValue!;
     console.log(e.contract.symbol, e.marketPrice);

--- a/docs-site/docs/streaming/indices/price.md
+++ b/docs-site/docs/streaming/indices/price.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'trade') {
     const e = event.trade!;
     console.log(e.contract.symbol, e.price, e.size);

--- a/docs-site/docs/streaming/options/full-open-interest.md
+++ b/docs-site/docs/streaming/options/full-open-interest.md
@@ -60,7 +60,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { SecType } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'open_interest') {
     const e = event.openInterest!;
     console.log(e.contract.symbol, e.openInterest);

--- a/docs-site/docs/streaming/options/full-trade.md
+++ b/docs-site/docs/streaming/options/full-trade.md
@@ -60,7 +60,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { SecType } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'trade') {
     const e = event.trade!;
     console.log(e.contract.symbol, e.price, e.size);

--- a/docs-site/docs/streaming/options/open-interest.md
+++ b/docs-site/docs/streaming/options/open-interest.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'open_interest') {
     const e = event.openInterest!;
     console.log(e.contract.symbol, e.openInterest);

--- a/docs-site/docs/streaming/options/quote.md
+++ b/docs-site/docs/streaming/options/quote.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'quote') {
     const e = event.quote!;
     console.log(e.contract.symbol, e.bid, e.ask);

--- a/docs-site/docs/streaming/options/trade.md
+++ b/docs-site/docs/streaming/options/trade.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'trade') {
     const e = event.trade!;
     console.log(e.contract.symbol, e.price, e.size);

--- a/docs-site/docs/streaming/stocks/full-trade.md
+++ b/docs-site/docs/streaming/stocks/full-trade.md
@@ -60,7 +60,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { SecType } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'trade') {
     const e = event.trade!;
     console.log(e.contract.symbol, e.price, e.size);

--- a/docs-site/docs/streaming/stocks/quote.md
+++ b/docs-site/docs/streaming/stocks/quote.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'quote') {
     const e = event.quote!;
     console.log(e.contract.symbol, e.bid, e.ask);

--- a/docs-site/docs/streaming/stocks/trade.md
+++ b/docs-site/docs/streaming/stocks/trade.md
@@ -59,7 +59,7 @@ client.stream.unsubscribe(sub)
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.startStreaming((event) => {
+await client.stream.startStreaming((event) => {
   if (event.kind === 'trade') {
     const e = event.trade!;
     console.log(e.contract.symbol, e.price, e.size);

--- a/sdks/typescript/__tests__/arrow_bigint_bounds.test.mjs
+++ b/sdks/typescript/__tests__/arrow_bigint_bounds.test.mjs
@@ -1,0 +1,76 @@
+// Arrow-IPC reconstruct rejects a `bigint` `volume` / `count` outside the
+// `i64` destination instead of silently truncating its wrapped low bits.
+//
+// The `<tick>ToArrowIpc(rows)` terminal copies the JS object back into the
+// columnar `tick::T`, where `volume` / `count` are `i64`. A JS `bigint`
+// outside `i64::MIN..=i64::MAX` (e.g. `2n ** 100n`) cannot be represented and
+// must raise `InvalidParameterError`, matching the config setters' rejection
+// of an out-of-range `bigint` rather than passing a wrapped value. Imports the
+// package entry (`streaming-session.js`) so the `[InvalidParameterError]`
+// prefix the native binding raises reaches the typed subclass the same way a
+// caller sees it.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const mod = await import('../streaming-session.js').then((m) => m.default ?? m);
+const { InvalidParameterError } = mod;
+
+const I64_MAX = 2n ** 63n - 1n;
+const I64_MIN = -(2n ** 63n);
+const OVER_I64 = 2n ** 100n; // far above i64::MAX
+const UNDER_I64 = I64_MIN - 1n; // one below i64::MIN
+
+// Minimal valid row per columnar i64-bearing tick type. Only the non-optional
+// fields are supplied; `volume` / `count` carry an in-range default that each
+// test overrides to probe the bound. Optional contract-identity and
+// `*TimestampMs` fields are left undefined (the documented absent shape).
+const ROWS = {
+  eodTickToArrowIpc: {
+    createdMsOfDay: 0, lastTradeMsOfDay: 0, open: 1, high: 2, low: 0.5, close: 1.5,
+    volume: 1000n, count: 10n, bidSize: 0, bidExchange: 0, bid: 0, bidCondition: 0,
+    askSize: 0, askExchange: 0, ask: 0, askCondition: 0, date: 20260115,
+  },
+  greeksEodTickToArrowIpc: {
+    msOfDay: 0, open: 1, high: 2, low: 0.5, close: 1.5, volume: 1000n, count: 10n,
+    bidSize: 0, bidExchange: 0, bid: 0, bidCondition: 0, askSize: 0, askExchange: 0,
+    ask: 0, askCondition: 0, delta: 0, theta: 0, vega: 0, rho: 0, epsilon: 0,
+    lambda: 0, gamma: 0, vanna: 0, charm: 0, vomma: 0, veta: 0, vera: 0, speed: 0,
+    zomma: 0, color: 0, ultima: 0, d1: 0, d2: 0, dualDelta: 0, dualGamma: 0,
+    impliedVolatility: 0, ivError: 0, underlyingMsOfDay: 0, underlyingPrice: 0,
+    date: 20260115,
+  },
+  ohlcTickToArrowIpc: {
+    msOfDay: 0, open: 1, high: 2, low: 0.5, close: 1.5, volume: 1000n, count: 10n,
+    vwap: 0, date: 20260115,
+  },
+};
+
+function looksLikeArrowIpcStream(buf) {
+  return buf.length >= 8 && buf[0] === 0xff && buf[1] === 0xff && buf[2] === 0xff && buf[3] === 0xff;
+}
+
+describe('Arrow IPC reconstruct rejects out-of-i64 bigint volume/count', () => {
+  for (const [fn, base] of Object.entries(ROWS)) {
+    it(`${fn} rejects 2n ** 100n volume with InvalidParameterError`, () => {
+      assert.throws(
+        () => mod[fn]([{ ...base, volume: OVER_I64 }]),
+        (err) => err instanceof InvalidParameterError && /volume/.test(err.message),
+        'an over-i64 volume must reject, not truncate',
+      );
+    });
+
+    it(`${fn} rejects a below-i64::MIN count with InvalidParameterError`, () => {
+      assert.throws(
+        () => mod[fn]([{ ...base, count: UNDER_I64 }]),
+        (err) => err instanceof InvalidParameterError && /count/.test(err.message),
+        'a below-i64::MIN count must reject, not truncate',
+      );
+    });
+
+    it(`${fn} accepts i64-range volume/count`, () => {
+      const buf = mod[fn]([{ ...base, volume: I64_MAX, count: I64_MIN }]);
+      assert.ok(looksLikeArrowIpcStream(buf), 'an i64-range row must serialise to an Arrow IPC stream');
+    });
+  }
+});

--- a/sdks/typescript/examples/flatfiles_trade_quotes_to_arrow.ts
+++ b/sdks/typescript/examples/flatfiles_trade_quotes_to_arrow.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
   const client = await Client.connectFromFile("creds.txt");
 
   // Whole-universe option trade-quotes for one trading day.
-  const rows = client.flatFiles.optionTradeQuote("20260428");
+  const rows = await client.flatFiles.optionTradeQuote("20260428");
   console.log(`option_trade_quote rows: ${rows.len()}`);
 
   // Apache Arrow table -- one column per vendor field plus the contract
@@ -26,11 +26,11 @@ async function main(): Promise<void> {
   console.log(table.schema.fields.map((f) => `${f.name}:${f.type}`).join(", "));
 
   // Same path, dispatched dynamically.
-  const oi = client.flatFiles.request("OPTION", "OPEN_INTEREST", "20260428");
+  const oi = await client.flatFiles.request("OPTION", "OPEN_INTEREST", "20260428");
   console.log(`open_interest rows: ${oi.len()}`);
 
   // Drop raw vendor CSV bytes to disk without materialising rows.
-  const path = client.flatFileToPath(
+  const path = await client.flatFileToPath(
     "OPTION",
     "TRADE_QUOTE",
     "20260428",

--- a/sdks/typescript/examples/fluent_streaming_quote.ts
+++ b/sdks/typescript/examples/fluent_streaming_quote.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
   // Register the per-event callback. The napi-rs binding hands every
   // streaming event to the JS callback on the Node main thread via a
   // `ThreadsafeFunction`, so the libuv loop stays responsive.
-  client.stream.startStreaming((event) => {
+  await client.stream.startStreaming((event) => {
     switch (event.kind) {
       case "trade": {
         const trade = event.trade!;

--- a/sdks/typescript/src/_generated/tick_classes.rs
+++ b/sdks/typescript/src/_generated/tick_classes.rs
@@ -1360,6 +1360,19 @@ fn trade_ticks_to_class_vec(ticks: &[tick::TradeTick]) -> Vec<TradeTick> {
         .collect()
 }
 
+/// Decode an `i64` from a JS `bigint` Arrow column, rejecting a magnitude that
+/// does not fit `i64` rather than truncating its wrapped low bits.
+fn bigint_to_i64(name: &str, v: &BigInt) -> napi::Result<i64> {
+    let (value, lossless) = v.get_i64();
+    if lossless {
+        Ok(value)
+    } else {
+        Err(crate::invalid_parameter_err(format!(
+            "{name}: BigInt magnitude must fit in i64"
+        )))
+    }
+}
+
 /// Serialise a `CalendarDay` history result to an Arrow IPC stream
 /// (the `apache-arrow` wire form). Mirrors the FlatFiles
 /// `FlatFileRowList.toArrowIpc()` exit and the Python
@@ -1415,8 +1428,8 @@ pub fn eod_tick_to_arrow_ipc(rows: Vec<EodTick>) -> napi::Result<napi::bindgen_p
                 high: r.high,
                 low: r.low,
                 close: r.close,
-                volume: { let (v, _) = r.volume.get_i64(); v },
-                count: { let (v, _) = r.count.get_i64(); v },
+                volume: bigint_to_i64("volume", &r.volume)?,
+                count: bigint_to_i64("count", &r.count)?,
                 bid_size: r.bid_size,
                 bid_exchange: r.bid_exchange,
                 bid: r.bid,
@@ -1531,8 +1544,8 @@ pub fn greeks_eod_tick_to_arrow_ipc(rows: Vec<GreeksEodTick>) -> napi::Result<na
                 high: r.high,
                 low: r.low,
                 close: r.close,
-                volume: { let (v, _) = r.volume.get_i64(); v },
-                count: { let (v, _) = r.count.get_i64(); v },
+                volume: bigint_to_i64("volume", &r.volume)?,
+                count: bigint_to_i64("count", &r.count)?,
                 bid_size: r.bid_size,
                 bid_exchange: r.bid_exchange,
                 bid: r.bid,
@@ -1921,8 +1934,8 @@ pub fn ohlc_tick_to_arrow_ipc(rows: Vec<OhlcTick>) -> napi::Result<napi::bindgen
                 high: r.high,
                 low: r.low,
                 close: r.close,
-                volume: { let (v, _) = r.volume.get_i64(); v },
-                count: { let (v, _) = r.count.get_i64(); v },
+                volume: bigint_to_i64("volume", &r.volume)?,
+                count: bigint_to_i64("count", &r.count)?,
                 vwap: r.vwap,
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),


### PR DESCRIPTION
## What

Two TypeScript-binding fixes.

**Arrow IPC reconstruct rejects an out-of-i64 bigint.** `<tick>ToArrowIpc(rows)` copies the JS object back into the columnar `tick::T`, where `volume` / `count` are `i64`. The reconstruct discarded `BigInt::get_i64()`'s `lossless` flag, so a JS `bigint` outside `i64::MIN..=i64::MAX` (e.g. `2n ** 100n`) silently truncated its wrapped low bits into the destination. The fix adds a checked `bigint_to_i64(name, BigInt)` decoder (the sibling of the config setters' `bigint_to_u64`) that rejects a non-lossless value as `InvalidParameterError`, and marks any `i64` / `eod_num64` column as a fallible reconstruct so the closure `?`-propagates. Emitted in the codegen template, so every affected site (volume/count on EodTick, GreeksEodTick, OhlcTick) regenerates together.

**Await Promise-returning APIs in examples and docs.** `startStreaming`, `flatFiles.*`, and `flatFileToPath` return Promises; the streaming/flat-file examples and the per-asset streaming docs snippets now `await` them.

## Proof

New `__tests__/arrow_bigint_bounds.test.mjs`: each of `eodTickToArrowIpc` / `greeksEodTickToArrowIpc` / `ohlcTickToArrowIpc` rejects `2n ** 100n` and a value below `i64::MIN` with `InvalidParameterError`, and accepts `i64`-range bigints. `index.d.ts` is byte-unchanged (BigInt still maps to `bigint`).

## Gates

cargo check (TS manifest + core), clippy `--workspace --all-targets --locked -D warnings` (+ excluded TS crate), cargo fmt --check (+ excluded TS manifest), cargo doc --no-deps --workspace, `npm run build` (regenerates), `npm test` (288 pass incl 9 new), `generate_sdk_surfaces --check` (no drift), check_binding_parity.py, check_docs_consistency.py — all green. No new `#[allow]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)