### PR TITLE
fix(cpp): share FFI handle ownership into async futures to remove the dangling-this lifetime hazard

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/cpp.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/cpp.rs
@@ -167,9 +167,13 @@ pub(super) fn render_cpp_historical_decls(endpoints: &[GeneratedEndpoint]) -> St
 ///
 /// Arguments are taken by value and moved into the task closure so the
 /// future stays valid no matter when the caller invokes `get()` — the
-/// closure owns its inputs rather than borrowing the caller's. The blocking
-/// member borrows the client handle only for the duration of the call. The
-/// underlying handle is not thread-safe for concurrent calls (the C ABI
+/// closure owns its inputs rather than borrowing the caller's. The closure
+/// also captures a COPY of the client (`self = *this`) and runs the blocking
+/// member on that copy, so the FFI handle is co-owned for the future's whole
+/// lifetime: a future may safely outlive the object it was launched from
+/// (the captured copy shares the underlying `shared_ptr`, so the handle is
+/// freed only once the last owner — object or in-flight future — drops).
+/// The underlying handle is not thread-safe for concurrent calls (the C ABI
 /// serialises per handle), so an `_async` request must not run concurrently
 /// with another query on the same client; callers that fan out share one
 /// client per in-flight request or synchronise externally, matching the
@@ -237,51 +241,37 @@ fn render_cpp_async_overload(
     forwards.push("options".to_string());
 
     out.push_str(
-        "    /// \\warning The future borrows the object it was called on; do not let it\n",
+        "    /// The detached task captures a copy of this object (`self = *this`), so the\n",
     );
-    out.push_str("    /// outlive that object. Call on a named `HistoricalClient` (or chain the\n");
-    out.push_str("    /// result), never on the temporary returned by `client.historical()`.\n");
-    out.push_str("    ///\n");
-    out.push_str("    /// Lvalue-only: the `&&` overload is deleted, so calling this on a\n");
+    out.push_str(
+        "    /// returned future co-owns the FFI handle and may safely outlive the object\n",
+    );
+    out.push_str(
+        "    /// it was launched from — including a temporary `client.historical()` view.\n",
+    );
+    out.push_str("    /// The handle is freed only once the last owner (this object or the\n");
+    out.push_str("    /// in-flight future) drops, so there is no dangling-`this` window.\n");
     writeln!(
         out,
-        "    /// temporary view (e.g. `client.historical().{async_name}(...)`) is a"
-    )
-    .unwrap();
-    out.push_str("    /// compile error. The detached task borrows the view, which would die\n");
-    out.push_str("    /// at the end of the full expression; bind the view to a variable first.\n");
-    writeln!(
-        out,
-        "    std::future<std::vector<{row}>> {async_name}({}) const& {{",
+        "    std::future<std::vector<{row}>> {async_name}({}) const {{",
         decls.join(", ")
     )
     .unwrap();
     writeln!(
         out,
-        "        return std::async(std::launch::async, [this, {}]() {{",
+        "        return std::async(std::launch::async, [self = *this, {}]() {{",
         captures.join(", ")
     )
     .unwrap();
     writeln!(
         out,
-        "            return this->{}({});",
+        "            return self.{}({});",
         endpoint.name,
         forwards.join(", ")
     )
     .unwrap();
     out.push_str("        });\n");
     out.push_str("    }\n\n");
-
-    // Reject the dangling temporary-view call at compile time: deleting the
-    // rvalue overload turns `client.historical().<name>_async(...)` — a future
-    // that would outlive the temporary `Historical` it borrows — into a hard
-    // error, while named-lvalue clients still resolve to the `const&` overload.
-    writeln!(
-        out,
-        "    std::future<std::vector<{row}>> {async_name}({}) && = delete;\n",
-        decls.join(", ")
-    )
-    .unwrap();
     out
 }
 

--- a/sdks/cpp/include/historical.hpp.inc
+++ b/sdks/cpp/include/historical.hpp.inc
@@ -3,1285 +3,945 @@
     /// List all available stock ticker symbols.
     std::vector<std::string> stock_list_symbols(const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_list_symbols_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> stock_list_symbols_async(EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, options = std::move(options)]() {
-            return this->stock_list_symbols(options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> stock_list_symbols_async(EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, options = std::move(options)]() {
+            return self.stock_list_symbols(options);
         });
     }
-
-    std::future<std::vector<std::string>> stock_list_symbols_async(EndpointRequestOptions options = {}) && = delete;
 
     /// List available dates for a stock by request type (EOD, TRADE, QUOTE, etc.).
     std::vector<std::string> stock_list_dates(const std::string& request_type, const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_list_dates_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> stock_list_dates_async(std::string request_type, std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, request_type = std::move(request_type), symbol = std::move(symbol), options = std::move(options)]() {
-            return this->stock_list_dates(request_type, symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> stock_list_dates_async(std::string request_type, std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, request_type = std::move(request_type), symbol = std::move(symbol), options = std::move(options)]() {
+            return self.stock_list_dates(request_type, symbol, options);
         });
     }
-
-    std::future<std::vector<std::string>> stock_list_dates_async(std::string request_type, std::string symbol, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest OHLC snapshot for one or more stocks.
     std::vector<OhlcTick> stock_snapshot_ohlc(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<OhlcTick> stock_snapshot_ohlc(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->stock_snapshot_ohlc(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.stock_snapshot_ohlc(symbol, options);
         });
     }
 
-    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->stock_snapshot_ohlc(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.stock_snapshot_ohlc(symbols, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> stock_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest trade snapshot for one or more stocks.
     std::vector<TradeTick> stock_snapshot_trade(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<TradeTick> stock_snapshot_trade(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->stock_snapshot_trade(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.stock_snapshot_trade(symbol, options);
         });
     }
 
-    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->stock_snapshot_trade(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.stock_snapshot_trade(symbols, options);
         });
     }
-
-    std::future<std::vector<TradeTick>> stock_snapshot_trade_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
     std::vector<QuoteTick> stock_snapshot_quote(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<QuoteTick> stock_snapshot_quote(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->stock_snapshot_quote(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.stock_snapshot_quote(symbol, options);
         });
     }
 
-    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->stock_snapshot_quote(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.stock_snapshot_quote(symbols, options);
         });
     }
-
-    std::future<std::vector<QuoteTick>> stock_snapshot_quote_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest market value snapshot for one or more stocks.
     std::vector<MarketValueTick> stock_snapshot_market_value(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<MarketValueTick> stock_snapshot_market_value(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_market_value_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->stock_snapshot_market_value(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.stock_snapshot_market_value(symbol, options);
         });
     }
 
-    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_snapshot_market_value_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->stock_snapshot_market_value(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.stock_snapshot_market_value(symbols, options);
         });
     }
-
-    std::future<std::vector<MarketValueTick>> stock_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
     std::vector<EodTick> stock_history_eod(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_history_eod_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<EodTick>> stock_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->stock_history_eod(symbol, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<EodTick>> stock_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.stock_history_eod(symbol, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<EodTick>> stock_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars for a stock on a single date.
     std::vector<OhlcTick> stock_history_ohlc(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_history_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> stock_history_ohlc_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
-            return this->stock_history_ohlc(symbol, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> stock_history_ohlc_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
+            return self.stock_history_ohlc(symbol, date, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> stock_history_ohlc_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all trades for a stock on a given date.
     std::vector<TradeTick> stock_history_trade(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_history_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> stock_history_trade_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
-            return this->stock_history_trade(symbol, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> stock_history_trade_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
+            return self.stock_history_trade(symbol, date, options);
         });
     }
-
-    std::future<std::vector<TradeTick>> stock_history_trade_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
     std::vector<QuoteTick> stock_history_quote(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_history_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> stock_history_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
-            return this->stock_history_quote(symbol, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> stock_history_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
+            return self.stock_history_quote(symbol, date, options);
         });
     }
-
-    std::future<std::vector<QuoteTick>> stock_history_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     std::vector<TradeQuoteTick> stock_history_trade_quote(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_history_trade_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeQuoteTick>> stock_history_trade_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
-            return this->stock_history_trade_quote(symbol, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeQuoteTick>> stock_history_trade_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
+            return self.stock_history_trade_quote(symbol, date, options);
         });
     }
-
-    std::future<std::vector<TradeQuoteTick>> stock_history_trade_quote_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the trade at a specific time of day across a date range.
     std::vector<TradeTick> stock_at_time_trade(const std::string& symbol, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_at_time_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> stock_at_time_trade_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
-            return this->stock_at_time_trade(symbol, start_date, end_date, time_of_day, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> stock_at_time_trade_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
+            return self.stock_at_time_trade(symbol, start_date, end_date, time_of_day, options);
         });
     }
-
-    std::future<std::vector<TradeTick>> stock_at_time_trade_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the quote at a specific time of day across a date range.
     std::vector<QuoteTick> stock_at_time_quote(const std::string& symbol, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_at_time_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> stock_at_time_quote_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
-            return this->stock_at_time_quote(symbol, start_date, end_date, time_of_day, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> stock_at_time_quote_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
+            return self.stock_at_time_quote(symbol, start_date, end_date, time_of_day, options);
         });
     }
-
-    std::future<std::vector<QuoteTick>> stock_at_time_quote_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// List all available option underlying symbols.
     std::vector<std::string> option_list_symbols(const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_list_symbols_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> option_list_symbols_async(EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, options = std::move(options)]() {
-            return this->option_list_symbols(options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> option_list_symbols_async(EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, options = std::move(options)]() {
+            return self.option_list_symbols(options);
         });
     }
-
-    std::future<std::vector<std::string>> option_list_symbols_async(EndpointRequestOptions options = {}) && = delete;
 
     /// List available dates for an option contract by request type.
     std::vector<std::string> option_list_dates(const std::string& request_type, const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_list_dates_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> option_list_dates_async(std::string request_type, std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, request_type = std::move(request_type), symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_list_dates(request_type, symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> option_list_dates_async(std::string request_type, std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, request_type = std::move(request_type), symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_list_dates(request_type, symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<std::string>> option_list_dates_async(std::string request_type, std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// List available expiration dates for an option underlying.
     std::vector<std::string> option_list_expirations(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_list_expirations_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> option_list_expirations_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->option_list_expirations(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> option_list_expirations_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.option_list_expirations(symbol, options);
         });
     }
-
-    std::future<std::vector<std::string>> option_list_expirations_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
 
     /// List available strike prices for an option at a given expiration.
     std::vector<std::string> option_list_strikes(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_list_strikes_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> option_list_strikes_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_list_strikes(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> option_list_strikes_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_list_strikes(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<std::string>> option_list_strikes_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// List all option contracts traded or quoted on a given date, optionally filtered to a symbol.
     std::vector<OptionContract> option_list_contracts(const std::string& request_type, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_list_contracts_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OptionContract>> option_list_contracts_async(std::string request_type, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, request_type = std::move(request_type), date = std::move(date), options = std::move(options)]() {
-            return this->option_list_contracts(request_type, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OptionContract>> option_list_contracts_async(std::string request_type, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, request_type = std::move(request_type), date = std::move(date), options = std::move(options)]() {
+            return self.option_list_contracts(request_type, date, options);
         });
     }
-
-    std::future<std::vector<OptionContract>> option_list_contracts_async(std::string request_type, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest OHLC snapshot for an option contract.
     std::vector<OhlcTick> option_snapshot_ohlc(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> option_snapshot_ohlc_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_ohlc(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> option_snapshot_ohlc_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_ohlc(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> option_snapshot_ohlc_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest trade snapshot for an option contract.
     std::vector<TradeTick> option_snapshot_trade(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> option_snapshot_trade_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_trade(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> option_snapshot_trade_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_trade(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<TradeTick>> option_snapshot_trade_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest NBBO quote snapshot for an option contract.
     std::vector<QuoteTick> option_snapshot_quote(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> option_snapshot_quote_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_quote(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> option_snapshot_quote_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_quote(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<QuoteTick>> option_snapshot_quote_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest open interest snapshot for an option contract.
     std::vector<OpenInterestTick> option_snapshot_open_interest(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_open_interest_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OpenInterestTick>> option_snapshot_open_interest_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_open_interest(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OpenInterestTick>> option_snapshot_open_interest_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_open_interest(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<OpenInterestTick>> option_snapshot_open_interest_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest market value snapshot for an option contract.
     std::vector<MarketValueTick> option_snapshot_market_value(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_market_value_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<MarketValueTick>> option_snapshot_market_value_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_market_value(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<MarketValueTick>> option_snapshot_market_value_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_market_value(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<MarketValueTick>> option_snapshot_market_value_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get implied volatility snapshot for an option contract (from ThetaData server).
     std::vector<IvTick> option_snapshot_greeks_implied_volatility(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_greeks_implied_volatility_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<IvTick>> option_snapshot_greeks_implied_volatility_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_greeks_implied_volatility(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<IvTick>> option_snapshot_greeks_implied_volatility_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_greeks_implied_volatility(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<IvTick>> option_snapshot_greeks_implied_volatility_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     std::vector<GreeksAllTick> option_snapshot_greeks_all(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_greeks_all_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksAllTick>> option_snapshot_greeks_all_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_greeks_all(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksAllTick>> option_snapshot_greeks_all_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_greeks_all(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<GreeksAllTick>> option_snapshot_greeks_all_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     std::vector<GreeksFirstOrderTick> option_snapshot_greeks_first_order(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_greeks_first_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksFirstOrderTick>> option_snapshot_greeks_first_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_greeks_first_order(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksFirstOrderTick>> option_snapshot_greeks_first_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_greeks_first_order(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<GreeksFirstOrderTick>> option_snapshot_greeks_first_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     std::vector<GreeksSecondOrderTick> option_snapshot_greeks_second_order(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_greeks_second_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksSecondOrderTick>> option_snapshot_greeks_second_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_greeks_second_order(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksSecondOrderTick>> option_snapshot_greeks_second_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_greeks_second_order(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<GreeksSecondOrderTick>> option_snapshot_greeks_second_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     std::vector<GreeksThirdOrderTick> option_snapshot_greeks_third_order(const std::string& symbol, const std::string& expiration, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_snapshot_greeks_third_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksThirdOrderTick>> option_snapshot_greeks_third_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
-            return this->option_snapshot_greeks_third_order(symbol, expiration, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksThirdOrderTick>> option_snapshot_greeks_third_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), options = std::move(options)]() {
+            return self.option_snapshot_greeks_third_order(symbol, expiration, options);
         });
     }
-
-    std::future<std::vector<GreeksThirdOrderTick>> option_snapshot_greeks_third_order_async(std::string symbol, std::string expiration, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day option data for a contract over a date range.
     std::vector<EodTick> option_history_eod(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_eod_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<EodTick>> option_history_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->option_history_eod(symbol, expiration, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<EodTick>> option_history_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.option_history_eod(symbol, expiration, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<EodTick>> option_history_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars for an option contract.
     std::vector<OhlcTick> option_history_ohlc(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> option_history_ohlc_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_ohlc(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> option_history_ohlc_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_ohlc(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> option_history_ohlc_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all trades for an option contract on a given date.
     std::vector<TradeTick> option_history_trade(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> option_history_trade_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> option_history_trade_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeTick>> option_history_trade_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch NBBO quotes for an option contract on a given date.
     std::vector<QuoteTick> option_history_quote(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> option_history_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_quote(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> option_history_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_quote(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<QuoteTick>> option_history_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch combined trade + quote ticks for an option contract.
     std::vector<TradeQuoteTick> option_history_trade_quote(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeQuoteTick>> option_history_trade_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade_quote(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeQuoteTick>> option_history_trade_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade_quote(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeQuoteTick>> option_history_trade_quote_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch open interest history for an option contract.
     std::vector<OpenInterestTick> option_history_open_interest(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_open_interest_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OpenInterestTick>> option_history_open_interest_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_open_interest(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OpenInterestTick>> option_history_open_interest_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_open_interest(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<OpenInterestTick>> option_history_open_interest_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day Greeks history for an option contract.
     std::vector<GreeksEodTick> option_history_greeks_eod(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_greeks_eod_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksEodTick>> option_history_greeks_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->option_history_greeks_eod(symbol, expiration, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksEodTick>> option_history_greeks_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.option_history_greeks_eod(symbol, expiration, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<GreeksEodTick>> option_history_greeks_eod_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
     std::vector<GreeksAllTick> option_history_greeks_all(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_greeks_all_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksAllTick>> option_history_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_greeks_all(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksAllTick>> option_history_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_greeks_all(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<GreeksAllTick>> option_history_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch all Greeks on each trade for an option contract.
     std::vector<TradeGreeksAllTick> option_history_trade_greeks_all(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_greeks_all_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeGreeksAllTick>> option_history_trade_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade_greeks_all(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeGreeksAllTick>> option_history_trade_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade_greeks_all(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeGreeksAllTick>> option_history_trade_greeks_all_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch first-order Greeks history (intraday, sampled by interval).
     std::vector<GreeksFirstOrderTick> option_history_greeks_first_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_greeks_first_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksFirstOrderTick>> option_history_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_greeks_first_order(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksFirstOrderTick>> option_history_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_greeks_first_order(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<GreeksFirstOrderTick>> option_history_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch first-order Greeks on each trade for an option contract.
     std::vector<TradeGreeksFirstOrderTick> option_history_trade_greeks_first_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_greeks_first_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeGreeksFirstOrderTick>> option_history_trade_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade_greeks_first_order(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeGreeksFirstOrderTick>> option_history_trade_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade_greeks_first_order(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeGreeksFirstOrderTick>> option_history_trade_greeks_first_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch second-order Greeks history (intraday, sampled by interval).
     std::vector<GreeksSecondOrderTick> option_history_greeks_second_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_greeks_second_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksSecondOrderTick>> option_history_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_greeks_second_order(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksSecondOrderTick>> option_history_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_greeks_second_order(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<GreeksSecondOrderTick>> option_history_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch second-order Greeks on each trade for an option contract.
     std::vector<TradeGreeksSecondOrderTick> option_history_trade_greeks_second_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_greeks_second_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeGreeksSecondOrderTick>> option_history_trade_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade_greeks_second_order(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeGreeksSecondOrderTick>> option_history_trade_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade_greeks_second_order(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeGreeksSecondOrderTick>> option_history_trade_greeks_second_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch third-order Greeks history (intraday, sampled by interval).
     std::vector<GreeksThirdOrderTick> option_history_greeks_third_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_greeks_third_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<GreeksThirdOrderTick>> option_history_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_greeks_third_order(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<GreeksThirdOrderTick>> option_history_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_greeks_third_order(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<GreeksThirdOrderTick>> option_history_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch third-order Greeks on each trade for an option contract.
     std::vector<TradeGreeksThirdOrderTick> option_history_trade_greeks_third_order(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_greeks_third_order_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeGreeksThirdOrderTick>> option_history_trade_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade_greeks_third_order(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeGreeksThirdOrderTick>> option_history_trade_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade_greeks_third_order(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeGreeksThirdOrderTick>> option_history_trade_greeks_third_order_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch implied volatility history (intraday, sampled by interval).
     std::vector<IvTick> option_history_greeks_implied_volatility(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_greeks_implied_volatility_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<IvTick>> option_history_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_greeks_implied_volatility(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<IvTick>> option_history_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_greeks_implied_volatility(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<IvTick>> option_history_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch implied volatility on each trade for an option contract.
     std::vector<TradeGreeksImpliedVolatilityTick> option_history_trade_greeks_implied_volatility(const std::string& symbol, const std::string& expiration, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_history_trade_greeks_implied_volatility_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeGreeksImpliedVolatilityTick>> option_history_trade_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
-            return this->option_history_trade_greeks_implied_volatility(symbol, expiration, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeGreeksImpliedVolatilityTick>> option_history_trade_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), date = std::move(date), options = std::move(options)]() {
+            return self.option_history_trade_greeks_implied_volatility(symbol, expiration, date, options);
         });
     }
-
-    std::future<std::vector<TradeGreeksImpliedVolatilityTick>> option_history_trade_greeks_implied_volatility_async(std::string symbol, std::string expiration, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the trade at a specific time of day across a date range for an option.
     std::vector<TradeTick> option_at_time_trade(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_at_time_trade_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<TradeTick>> option_at_time_trade_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
-            return this->option_at_time_trade(symbol, expiration, start_date, end_date, time_of_day, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<TradeTick>> option_at_time_trade_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
+            return self.option_at_time_trade(symbol, expiration, start_date, end_date, time_of_day, options);
         });
     }
-
-    std::future<std::vector<TradeTick>> option_at_time_trade_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the quote at a specific time of day across a date range for an option.
     std::vector<QuoteTick> option_at_time_quote(const std::string& symbol, const std::string& expiration, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().option_at_time_quote_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<QuoteTick>> option_at_time_quote_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
-            return this->option_at_time_quote(symbol, expiration, start_date, end_date, time_of_day, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<QuoteTick>> option_at_time_quote_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), expiration = std::move(expiration), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
+            return self.option_at_time_quote(symbol, expiration, start_date, end_date, time_of_day, options);
         });
     }
-
-    std::future<std::vector<QuoteTick>> option_at_time_quote_async(std::string symbol, std::string expiration, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// List all available index symbols.
     std::vector<std::string> index_list_symbols(const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_list_symbols_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> index_list_symbols_async(EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, options = std::move(options)]() {
-            return this->index_list_symbols(options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> index_list_symbols_async(EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, options = std::move(options)]() {
+            return self.index_list_symbols(options);
         });
     }
-
-    std::future<std::vector<std::string>> index_list_symbols_async(EndpointRequestOptions options = {}) && = delete;
 
     /// List available dates for an index symbol.
     std::vector<std::string> index_list_dates(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_list_dates_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<std::string>> index_list_dates_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->index_list_dates(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<std::string>> index_list_dates_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.index_list_dates(symbol, options);
         });
     }
-
-    std::future<std::vector<std::string>> index_list_dates_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest OHLC snapshot for one or more indices.
     std::vector<OhlcTick> index_snapshot_ohlc(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<OhlcTick> index_snapshot_ohlc(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_snapshot_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->index_snapshot_ohlc(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.index_snapshot_ohlc(symbol, options);
         });
     }
 
-    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_snapshot_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->index_snapshot_ohlc(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.index_snapshot_ohlc(symbols, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> index_snapshot_ohlc_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest price snapshot for one or more indices.
     std::vector<PriceTick> index_snapshot_price(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<PriceTick> index_snapshot_price(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_snapshot_price_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->index_snapshot_price(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.index_snapshot_price(symbol, options);
         });
     }
 
-    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_snapshot_price_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->index_snapshot_price(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.index_snapshot_price(symbols, options);
         });
     }
-
-    std::future<std::vector<PriceTick>> index_snapshot_price_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Get the latest market value snapshot for one or more indices.
     std::vector<MarketValueTick> index_snapshot_market_value(const std::string& symbol, const EndpointRequestOptions& options = {}) const;
 
     std::vector<MarketValueTick> index_snapshot_market_value(const std::vector<std::string>& symbols, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_snapshot_market_value_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), options = std::move(options)]() {
-            return this->index_snapshot_market_value(symbol, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), options = std::move(options)]() {
+            return self.index_snapshot_market_value(symbol, options);
         });
     }
 
-    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::string symbol, EndpointRequestOptions options = {}) && = delete;
-
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_snapshot_market_value_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbols = std::move(symbols), options = std::move(options)]() {
-            return this->index_snapshot_market_value(symbols, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbols = std::move(symbols), options = std::move(options)]() {
+            return self.index_snapshot_market_value(symbols, options);
         });
     }
-
-    std::future<std::vector<MarketValueTick>> index_snapshot_market_value_async(std::vector<std::string> symbols, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day index data for a date range.
     std::vector<EodTick> index_history_eod(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_history_eod_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<EodTick>> index_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->index_history_eod(symbol, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<EodTick>> index_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.index_history_eod(symbol, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<EodTick>> index_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars for an index.
     std::vector<OhlcTick> index_history_ohlc(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_history_ohlc_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> index_history_ohlc_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->index_history_ohlc(symbol, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> index_history_ohlc_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.index_history_ohlc(symbol, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> index_history_ohlc_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday price history for an index.
     std::vector<PriceTick> index_history_price(const std::string& symbol, const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_history_price_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<PriceTick>> index_history_price_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
-            return this->index_history_price(symbol, date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<PriceTick>> index_history_price_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), date = std::move(date), options = std::move(options)]() {
+            return self.index_history_price(symbol, date, options);
         });
     }
-
-    std::future<std::vector<PriceTick>> index_history_price_async(std::string symbol, std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch the index price at a specific time of day across a date range.
     std::vector<IndexPriceAtTimeTick> index_at_time_price(const std::string& symbol, const std::string& start_date, const std::string& end_date, const std::string& time_of_day, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().index_at_time_price_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<IndexPriceAtTimeTick>> index_at_time_price_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
-            return this->index_at_time_price(symbol, start_date, end_date, time_of_day, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<IndexPriceAtTimeTick>> index_at_time_price_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), time_of_day = std::move(time_of_day), options = std::move(options)]() {
+            return self.index_at_time_price(symbol, start_date, end_date, time_of_day, options);
         });
     }
-
-    std::future<std::vector<IndexPriceAtTimeTick>> index_at_time_price_async(std::string symbol, std::string start_date, std::string end_date, std::string time_of_day, EndpointRequestOptions options = {}) && = delete;
 
     /// Check whether the market is open today.
     std::vector<CalendarDay> calendar_open_today(const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().calendar_open_today_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<CalendarDay>> calendar_open_today_async(EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, options = std::move(options)]() {
-            return this->calendar_open_today(options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<CalendarDay>> calendar_open_today_async(EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, options = std::move(options)]() {
+            return self.calendar_open_today(options);
         });
     }
-
-    std::future<std::vector<CalendarDay>> calendar_open_today_async(EndpointRequestOptions options = {}) && = delete;
 
     /// Get calendar information for a specific date.
     std::vector<CalendarDay> calendar_on_date(const std::string& date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().calendar_on_date_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<CalendarDay>> calendar_on_date_async(std::string date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, date = std::move(date), options = std::move(options)]() {
-            return this->calendar_on_date(date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<CalendarDay>> calendar_on_date_async(std::string date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, date = std::move(date), options = std::move(options)]() {
+            return self.calendar_on_date(date, options);
         });
     }
-
-    std::future<std::vector<CalendarDay>> calendar_on_date_async(std::string date, EndpointRequestOptions options = {}) && = delete;
 
     /// Get equity market holidays and early-close days for a year (vendor `year_holidays` endpoint — only non-standard days, not every trading day).
     std::vector<CalendarDay> calendar_year(const std::string& year, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().calendar_year_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<CalendarDay>> calendar_year_async(std::string year, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, year = std::move(year), options = std::move(options)]() {
-            return this->calendar_year(year, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<CalendarDay>> calendar_year_async(std::string year, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, year = std::move(year), options = std::move(options)]() {
+            return self.calendar_year(year, options);
         });
     }
-
-    std::future<std::vector<CalendarDay>> calendar_year_async(std::string year, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch end-of-day interest rate history.
     std::vector<InterestRateTick> interest_rate_history_eod(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().interest_rate_history_eod_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<InterestRateTick>> interest_rate_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->interest_rate_history_eod(symbol, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<InterestRateTick>> interest_rate_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.interest_rate_history_eod(symbol, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<InterestRateTick>> interest_rate_history_eod_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 
     /// Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
     std::vector<OhlcTick> stock_history_ohlc_range(const std::string& symbol, const std::string& start_date, const std::string& end_date, const EndpointRequestOptions& options = {}) const;
 
-    /// \warning The future borrows the object it was called on; do not let it
-    /// outlive that object. Call on a named `HistoricalClient` (or chain the
-    /// result), never on the temporary returned by `client.historical()`.
-    ///
-    /// Lvalue-only: the `&&` overload is deleted, so calling this on a
-    /// temporary view (e.g. `client.historical().stock_history_ohlc_range_async(...)`) is a
-    /// compile error. The detached task borrows the view, which would die
-    /// at the end of the full expression; bind the view to a variable first.
-    std::future<std::vector<OhlcTick>> stock_history_ohlc_range_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const& {
-        return std::async(std::launch::async, [this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
-            return this->stock_history_ohlc_range(symbol, start_date, end_date, options);
+    /// The detached task captures a copy of this object (`self = *this`), so the
+    /// returned future co-owns the FFI handle and may safely outlive the object
+    /// it was launched from — including a temporary `client.historical()` view.
+    /// The handle is freed only once the last owner (this object or the
+    /// in-flight future) drops, so there is no dangling-`this` window.
+    std::future<std::vector<OhlcTick>> stock_history_ohlc_range_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) const {
+        return std::async(std::launch::async, [self = *this, symbol = std::move(symbol), start_date = std::move(start_date), end_date = std::move(end_date), options = std::move(options)]() {
+            return self.stock_history_ohlc_range(symbol, start_date, end_date, options);
         });
     }
-
-    std::future<std::vector<OhlcTick>> stock_history_ohlc_range_async(std::string symbol, std::string start_date, std::string end_date, EndpointRequestOptions options = {}) && = delete;
 

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -940,7 +940,14 @@ public:
     #include "historical.hpp.inc"
 
 private:
-    explicit HistoricalClient(ThetaDataDxHistoricalClient* h) : handle_(h) {}
+    // Hold the FFI handle by `shared_ptr` (with the single-free deleter)
+    // rather than `unique_ptr` so an `<endpoint>_async` future can capture a
+    // copy of this client and co-own the handle for the future's whole
+    // lifetime: the handle is freed exactly once, when the last owner (this
+    // client or any in-flight future) drops. A copy therefore shares the one
+    // handle rather than double-freeing it.
+    explicit HistoricalClient(ThetaDataDxHistoricalClient* h)
+        : handle_(h, HistoricalClientDeleter{}) {}
 
     /// Resolve the historical sub-handle the generated buffered query
     /// definitions call into. On the standalone client this is the owned
@@ -949,7 +956,7 @@ private:
     /// the generator emit one definition body for both classes.
     const ThetaDataDxHistoricalClient* historical_handle() const { return handle_.get(); }
 
-    std::unique_ptr<ThetaDataDxHistoricalClient, HistoricalClientDeleter> handle_;
+    std::shared_ptr<ThetaDataDxHistoricalClient> handle_;
 };
 
 // ── streaming event types (re-exported from thetadatadx.h) ──
@@ -1432,14 +1439,16 @@ struct UnifiedDeleter {
 
 /// Historical-data sub-namespace returned by `Client::historical()`.
 ///
-/// Borrows the unified `ThetaDataDxClient*` and derives the historical
-/// sub-handle (`thetadatadx_client_historical`) on each call, so constructing it
-/// performs no auth round-trip and opens no second connection. Exposes the
-/// full buffered historical query surface (mixed in from
-/// `historical.hpp.inc`) and the server-stream companions
+/// Shares the parent `Client`'s `ThetaDataDxClient` handle (by `shared_ptr`)
+/// and derives the historical sub-handle (`thetadatadx_client_historical`) on
+/// each call, so constructing it performs no auth round-trip and opens no
+/// second connection. Exposes the full buffered historical query surface
+/// (mixed in from `historical.hpp.inc`) and the server-stream companions
 /// (`historical_stream.hpp.inc`) generated identically with the standalone
-/// `HistoricalClient`. The view is non-owning: its lifetime is bounded by
-/// the parent `Client`.
+/// `HistoricalClient`. The view co-owns the handle, so it (and any
+/// `<endpoint>_async` future that captured a copy of it) keeps the handle
+/// alive on its own — a future launched from a `client.historical()` view
+/// stays sound even after that view and its parent `Client` are gone.
 class Historical {
 public:
     /// Generated buffered historical query declarations
@@ -1454,21 +1463,25 @@ public:
 
 private:
     friend class Client;
-    explicit Historical(const ThetaDataDxClient* h) : handle_(h) {}
+    explicit Historical(std::shared_ptr<ThetaDataDxClient> h) : handle_(std::move(h)) {}
 
     /// Resolve the historical sub-handle the generated query definitions
     /// call into. Derives it from the unified handle via
     /// `thetadatadx_client_historical`; throws on the (unexpected) null result so
     /// the failure surfaces as a typed error rather than a null deref.
     const ThetaDataDxHistoricalClient* historical_handle() const {
-        const ThetaDataDxHistoricalClient* hist = thetadatadx_client_historical(handle_);
+        const ThetaDataDxHistoricalClient* hist = thetadatadx_client_historical(handle_.get());
         if (hist == nullptr) {
             detail::throw_last_ffi_error();
         }
         return hist;
     }
 
-    const ThetaDataDxClient* handle_;
+    // Co-owns the unified handle (shared with the parent `Client` and any
+    // in-flight async future that captured a copy of this view), so the
+    // handle outlives any future even if the view and its `Client` drop
+    // first. Freed once, when the last shared owner drops.
+    std::shared_ptr<ThetaDataDxClient> handle_;
 };
 
 /// Backing node for a single push-callback registration. The
@@ -2225,14 +2238,12 @@ public:
 
     /// Historical-data sub-namespace: `client.historical().stock_history_eod(...)`.
     ///
-    /// Returns a `Historical` view borrowing this client's handle. No auth
-    /// round-trip, no second connection; the view borrows `*this` and must
-    /// not outlive it.
-    ///
-    /// Lvalue-only: the accessor is ref-qualified to `const&`, so calling
-    /// it on a temporary is a compile error. Bind the client to a variable
-    /// first; the view then cannot outlive its client.
-    Historical historical() const& { return Historical(handle_.get()); }
+    /// Returns a `Historical` view that SHARES this client's handle (by
+    /// `shared_ptr`). No auth round-trip, no second connection. Because the
+    /// view co-owns the handle, an `<endpoint>_async` future launched from it
+    /// stays sound even if the view (and this client) drop before the future
+    /// completes — the captured copy keeps the handle alive.
+    Historical historical() const { return Historical(handle_); }
 
     /// Real-time-streaming sub-namespace: `client.stream().subscribe(...)`,
     /// `client.stream().set_callback(cb)`, …

--- a/sdks/cpp/tests/history_async.cpp
+++ b/sdks/cpp/tests/history_async.cpp
@@ -8,8 +8,10 @@
 // live half guards that `.get()` yields the same rows as the blocking call
 // and that a typed error surfaces on `.get()`.
 
+#include <atomic>
 #include <cstdlib>
 #include <future>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -28,8 +30,9 @@ std::string env_or_empty(const char* key) {
 namespace detail {
 
 // Detects whether `<obj>.stock_list_symbols_async()` is well-formed for a given
-// value category of the object. The `_async` companions delete their rvalue
-// overload, so this is true for an lvalue object and false for an rvalue one.
+// value category of the object. The `_async` companions co-own the FFI handle
+// (the closure captures a copy of the object), so the future may safely outlive
+// the object — the call is well-formed on BOTH an lvalue and an rvalue.
 template <typename T, typename = void>
 struct async_lvalue : std::false_type {};
 template <typename T>
@@ -93,18 +96,88 @@ TEST_CASE("async query methods return std::future of the sync row type",
             std::declval<thetadatadx::EndpointRequestOptions>()));
     STATIC_REQUIRE(std::is_same_v<ListRet, std::future<std::vector<std::string>>>);
 
-    // Dangling-temporary guard. The `_async` companions have their rvalue
-    // (`&&`) overload deleted, so they are callable on an lvalue view but NOT
-    // on an rvalue one. This makes the natural-looking
+    // Shared-ownership safety. The `_async` companions capture a copy of the
+    // object (`self = *this`), which co-owns the FFI handle, so the future
+    // keeps the handle alive on its own. The natural-looking
     // `client.historical().foo_async(...)` — where the `Historical` view is a
-    // temporary that dies at the end of the full expression while the detached
-    // task still borrows it — a compile error rather than a use-after-free. A
-    // named `auto h = client.historical();` (an lvalue) keeps working.
+    // temporary — is therefore SOUND, not a use-after-free, so the call is
+    // well-formed on both an lvalue and an rvalue object (no `&&`-deleted
+    // overload). The runtime lifetime test below proves the handle outlives a
+    // destroyed originating object.
     STATIC_REQUIRE(detail::async_callable_on_lvalue<View>);
-    STATIC_REQUIRE_FALSE(detail::async_callable_on_rvalue<View>);
-    // Same guard on the dedicated historical client.
+    STATIC_REQUIRE(detail::async_callable_on_rvalue<View>);
+    // Same on the dedicated historical client.
     STATIC_REQUIRE(detail::async_callable_on_lvalue<Hist>);
-    STATIC_REQUIRE_FALSE(detail::async_callable_on_rvalue<Hist>);
+    STATIC_REQUIRE(detail::async_callable_on_rvalue<Hist>);
+}
+
+// ── Lifetime regression: a future may outlive the object it was launched from ──
+//
+// The real `HistoricalClient` / `Historical` can only be constructed by a live
+// `connect()` (private ctor + gRPC handshake), so a true destroy-mid-flight
+// against a live FFI handle is a `[live]` scenario (last test below). This
+// offline case proves the load-bearing mechanism the generated `_async`
+// companions now rely on, with NO network: an owner that holds its resource by
+// `shared_ptr` and whose `_async`-shaped method captures a COPY of itself
+// (`self = *this`) keeps the resource alive for the future's whole lifetime,
+// even when the originating object is destroyed while the future is still
+// pending. A regression to capturing a raw `this` (or a non-owning copy) would
+// free the resource at the originator's destruction and fail these assertions
+// (and trip ASan on the dangling access inside the task).
+namespace {
+
+// Free-counting resource standing in for the FFI client handle.
+struct Resource {
+    int value;
+};
+
+// Mirrors the generated owner: holds the handle by `shared_ptr` (single-free
+// deleter) and exposes a `_async`-shaped method that captures a copy of itself.
+struct OwningStub {
+    std::shared_ptr<Resource> handle;
+
+    explicit OwningStub(std::atomic<int>* free_counter)
+        : handle(new Resource{42}, [free_counter](Resource* r) {
+              free_counter->fetch_add(1, std::memory_order_relaxed);
+              delete r;
+          }) {}
+
+    // The blocking body the future runs — touches the co-owned resource.
+    int read() const { return handle->value; }
+
+    // `_async` shape: capture a copy of `*this`, gated on `start` so the caller
+    // can destroy the originator before the body runs (destroy-mid-flight).
+    std::future<int> read_async(std::shared_future<void> start) const {
+        return std::async(std::launch::async, [self = *this, start]() {
+            start.wait();           // block until the originator is destroyed
+            return self.read();     // co-owned resource still alive
+        });
+    }
+};
+
+} // namespace
+
+TEST_CASE("async future outlives the destroyed originating object",
+          "[history][async][offline]") {
+    std::atomic<int> frees{0};
+    std::promise<void> gate;
+    std::shared_future<void> start = gate.get_future().share();
+
+    std::future<int> fut;
+    {
+        OwningStub owner(&frees);
+        fut = owner.read_async(start);
+        // Owner (and its shared_ptr reference) drops here, while the task is
+        // parked on `start` — i.e. the future is still pending. The resource
+        // must NOT be freed yet: the captured copy inside the task co-owns it.
+    }
+    REQUIRE(frees.load() == 0);
+
+    gate.set_value();           // release the task; it reads the co-owned resource
+    REQUIRE(fut.get() == 42);   // correct result, no use-after-free
+
+    fut = {};                   // drop the last owner (the future's captured copy)
+    REQUIRE(frees.load() == 1); // freed exactly once, only now
 }
 
 TEST_CASE("async query resolves to the same rows as the blocking call",
@@ -148,4 +221,26 @@ TEST_CASE("async query surfaces a typed error on future::get",
     std::future<std::vector<thetadatadx::EodTick>> fut =
         client.stock_history_eod_async("AAPL", "not-a-date", "not-a-date");
     REQUIRE_THROWS_AS(fut.get(), thetadatadx::ThetaDataError);
+}
+
+TEST_CASE("async query from a destroyed Historical view resolves safely",
+          "[history][async][live]") {
+    const auto creds_path = env_or_empty("THETADATADX_LIVE_CREDS");
+    if (creds_path.empty()) {
+        SKIP("THETADATADX_LIVE_CREDS not set");
+    }
+    auto creds = thetadatadx::Credentials::from_file(creds_path);
+    auto config = thetadatadx::Config::production();
+    auto client = thetadatadx::Client::connect(creds, config);
+
+    // Launch the async query directly on the temporary `client.historical()`
+    // view — the view is destroyed at the end of the full expression, while the
+    // detached task is still in flight. With shared handle ownership the task's
+    // captured copy keeps the handle alive, so `.get()` returns the correct
+    // rows instead of dereferencing a freed handle. (Pre-fix this was a
+    // deliberately-deleted `&&` overload; the UAF it guarded is now gone.)
+    std::future<std::vector<thetadatadx::EodTick>> fut =
+        client.historical().stock_history_eod_async("AAPL", "20240101", "20240131");
+    auto rows = fut.get();
+    REQUIRE_FALSE(rows.empty());
 }

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -182,12 +182,14 @@ TEST_CASE("Stream binds the full FPSS surface",
         decltype(std::declval<const thetadatadx::Client&>().historical()),
         thetadatadx::Historical>);
 
-    // Lvalue-only borrow contract: the view accessors are ref-qualified so
-    // they bind only to an lvalue `Client`. A view borrows the client's
-    // handle and must not outlive it, so calling an accessor on a temporary
-    // (`makeClient().historical()`) is a compile error: the view would
-    // dangle at the end of the full expression. These assertions pin that
-    // the lvalue forms are callable and the rvalue forms are not.
+    // View accessor binding contract. `stream()` (`&`) and `flat_files()`
+    // (`const&`) hand out non-owning views that borrow the client's handle,
+    // so they stay ref-qualified to reject a temporary `Client`. `historical()`
+    // is NOT ref-qualified (plain `const`): the `Historical` view it returns
+    // co-owns the handle by `shared_ptr`, so it (and any `<endpoint>_async`
+    // future launched from it) keeps the handle alive on its own and may
+    // safely outlive a temporary `Client`. These assertions pin those binding
+    // rules.
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::stream), thetadatadx::Client&>);
     // `stream()` is `&`-qualified (non-const lvalue ref), so it rejects an
@@ -198,17 +200,20 @@ TEST_CASE("Stream binds the full FPSS surface",
         decltype(&thetadatadx::Client::historical), const thetadatadx::Client&>);
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::flat_files), const thetadatadx::Client&>);
-    // `historical()` / `flat_files()` are `const&`-qualified. C++17 treats
-    // `is_invocable` of a `const&` member on an rvalue as false (the rvalue
-    // is rejected), but C++20 (LWG-resolved) treats it as true — an rvalue
-    // binds to a const lvalue ref. The runtime borrow contract (a view must
-    // not outlive the client) is unchanged; only the trait's answer differs
-    // by standard, so this rvalue assertion is gated to C++17. The C++ SDK
-    // builds C++17 by default; the `THETADATADX_CPP_ARROW` reader links
-    // arrow-cpp, which mandates C++20.
-#if __cplusplus < 202002L
-    STATIC_REQUIRE_FALSE(std::is_invocable_v<
+    // `historical()` is plain `const` (not ref-qualified), so it binds to an
+    // rvalue `Client` in every standard — the co-owning view it returns is
+    // sound on a temporary.
+    STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::historical), thetadatadx::Client&&>);
+    // `flat_files()` is `const&`-qualified. C++17 treats `is_invocable` of a
+    // `const&` member on an rvalue as false (the rvalue is rejected), but
+    // C++20 (LWG-resolved) treats it as true — an rvalue binds to a const
+    // lvalue ref. The runtime borrow contract (the flat-files view must not
+    // outlive the client) is unchanged; only the trait's answer differs by
+    // standard, so this rvalue assertion is gated to C++17. The C++ SDK builds
+    // C++17 by default; the `THETADATADX_CPP_ARROW` reader links arrow-cpp,
+    // which mandates C++20.
+#if __cplusplus < 202002L
     STATIC_REQUIRE_FALSE(std::is_invocable_v<
         decltype(&thetadatadx::Client::flat_files), thetadatadx::Client&&>);
 #endif


### PR DESCRIPTION
The generated C++ `<endpoint>_async` companions launched a detached `std::async` task that captured a raw `this`. A named `HistoricalClient` or a `Historical` view destroyed while its `std::future` was still running would leave that task dereferencing a freed handle — a use-after-free. The previous mitigation deleted the rvalue overload so the temporary-view one-liner (`client.historical().foo_async(...)`) was a compile error, but it did not cover the named-then-destroyed case.

This switches to shared ownership so the hazard is gone in both cases. The owning `HistoricalClient` now holds its `ThetaDataDxHistoricalClient*` by `shared_ptr` (with the existing single-free deleter) instead of `unique_ptr`, and the `Historical` view co-owns the parent `Client`'s `shared_ptr<ThetaDataDxClient>` instead of borrowing a raw pointer. The async codegen template then captures a copy of the object (`self = *this`) and runs the blocking member on that copy, so the captured copy's `shared_ptr` keeps the FFI handle alive for the future's full lifetime. The handle is still freed exactly once — when the last owner (the object or an in-flight future) drops — so there is no double-free or leak.

With shared ownership plus capture-by-copy the deleted rvalue overload is no longer needed, so it is removed and the async method is a normal `const` overload again; `client.historical().foo_async()` is now safe. `Client::historical()` is no longer ref-qualified because the view it returns co-owns the handle and is sound on a temporary.

Cross-binding parity is unchanged: same async method names and signatures (61 historical-async rows still match across Rust/Python/TypeScript/C++), only the capture and ownership change. The FFI ABI and the sync methods' behavior are untouched. The capture change is templated, so it scales across all 68 async methods at zero per-method cost.

## Tests

The SFINAE type-level test is updated — the temporary-view call is now allowed (well-formed on both lvalue and rvalue). A new offline regression test starts an async-shaped call, destroys the originating object while the future is parked, then `.get()`s it: it asserts the result is correct and that the co-owned handle is freed exactly once, only after the last owner drops (a regression to raw-`this` capture would free early and fail the test, and trip the sanitizer on the dangling access). A live destroy-mid-flight test launches a real query from a temporary `client.historical()` view that is destroyed before `.get()` and asserts it resolves to the correct rows.

## Verification

Regenerated the C++ surfaces; `generate_sdk_surfaces -- --check` reports no drift. `check_binding_parity.py` is clean. `cargo build -p thetadatadx-ffi` and `cargo check -p thetadatadx-ffi` pass. The Catch2 harness was built under `-fsanitize=address` and the full offline suite passed (70 cases, 62 passed, 8 live skipped; 323/323 assertions) with zero sanitizer reports, including the new lifetime test. No new lint suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)