### PR TITLE
feat(parity): streaming-lifecycle signature specs + record-batch pyi stub

### DIFF
--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -6307,6 +6307,53 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # fails closed (those bindings carry the bool, not the enum).
     "Scope": {"cpp": ("Scope", "FluentSubscription::Scope")},
     "Kind": {"cpp": ("Kind", "FluentSubscription::Kind")},
+    # A single built subscription handed to subscribe / unsubscribe. Each
+    # binding takes its own value-object spelling: Python the polymorphic
+    # `&Bound<PyAny>` it coerces internally (a `Subscription` or a contract
+    # spec), the napi `&Subscription` handle (qualified `&fluent::Subscription`
+    # when imported through the module path), the `.d.ts` `Subscription`, the
+    # C++ `const FluentSubscription&`.
+    "Subscription": {
+        "python": ("&Bound<'_, PyAny>", "PyObject", "Py<PyAny>"),
+        "ts_napi": ("&fluent::Subscription", "&Subscription"),
+        "ts_dts": ("Subscription",),
+        "cpp": ("const class FluentSubscription&", "const FluentSubscription&"),
+    },
+    # The iterable of subscriptions handed to subscribeMany / unsubscribeMany.
+    # Python takes the same polymorphic `&Bound<PyAny>` (an iterable it
+    # coerces); the napi `Vec<&Subscription>`; the `.d.ts` `Array<Subscription>`;
+    # the C++ `std::initializer_list<FluentSubscription>`.
+    "SubscriptionList": {
+        "python": ("&Bound<'_, PyAny>",),
+        "ts_napi": ("Vec<&fluent::Subscription>", "Vec<&Subscription>"),
+        "ts_dts": ("Array<Subscription>",),
+        "cpp": (
+            "std::initializer_list<class FluentSubscription>",
+            "std::initializer_list<FluentSubscription>",
+        ),
+    },
+    # The per-event streaming callback handed to startStreaming / setCallback.
+    # Python takes a `Py<PyAny>` callable; C++ a `std::function`. The napi
+    # `ThreadsafeFunction<...>` carries a long generic argument list that is
+    # pure binding machinery (queue depth, status), so the napi callback param
+    # is left to a `skip_langs = ["ts_napi"]` on the row rather than pinned
+    # here — there is no cross-binding contract in those generics.
+    "Callback": {
+        "python": ("Py<PyAny>", "PyObject"),
+        "cpp": ("std::function<void(const StreamEvent&)>",),
+    },
+    # The optional batch-reader tuning bag on `StreamView.batches`. The managed
+    # bindings pass a single options object (the napi / `.d.ts` `BatchesOptions`
+    # struct); Python and C++ spread it into positional / keyword params
+    # instead, so this cell covers only the object-passing bindings.
+    "BatchesOptions": {
+        "ts_napi": ("BatchesOptions", "crate::streaming_batches::BatchesOptions"),
+        "ts_dts": ("BatchesOptions",),
+    },
+    # The C++-only back-pressure mode enum on `StreamView.batches` (block vs
+    # drop-oldest); the managed bindings pass the mode as the `BatchesOptions`
+    # field instead, so only the C++ cell exists.
+    "Backpressure": {"cpp": ("Backpressure",)},
 }
 
 # Return-position canonical types (the result / unit wrappers). Kept apart
@@ -6362,6 +6409,45 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
         "ts_napi": ("Credentials", "napi::Result<Credentials>"),
         "cpp": ("Credentials",),
     },
+    # The per-contract active-subscription snapshot. Each binding returns its
+    # own collection shape: Python a `Vec<Subscription>` of typed handles (the
+    # `StreamView` surface wraps it in `PyResult`, unwrapped before the
+    # compare), the napi a `serde_json::Value` JSON tree (`.d.ts` `any`), C++ a
+    # `std::vector<Subscription>`. There is no single scalar twin, so the
+    # divergence is encoded per binding here rather than forced symmetric.
+    "Subscriptions": {
+        "python": ("Vec<crate::fluent::PySubscription>", "Vec<PySubscription>"),
+        "ts_napi": ("serde_json::Value",),
+        "ts_dts": ("any",),
+        "cpp": ("std::vector<Subscription>",),
+    },
+    # The full-stream active-subscription snapshot. Same per-binding collection
+    # shapes as `Subscriptions`, except the C++ element type is the full-stream
+    # `FullSubscription` (the managed bindings return the same typed list / JSON
+    # tree as the per-contract variant).
+    "FullSubscriptions": {
+        "python": ("Vec<crate::fluent::PySubscription>", "Vec<PySubscription>"),
+        "ts_napi": ("serde_json::Value",),
+        "ts_dts": ("any",),
+        "cpp": ("std::vector<FullSubscription>",),
+    },
+    # The pull-based columnar reader returned by `StreamView.batches`. Python
+    # hands back the `RecordBatchStream` pyclass (wrapped in `PyResult`,
+    # unwrapped before the compare), the napi the `RecordBatchStreamHandle`
+    # transport, the `.d.ts` the `Promise<RecordBatchStream>` JS wrapper, C++
+    # the `std::shared_ptr<RecordBatchStream>` (an `arrow::RecordBatchReader`).
+    "RecordBatchStream": {
+        "python": (
+            "crate::streaming_batches::RecordBatchStream",
+            "RecordBatchStream",
+        ),
+        "ts_napi": (
+            "crate::streaming_batches::RecordBatchStreamHandle",
+            "RecordBatchStreamHandle",
+        ),
+        "ts_dts": ("Promise<RecordBatchStream>", "RecordBatchStream"),
+        "cpp": ("std::shared_ptr<RecordBatchStream>",),
+    },
 }
 
 
@@ -6378,12 +6464,16 @@ def _sig_canon_type(raw: str) -> str:
 
 def _sig_unwrap_result(spelling: str) -> str:
     """Strip one fallible-result wrapper from a RETURN spelling: `PyResult<T>`
-    / `napi::Result<T>` / `Result<T>` → `T`. Fallibility is a per-binding
-    surface property (pyo3 `PyResult`, a thrown napi error), not a
-    cross-binding return-type difference the signature gate pins, so the inner
-    `T` is what the type map / Option rule compares. A non-wrapped spelling is
-    returned unchanged."""
-    m = re.fullmatch(r"(?:Py|napi::)?Result\s*<\s*(.+)\s*>", spelling.strip())
+    / `napi::Result<T>` / `Result<T>` → `T`. An optional module qualifier on
+    the wrapper is tolerated (`pyo3::PyResult<T>`, the fully-qualified form one
+    streaming accessor writes), so the inner `T` is compared regardless of how
+    the binding spells the path. Fallibility is a per-binding surface property
+    (pyo3 `PyResult`, a thrown napi error), not a cross-binding return-type
+    difference the signature gate pins. A non-wrapped spelling is returned
+    unchanged."""
+    m = re.fullmatch(
+        r"(?:[A-Za-z_][\w:]*::)?(?:Py)?Result\s*<\s*(.+)\s*>", spelling.strip()
+    )
     return m.group(1).strip() if m else spelling.strip()
 
 
@@ -6675,6 +6765,11 @@ def _sig_cpp_return_before(prefix: str) -> str | None:
     with a leading `virtual`/`static`/`inline`/`constexpr` specifier dropped.
     Returns None when nothing precedes (a constructor)."""
     seg = re.split(r"[;{}]", prefix)[-1]
+    # A preprocessor directive (`#ifdef THETADATADX_CPP_ARROW`, `#endif`)
+    # carries no `;`/`{`/`}`, so a method guarded by one — the Arrow-gated
+    # `Stream::batches` — would otherwise prepend the whole directive run to
+    # its return type. The directive line is a boundary, not a return token.
+    seg = re.sub(r"(?m)^\s*#.*$", "", seg)
     for kw in _SIG_CPP_ACCESS_KEYWORDS:
         seg = re.sub(rf".*\b{kw}\s*:", "", seg, flags=re.S)
     ret = re.sub(
@@ -11196,6 +11291,27 @@ def _run_selftest() -> int:
             )
             assert _sig_extract_cpp(hpp, "Rows", "get") == ([], "const Handle*")
 
+    def _case_sig_extract_cpp_preprocessor_guarded_return() -> None:
+        """A method behind a `#ifdef` (the Arrow-gated `Stream::batches`) must
+        extract its real return type — the preprocessor directive carries no
+        `;`/`{`/`}`, so without stripping it the directive run prepends onto the
+        return spelling (`#ifdef ... std::shared_ptr<...>`) and the type compare
+        fails closed on a legitimate signature."""
+        with tempfile.TemporaryDirectory() as tmp:
+            hpp = pathlib.Path(tmp) / "h.hpp"
+            hpp.write_text(
+                "class Stream {\npublic:\n"
+                "    bool is_streaming() const;\n"
+                "#ifdef THETADATADX_CPP_ARROW\n"
+                "    std::shared_ptr<RecordBatchStream> batches(size_t n) const;\n"
+                "#endif\n};\n",
+                encoding="utf-8",
+            )
+            assert _sig_extract_cpp(hpp, "Stream", "batches") == (
+                ["size_t"],
+                "std::shared_ptr<RecordBatchStream>",
+            )
+
     def _case_sig_ffi_opaque_pointer_exact() -> None:
         """For the `ffi` lang an unmapped canonical (a raw handle pointer / a
         C-ABI owned struct) compares by EXACT spelling — the C ABI is the
@@ -11247,6 +11363,9 @@ def _run_selftest() -> int:
             "X.workerThreads", ([], "Option<usize>"), ([], "napi::Result<Option<u32>>"), "ts_napi"
         )
         assert errs == [], errs
+        # A fully-qualified `pyo3::PyResult<T>` (the `activeFullSubscriptions`
+        # view spelling) unwraps past the module qualifier to its inner `T`.
+        assert _sig_unwrap_result("pyo3::PyResult<Vec<Subscription>>") == "Vec<Subscription>"
         # The qualified napi BigInt param folds to the bare `BigInt` cell.
         errs = _sig_compare_one(
             "X.setRing", (["usize"], "()"), (["napi::bindgen_prelude::BigInt"], "napi::Result<()>"), "ts_napi"
@@ -11552,6 +11671,7 @@ def _run_selftest() -> int:
     _case("sig extractor — C++ get_ getter prefix", _case_sig_extract_cpp_getter_prefix)
     _case("sig extractor — C++ elaborated-type param not class def", _case_sig_extract_cpp_elaborated_type_param)
     _case("sig extractor — C++ in-body call shadow rejected", _case_sig_extract_cpp_in_body_call_shadow)
+    _case("sig extractor — C++ #ifdef-guarded return stripped", _case_sig_extract_cpp_preprocessor_guarded_return)
     _case("sig type-map — FFI opaque pointer exact match", _case_sig_ffi_opaque_pointer_exact)
     _case("sig type-map — C++ raw handle exact match", _case_sig_cpp_raw_handle_exact)
     _case("sig type-map — return result-unwrap + lifetime/napi-path fold", _case_sig_return_result_unwrap_and_lifetime)

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1217,12 +1217,25 @@ typescript = true
 cpp = true
 rust = true         # `FlatFiles::to_path` on the `Client::flat_files()` view
 
+# ── StreamView signature specs (the `client.stream()` lifecycle view) ──
+#
+# The Rust core column is intentionally absent: the core `StreamSurface`
+# and `StreamingClient` surfaces legitimately differ (the observability
+# reverse scan covers their real risk), so neither is enrolled in
+# `RUST_METHOD_CLASS` and the `rust` signature-lang stays deferred.
 [[method]]
 class = "StreamView"
 name = "startStreaming"
 python = true
 typescript = true
 cpp = false  # C++ uses `setCallback` for the same role; tracked below
+# Registers the per-event callback and opens the session. The callback is a
+# Python callable; the napi `ThreadsafeFunction` generics are binding
+# machinery with no cross-binding contract, so `ts_napi` is left unpinned.
+[method.signature]
+params = ["Callback"]
+returns = "()"
+skip_langs = ["ts_napi"]
 
 [[method]]
 class = "StreamView"
@@ -1230,6 +1243,8 @@ name = "stopStreaming"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1237,6 +1252,8 @@ name = "shutdown"
 python = true
 typescript = true
 cpp = false  # C++ frees through the RAII destructor on `Client`
+[method.signature]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1244,6 +1261,12 @@ name = "reconnect"
 python = true
 typescript = true
 cpp = true
+# Every binding exposes the lifecycle method as `reconnect`. The core view
+# spells it `reconnect_streaming` (the standalone `StreamingClient` has no
+# method form at all — reconnection there is config-driven); that core
+# naming split is the maintainer's to resolve and is flagged separately.
+[method.signature]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1251,6 +1274,8 @@ name = "isStreaming"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "bool"
 
 [[method]]
 class = "StreamView"
@@ -1258,6 +1283,16 @@ name = "batches"
 python = true
 typescript = true
 cpp = true
+# The pull-based columnar reader. The tuning arguments are passed per-binding
+# idiom: Python keyword-only `Option`s, the managed `BatchesOptions` object on
+# TypeScript, four positional defaults (with the `Backpressure` enum) on C++.
+# The shared contract is the reader return.
+[method.signature]
+params = ["Option<usize>", "Option<u64>", "Option<String>", "Option<usize>"]
+returns = "RecordBatchStream"
+ts_napi_params = ["Option<BatchesOptions>"]
+ts_dts_params = ["BatchesOptions"]
+cpp_params = ["usize", "Duration", "Backpressure", "usize"]
 
 [[method]]
 class = "StreamView"
@@ -1265,6 +1300,8 @@ name = "isAuthenticated"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "bool"
 
 [[method]]
 class = "StreamView"
@@ -1272,6 +1309,11 @@ name = "awaitDrain"
 python = true
 typescript = true
 cpp = true
+# The drain-deadline argument: a millisecond span (the C++ form is
+# `std::chrono::milliseconds`); returns whether the buffer drained in time.
+[method.signature]
+params = ["Duration"]
+returns = "bool"
 
 [[method]]
 class = "StreamView"
@@ -1279,6 +1321,11 @@ name = "subscribe"
 python = true
 typescript = true
 cpp = true
+# One built subscription. Python takes the polymorphic value it coerces; the
+# napi / C++ take their typed `Subscription` / `FluentSubscription` handle.
+[method.signature]
+params = ["Subscription"]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1286,6 +1333,9 @@ name = "subscribeMany"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["SubscriptionList"]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1293,6 +1343,9 @@ name = "unsubscribe"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["Subscription"]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1300,6 +1353,9 @@ name = "unsubscribeMany"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["SubscriptionList"]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1307,6 +1363,13 @@ name = "activeSubscriptions"
 python = true
 typescript = true
 cpp = true
+# The per-contract snapshot: a typed list on Python / C++, a JSON tree on
+# TypeScript. The core view returns `Result<Vec<..>>` while the standalone
+# `StreamingClient` returns a bare `Vec<..>`; fallibility is unwrapped before
+# the compare, so the binding spec is identical — that core fallibility split
+# is the maintainer's to resolve and is flagged separately.
+[method.signature]
+returns = "Subscriptions"
 
 [[method]]
 class = "StreamView"
@@ -1314,6 +1377,10 @@ name = "activeFullSubscriptions"
 python = true
 typescript = true
 cpp = true
+# The full-stream snapshot (C++ element type `FullSubscription`). Same core
+# `Result`-vs-bare split as `activeSubscriptions`, flagged separately.
+[method.signature]
+returns = "FullSubscriptions"
 
 [[method]]
 class = "StreamView"
@@ -1321,6 +1388,12 @@ name = "droppedEventCount"
 python = true
 typescript = true
 cpp = true
+# Cumulative dropped-event counter. Every binding exposes it as
+# `droppedEventCount`; the core spells it `dropped_event_count` on this view
+# but `dropped_count` on the standalone `StreamingClient`, both folded to the
+# one row name by `CORE_STREAMING_METHOD_RENAMES`.
+[method.signature]
+returns = "u64"
 
 [[method]]
 class = "StreamView"
@@ -1328,6 +1401,8 @@ name = "ringOccupancy"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "usize"
 
 [[method]]
 class = "StreamView"
@@ -1335,6 +1410,8 @@ name = "ringCapacity"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "usize"
 
 [[method]]
 class = "StreamView"
@@ -1342,6 +1419,8 @@ name = "panicCount"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u64"
 
 [[method]]
 class = "StreamView"
@@ -1349,6 +1428,8 @@ name = "slowCallbackCount"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u64"
 
 [[method]]
 class = "StreamView"
@@ -1356,6 +1437,13 @@ name = "setSlowCallbackThresholdUs"
 python = true
 typescript = true
 cpp = true
+# The argument is an integer microsecond count on every binding (`u64` /
+# `BigInt` / `uint64_t`). The core takes a `Duration` and converts from
+# microseconds internally, so the `Us` suffix names the binding unit, not the
+# core type; the naming is flagged for the maintainer.
+[method.signature]
+params = ["u64"]
+returns = "()"
 
 [[method]]
 class = "StreamView"
@@ -1363,6 +1451,13 @@ name = "millisSinceLastEvent"
 python = true
 typescript = true
 cpp = true
+# Milliseconds since the last event, absent before the first. Python /
+# TypeScript return the optional directly; C++ uses the status-plus-out-param
+# ABI shape (`int32_t` status, the value via `uint64_t*`).
+[method.signature]
+returns = "Option<u64>"
+cpp_params = ["uint64_t*"]
+cpp_returns = "i32"
 
 [[method]]
 class = "StreamView"
@@ -1370,6 +1465,8 @@ name = "lastEventReceivedAtUnixNanos"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "i64"
 
 [[method]]
 class = "StreamView"
@@ -1377,6 +1474,13 @@ name = "lastConnectedAddr"
 python = true
 typescript = true
 cpp = true
+# The peer address of the live session. Python / TypeScript return the
+# optional string; C++ returns a bare `std::string` (empty when no session).
+# The core view returns `Option<String>` while the standalone
+# `StreamingClient` returns a bare `String`; that core split is flagged.
+[method.signature]
+returns = "Option<String>"
+cpp_returns = "String"
 
 [[method]]
 class = "StreamView"
@@ -1384,6 +1488,10 @@ name = "setCallback"
 python = false  # Python uses `startStreaming(callback)` for the same role
 typescript = false  # TypeScript uses `startStreaming(callback)` likewise
 cpp = true
+# C++-only callback registrar (the `startStreaming` role on Python / TS).
+[method.signature]
+cpp_params = ["Callback"]
+cpp_returns = "()"
 
 # ── StreamingClient (the standalone streaming-only client) ──
 #
@@ -1391,12 +1499,22 @@ cpp = true
 # the class-level row above). Every `typescript = false` below reflects
 # the same gap and is NOT an action item by itself.
 
+# ── StreamingClient signature specs (the standalone streaming-only client) ──
+#
+# The same binding signatures as the matching `StreamView` rows. The Rust
+# core column is deferred for the same reason (the core `StreamingClient`
+# surface is not in `RUST_METHOD_CLASS`). `batches` has no row here — the
+# columnar reader ships only on the unified `StreamView`.
 [[method]]
 class = "StreamingClient"
 name = "startStreaming"
 python = true
 typescript = true
 cpp = false  # C++ uses `setCallback` for the same role
+[method.signature]
+params = ["Callback"]
+returns = "()"
+skip_langs = ["ts_napi"]
 
 [[method]]
 class = "StreamingClient"
@@ -1404,6 +1522,8 @@ name = "stopStreaming"
 python = true
 typescript = true
 cpp = false  # C++ frees through the RAII destructor on `StreamingClient`
+[method.signature]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1411,6 +1531,8 @@ name = "shutdown"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1418,6 +1540,8 @@ name = "reconnect"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1425,6 +1549,8 @@ name = "isStreaming"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "bool"
 
 [[method]]
 class = "StreamingClient"
@@ -1432,6 +1558,8 @@ name = "isAuthenticated"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "bool"
 
 [[method]]
 class = "StreamingClient"
@@ -1439,6 +1567,9 @@ name = "awaitDrain"
 python = true
 typescript = true
 cpp = false  # C++ drain barrier runs inside the RAII destructor
+[method.signature]
+params = ["Duration"]
+returns = "bool"
 
 [[method]]
 class = "StreamingClient"
@@ -1446,6 +1577,9 @@ name = "subscribe"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["Subscription"]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1453,6 +1587,9 @@ name = "subscribeMany"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["SubscriptionList"]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1460,6 +1597,9 @@ name = "unsubscribe"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["Subscription"]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1467,6 +1607,9 @@ name = "unsubscribeMany"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["SubscriptionList"]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1474,6 +1617,10 @@ name = "activeSubscriptions"
 python = true
 typescript = true
 cpp = true
+# Bare `Vec<..>` on the core `StreamingClient` (vs `Result<Vec<..>>` on the
+# `StreamView`); fallibility is unwrapped, so the binding spec matches.
+[method.signature]
+returns = "Subscriptions"
 
 [[method]]
 class = "StreamingClient"
@@ -1481,6 +1628,8 @@ name = "activeFullSubscriptions"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "FullSubscriptions"
 
 [[method]]
 class = "StreamingClient"
@@ -1488,6 +1637,10 @@ name = "droppedEventCount"
 python = true
 typescript = true
 cpp = true
+# Core `dropped_count` on this surface, `dropped_event_count` on the
+# `StreamView`; both fold to this row name via `CORE_STREAMING_METHOD_RENAMES`.
+[method.signature]
+returns = "u64"
 
 [[method]]
 class = "StreamingClient"
@@ -1495,6 +1648,8 @@ name = "ringOccupancy"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "usize"
 
 [[method]]
 class = "StreamingClient"
@@ -1502,6 +1657,8 @@ name = "ringCapacity"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "usize"
 
 [[method]]
 class = "StreamingClient"
@@ -1509,6 +1666,8 @@ name = "panicCount"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u64"
 
 [[method]]
 class = "StreamingClient"
@@ -1516,6 +1675,8 @@ name = "slowCallbackCount"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u64"
 
 [[method]]
 class = "StreamingClient"
@@ -1523,6 +1684,11 @@ name = "setSlowCallbackThresholdUs"
 python = true
 typescript = true
 cpp = true
+# Integer microseconds on every binding; the core takes a `Duration`. Same
+# `Us`-names-the-unit naming flagged on the `StreamView` row.
+[method.signature]
+params = ["u64"]
+returns = "()"
 
 [[method]]
 class = "StreamingClient"
@@ -1530,6 +1696,10 @@ name = "millisSinceLastEvent"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "Option<u64>"
+cpp_params = ["uint64_t*"]
+cpp_returns = "i32"
 
 [[method]]
 class = "StreamingClient"
@@ -1537,6 +1707,8 @@ name = "lastEventReceivedAtUnixNanos"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "i64"
 
 [[method]]
 class = "StreamingClient"
@@ -1544,6 +1716,11 @@ name = "lastConnectedAddr"
 python = true
 typescript = true
 cpp = true
+# Bare `String` on the core `StreamingClient` (vs `Option<String>` on the
+# `StreamView`); C++ returns `std::string`, Python / TypeScript the optional.
+[method.signature]
+returns = "Option<String>"
+cpp_returns = "String"
 
 [[method]]
 class = "StreamingClient"
@@ -1551,6 +1728,9 @@ name = "setCallback"
 python = false
 typescript = false
 cpp = true
+[method.signature]
+cpp_params = ["Callback"]
+cpp_returns = "()"
 
 # ── Credentials (the auth-handle class) ──
 #

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -5103,6 +5103,22 @@ class StreamView:
         """
         ...
 
+    def batches(
+        self,
+        *,
+        batch_size: Optional[int] = None,
+        linger_ms: Optional[int] = None,
+        backpressure: Optional[str] = None,
+        capacity: Optional[int] = None,
+    ) -> RecordBatchStream:
+        """Open a pull-based columnar reader over the live stream.
+
+        Returns a :class:`RecordBatchStream` yielding ``pyarrow.RecordBatch``
+        objects. ``backpressure`` selects ``"block"`` (lossless, the default)
+        or ``"drop_oldest"`` (bounded by ``capacity`` buffered batches).
+        """
+        ...
+
     def stop_streaming(self) -> None:
         """Stop streaming while keeping the historical client usable.
 
@@ -5937,6 +5953,72 @@ class HistoricalClient:
 # ─────────────────────────────────────────────────────────────────────
 # Streaming context managers + iterator
 # ─────────────────────────────────────────────────────────────────────
+
+
+@final
+class RecordBatchStream:
+    """Pull-based columnar reader returned by :meth:`StreamView.batches`.
+
+    Synchronous and asynchronous iterable, and a context manager on both
+    protocols; each iteration yields a ``pyarrow.RecordBatch``. Closing the
+    reader (explicitly, or on block exit) releases the underlying stream.
+    """
+
+    def __iter__(self) -> RecordBatchStream:
+        """Return ``self`` as a synchronous iterator."""
+        ...
+
+    def __next__(self) -> Any:
+        """Return the next ``pyarrow.RecordBatch``; raise ``StopIteration`` at end."""
+        ...
+
+    def __aiter__(self) -> RecordBatchStream:
+        """Return ``self`` as an asynchronous iterator."""
+        ...
+
+    async def __anext__(self) -> Any:
+        """Return the next ``pyarrow.RecordBatch``; raise ``StopAsyncIteration`` at end."""
+        ...
+
+    def __enter__(self) -> RecordBatchStream:
+        """Return the reader for use as a context manager."""
+        ...
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[Any],
+    ) -> bool:
+        """Close the reader; never suppresses exceptions."""
+        ...
+
+    async def __aenter__(self) -> RecordBatchStream:
+        """Return the reader for use as an async context manager."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[Any],
+    ) -> bool:
+        """Close the reader; never suppresses exceptions."""
+        ...
+
+    def close(self) -> None:
+        """Release the underlying stream. Idempotent."""
+        ...
+
+    @property
+    def schema(self) -> Any:
+        """The fixed ``pyarrow.Schema`` every batch carries."""
+        ...
+
+    @property
+    def dropped(self) -> int:
+        """Count of batches dropped under back-pressure."""
+        ...
 
 
 @final


### PR DESCRIPTION
Final surface-by-surface pass of the cross-SDK signature guard: enrolls the streaming-lifecycle surfaces (`StreamView` from `client.stream()` and the standalone `StreamingClient`) into the opt-in `[method.signature]` plane, and fixes a real user-facing Python stub gap. Static-only; no runtime changes to the streaming API.

## What landed

Every `StreamView` (24) and `StreamingClient` (23) lifecycle row now carries a `[method.signature]` sub-table verified against the real binding sources through the type map and per-binding overrides. The forward Rust column stays deferred by design (neither core surface is in `RUST_METHOD_CLASS`; the observability reverse scan already covers their real risk).

Idiomatic divergence is codified as type-map cells / overrides rather than forced symmetric: the single vs. iterable subscription value-objects (`&Bound<PyAny>` / `&Subscription` / `const FluentSubscription&` and the `Vec` / `initializer_list` many-forms), the per-event callback (Python callable / C++ `std::function`; the napi `ThreadsafeFunction` generics are left unpinned via `skip_langs` since they carry no cross-binding contract), the `batches` reader return plus its per-binding option bag, the `millisSinceLastEvent` C++ status-plus-out-param ABI shape, and the integer-microsecond threshold setter.

Two extractor fixes (each with a self-test probe): the C++ signature extractor now strips a `#ifdef`-guarded line so the Arrow-gated `Stream::batches` return type reads cleanly instead of absorbing the preprocessor run, and the return result-unwrap now sees a fully-qualified `pyo3::PyResult<T>` (the spelling one accessor uses).

Stub fix: `RecordBatchStream` and `StreamView.batches` were compiled but absent from the Python type stub. The stub is hand-maintained outside its one generated region (the generated `HistoricalView` block, validated by `generate_sdk_surfaces --check`, is untouched), so both were added by hand to match the existing stub style.

## Drift reconciled

Codified as overrides (idiomatic, type-map-justified):
- `setSlowCallbackThresholdUs` takes an integer-microsecond count on every binding while the core takes a `Duration` and converts internally — the `Us` suffix names the binding unit, pinned as a `u64` param.
- `droppedEventCount` is the row name on every binding; the core spells it `dropped_event_count` on the view and `dropped_count` on the standalone client, already folded by the rename table.
- `lastConnectedAddr` returns a bare `std::string` on C++ vs. the optional on Python/TypeScript, pinned via a C++ return override.
- `reconnect` is the binding method name on every surface (the core view spells it `reconnect_streaming`; the standalone client has no method form).

## Flagged for the maintainer (core API decisions, not changed here)

1. `active_subscriptions` / `active_full_subscriptions` return `Result<Vec<..>>` on the core `StreamSurface` (`client.rs`) but a bare `Vec<..>` on `StreamingClient` (`fpss/mod.rs`): one can surface a lock/poison error to the caller, the other cannot. The binding spec is identical (fallibility is unwrapped before the compare), but the two core surfaces disagree on whether reading the active set is fallible. Options: make `StreamingClient` return `Result` for symmetry, or document the bare-`Vec` as an intentional infallible-by-construction guarantee.
2. `last_connected_addr` returns `Option<String>` on `StreamSurface` but a bare `String` on `StreamingClient` (empty string as the no-session sentinel). Options: align `StreamingClient` to `Option<String>`, or document the empty-string sentinel as intentional.
3. Naming note on `setSlowCallbackThresholdUs`: the binding method advertises microseconds while the core takes `Duration` — fine as a unit-named convenience, but worth a deliberate call on whether the binding name should stay unit-suffixed.

## Gates

`check_binding_parity.py --selftest` (192 passed), full `check_binding_parity.py` (clean; 120 method rows, 79 signature-pinned), `tests/test_check_binding_parity.py` (54 passed), `generate_sdk_surfaces --features config-file -- --check` (no codegen drift) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)