### PR TITLE
feat(parity): close signature-coverage gaps with fail-closed enrollment, ts_dts property and absence checks, and exact-width integer type-map

### DIFF
--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -102,6 +102,19 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
             // + `Symbol.asyncDispose` surface; only this entry is generated
             // so the cross-binding surface stays in lockstep. `async`
             // because the FPSS connect runs on a blocking worker.
+            //
+            // `skip_typescript` suppresses the napi `.d.ts` line so the
+            // public return type is declared in exactly ONE place: the
+            // `streaming-session.d.ts` augmentation, which presents the
+            // `Promise<RecordBatchStream>` wrapper (the iterable/closeable
+            // surface) instead of this raw `RecordBatchStreamHandle`. Were
+            // both emitted, the class declaration and the `declare module`
+            // augmentation would merge as two overloads of `batches`,
+            // leaving the resolved return ambiguous and re-exposing the raw
+            // handle. One declaration keeps the client-facing return
+            // unambiguous and checkable by the parity guard. The runtime
+            // `#[napi]` registration is unaffected — only `.d.ts` emission
+            // is skipped.
             push_rust_doc_comment(
                 &mut out,
                 "    ",
@@ -120,7 +133,7 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
                  `backpressure` is `\"block\"` (default, lossless) or\n\
                  `\"dropOldest\"`; `capacity` bounds the drop-oldest buffer.",
             );
-            writeln!(out, "    #[napi(js_name = \"batches\")]").unwrap();
+            writeln!(out, "    #[napi(js_name = \"batches\", skip_typescript)]").unwrap();
             writeln!(
                 out,
                 "    pub async fn {}(&self, options: Option<crate::streaming_batches::BatchesOptions>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {{",

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -6884,18 +6884,29 @@ def _ts_dts_files(dts: pathlib.Path) -> list[pathlib.Path]:
     return out
 
 
+def _ts_dts_class_bodies_with_src(dts: pathlib.Path, cls: str) -> list[tuple[pathlib.Path, str]]:
+    """`(source file, body)` for every `class cls` / `interface cls` across the
+    public `.d.ts` surface, in PRECEDENCE order: the package entry first (its
+    `declare module` augmentation overrides), then each re-exported sibling
+    (the napi-generated `index.d.ts`). The source file is carried so a conflict
+    between an entry augmentation and a re-exported generated declaration can be
+    reported with both locations."""
+    out: list[tuple[pathlib.Path, str]] = []
+    cls_re = re.compile(r"\b(?:class|interface)\s+" + re.escape(cls) + r"\b[^{]*\{")
+    for f in _ts_dts_files(dts):
+        text = _read_source(f)
+        for m in cls_re.finditer(text):
+            out.append((f, _balanced_body(text, m.end())))
+    return out
+
+
 def _ts_dts_class_bodies(dts: pathlib.Path, cls: str) -> list[str]:
     """Every `class cls` / `interface cls` body across the public `.d.ts`
     surface (entry + re-exported siblings). A class can appear more than once
     — the napi `index.d.ts` declaration plus a `declare module` augmentation
     in the wrapper — so all bodies are returned and the member is looked up in
     each."""
-    bodies: list[str] = []
-    cls_re = re.compile(r"\b(?:class|interface)\s+" + re.escape(cls) + r"\b[^{]*\{")
-    for f in _ts_dts_files(dts):
-        text = _read_source(f)
-        for m in cls_re.finditer(text):
-            bodies.append(_balanced_body(text, m.end()))
+    bodies = [body for _, body in _ts_dts_class_bodies_with_src(dts, cls)]
     return bodies
 
 
@@ -6934,27 +6945,76 @@ def _sig_extract_ts_dts(dts: pathlib.Path, cls: str, method_camel: str) -> tuple
     only a member genuinely absent from the public `.d.ts` (a napi-only
     streaming row whose `.d.ts` shape is not redeclared) degrades to
     napi-as-authority."""
+    decls = _sig_dts_all_decls(dts, cls, method_camel)
+    # Precedence: the package-entry augmentation (declared first across the
+    # surface) overrides the re-exported generated declaration, matching how
+    # `_ts_dts_class_bodies_with_src` orders the surface.
+    return decls[0][1] if decls else None
+
+
+def _sig_parse_dts_member(body: str, dm: "re.Match[str]") -> tuple[list[str], str]:
+    """Parse the `(params, ret)` of the member matched by `dm` inside a single
+    `.d.ts` class body — the method (`name(p: T): R`) or property (`name: T`,
+    zero-arg) form. Shared by the single-decl extractor and the all-decls
+    conflict scan so both read the surface identically."""
+    if dm.group("kind") == "(":
+        arglist, after = _sig_balanced_parens(body, dm.end())
+        rm = re.match(r"\s*:\s*([^;{\n]+)", body[after:])
+        ret = rm.group(1).strip() if rm else "void"
+        params: list[str] = []
+        for p in _sig_split_params(arglist):
+            # `name: Type` / `name?: Type` — keep the Type half.
+            pm = re.match(r"\s*[A-Za-z_]\w*\s*\??\s*:\s*(.+)", p)
+            params.append(pm.group(1).strip() if pm else p.strip())
+        return params, ret
+    # Property form: a zero-arg accessor. The match ended on `?`/`:`; the
+    # type runs from the `:` to the line / statement terminator.
+    colon = body.index(":", dm.start())
+    rm = re.match(r"\s*([^;{\n]+)", body[colon + 1 :])
+    return [], (rm.group(1).strip() if rm else "void")
+
+
+def _sig_dts_all_decls(
+    dts: pathlib.Path, cls: str, method_camel: str
+) -> list[tuple[pathlib.Path, tuple[list[str], str]]]:
+    """EVERY `(source file, (params, ret))` declaration of `cls.method_camel`
+    across the public `.d.ts` surface, in precedence order (entry first). A TS
+    `declare module` interface→class augmentation MERGES with the generated
+    class declaration as OVERLOADS rather than replacing it, so a pinned member
+    can legitimately resolve to its entry-augmentation while a stale generated
+    overload of a different return still rides along in `index.d.ts`. Returning
+    all of them lets the gate enforce that the surviving public surface carries
+    no conflicting declaration."""
     decl_re = _ts_dts_member_decl_re(method_camel)
-    for body in _ts_dts_class_bodies(dts, cls):
+    out: list[tuple[pathlib.Path, tuple[list[str], str]]] = []
+    for src, body in _ts_dts_class_bodies_with_src(dts, cls):
         dm = decl_re.search(body)
-        if not dm:
+        if dm:
+            out.append((src, _sig_parse_dts_member(body, dm)))
+    return out
+
+
+def _sig_dts_conflicting_decls(
+    dts: pathlib.Path, cls: str, method_camel: str, spec: tuple[list[str], str]
+) -> list[tuple[pathlib.Path, tuple[list[str], str]]]:
+    """The SIBLING public-surface declarations of `cls.method_camel` that do NOT
+    satisfy `spec`. The precedence-winning declaration (index 0) is compared
+    against the spec by the caller, so it is skipped here; this catches a
+    drifting sibling — e.g. a generated `index.d.ts` overload still returning the
+    raw handle while the entry augmentation presents the wrapper. Because the two
+    merge as overloads, the raw one re-leaks even though the resolved type looks
+    correct, so any sibling that disagrees with the spec must fail the gate."""
+    spec_params, spec_ret = spec
+    bad: list[tuple[pathlib.Path, tuple[list[str], str]]] = []
+    for src, (params, ret) in _sig_dts_all_decls(dts, cls, method_camel)[1:]:
+        if len(params) != len(spec_params) or not all(
+            _sig_type_agrees(sp, ap, "ts_dts") for sp, ap in zip(spec_params, params)
+        ):
+            bad.append((src, (params, ret)))
             continue
-        if dm.group("kind") == "(":
-            arglist, after = _sig_balanced_parens(body, dm.end())
-            rm = re.match(r"\s*:\s*([^;{\n]+)", body[after:])
-            ret = rm.group(1).strip() if rm else "void"
-            params: list[str] = []
-            for p in _sig_split_params(arglist):
-                # `name: Type` / `name?: Type` — keep the Type half.
-                pm = re.match(r"\s*[A-Za-z_]\w*\s*\??\s*:\s*(.+)", p)
-                params.append(pm.group(1).strip() if pm else p.strip())
-            return params, ret
-        # Property form: a zero-arg accessor. The match ended on `?`/`:`; the
-        # type runs from the `:` to the line / statement terminator.
-        colon = body.index(":", dm.start())
-        rm = re.match(r"\s*([^;{\n]+)", body[colon + 1 :])
-        return [], (rm.group(1).strip() if rm else "void")
-    return None
+        if not _sig_type_agrees(spec_ret, _sig_unwrap_result(ret), "ts_dts"):
+            bad.append((src, (params, ret)))
+    return bad
 
 
 def _sig_dts_public_member_missing(dts: pathlib.Path, cls: str, method_camel: str) -> bool:
@@ -7240,6 +7300,25 @@ def _sig_check_method_signatures(
                 actual_dts = _sig_extract_ts_dts(ts_dts, ts_cls, ts_member)
                 if actual_dts is not None:
                     errors += _sig_compare_one(label, spec_dts, actual_dts, "ts_dts")
+                    # The precedence-winning declaration above is the resolved
+                    # public type, but a `declare module` augmentation MERGES
+                    # with the generated class declaration as overloads — so a
+                    # stale re-exported declaration of a different return rides
+                    # along and re-leaks. Every public-surface declaration must
+                    # satisfy the spec; report each one that drifts.
+                    for src, (p_act, r_act) in _sig_dts_conflicting_decls(
+                        ts_dts, ts_cls, ts_member, spec_dts
+                    ):
+                        errors.append(
+                            f"  {label}.ts_dts: conflicting public declaration in "
+                            f"`{src.name}` — `{ts_member}({', '.join(p_act)}): "
+                            f"{r_act}` does not satisfy `[method.signature]`. A "
+                            f"`.d.ts` augmentation merges with the generated "
+                            f"declaration as overloads, so this drifting "
+                            f"declaration re-exposes a non-client-facing return "
+                            f"alongside the intended one — the public surface "
+                            f"must carry a single consistent signature."
+                        )
                 elif _sig_dts_public_member_missing(ts_dts, ts_cls, ts_member):
                     # The class IS part of the public `.d.ts` surface but the
                     # member's declaration is gone — dropping a pinned public
@@ -11562,6 +11641,55 @@ def _run_selftest() -> int:
             got = _sig_extract_ts_dts(d / "entry.d.ts", "Config", "workerThreads")
             assert got == ([], "number | null"), got
 
+    def _case_sig_ts_dts_conflicting_overload() -> None:
+        """The package entry's `declare module` augmentation OVERRIDES the
+        re-exported generated declaration for precedence (the resolved type),
+        but the two MERGE as overloads — so a re-exported declaration that
+        drifts to a non-client-facing return must be reported as a conflict even
+        though the resolved type looks correct. Mirrors the `StreamView.batches`
+        leak: the entry presents `Promise<RecordBatchStream>` while a generated
+        `index.d.ts` overload returns the raw `Promise<RecordBatchStreamHandle>`."""
+        spec = (["BatchesOptions"], "RecordBatchStream")
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            entry = d / "entry.d.ts"
+            entry.write_text(
+                "export * from './index'\n"
+                "declare module './index' {\n"
+                "  interface StreamView {\n"
+                "    batches(options?: BatchesOptions): Promise<RecordBatchStream>;\n"
+                "  }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            # Drift case: the re-exported generated declaration still returns the
+            # raw handle. Precedence resolves to the wrapper, but the stale
+            # overload must trip the gate.
+            (d / "index.d.ts").write_text(
+                "export declare class StreamView {\n"
+                "  batches(options?: BatchesOptions | undefined | null): "
+                "Promise<RecordBatchStreamHandle>\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            # Precedence winner is the entry augmentation (the wrapper return).
+            assert _sig_extract_ts_dts(entry, "StreamView", "batches") == (
+                ["BatchesOptions"], "Promise<RecordBatchStream>"
+            )
+            conflicts = _sig_dts_conflicting_decls(entry, "StreamView", "batches", spec)
+            assert len(conflicts) == 1, conflicts
+            assert conflicts[0][0].name == "index.d.ts", conflicts
+            assert conflicts[0][1] == (
+                ["BatchesOptions | undefined | null"], "Promise<RecordBatchStreamHandle>"
+            ), conflicts
+            # FIX case: the generated declaration is suppressed (skip_typescript),
+            # so the augmentation is the SOLE declaration — no conflict.
+            (d / "index.d.ts").write_text(
+                "export declare class StreamView {\n  isStreaming(): boolean\n}\n",
+                encoding="utf-8",
+            )
+            assert _sig_dts_conflicting_decls(entry, "StreamView", "batches", spec) == []
+
     def _case_sig_ts_dts_absence_promotion() -> None:
         """A MISSING `.d.ts` declaration is an error when the class IS part of
         the public surface (a dropped public member), but degrades to
@@ -12069,6 +12197,7 @@ def _run_selftest() -> int:
     _case("sig extractor — TS .d.ts decl", _case_sig_extract_ts_dts)
     _case("sig extractor — TS .d.ts property + getter/static/Promise", _case_sig_extract_ts_dts_property_and_modifiers)
     _case("sig extractor — TS .d.ts follows export-* re-export", _case_sig_ts_dts_follows_reexport)
+    _case("sig gate — TS .d.ts conflicting merged overload fails", _case_sig_ts_dts_conflicting_overload)
     _case("sig gate — TS .d.ts absence promoted for public member", _case_sig_ts_dts_absence_promotion)
     _case("sig extractor — C++ in-class decl", _case_sig_extract_cpp)
     _case("sig extractor — Rust core impl fn", _case_sig_extract_rust)

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -2323,13 +2323,27 @@ NAME_ONLY_METHOD_ALLOWLIST: dict[tuple[str, str], str] = {
 # read-write PROPERTY, not a `def set_<name>(...)` method. pyo3 exposes a
 # `#[setter] fn set_x(value)` as the attribute `config.x = value`, and the
 # hand-written stub models it as the bare read-write annotation `x: T` — there
-# is no `set_x` declaration to extract. The MATCHING getter row (`x`) already
-# pins that property's type through the `.pyi` lane (return = T), which is the
-# same `T` this setter's param would check, so re-checking it off a synthetic
-# `set_x` is redundant and would false-fail on the (correctly) absent `set_x`.
-# So these rows DEGRADE in the `.pyi` lane to the pyo3-source `python` lane +
-# stubtest (which DO see the runtime `set_x` setter and its parameter). Every
-# entry's getter twin is `.pyi`-checked, so the property type stays pinned.
+# is no `set_x` declaration to extract. The MATCHING getter row (`x`) pins that
+# property's type through the `.pyi` lane (return = T), which is the same `T`
+# this setter's param would check, so re-checking it off a synthetic `set_x` is
+# redundant and would false-fail on the (correctly) absent `set_x`. So these
+# rows DEGRADE in the `.pyi` lane to the pyo3-source `python` lane + stubtest
+# (which DO see the runtime `set_x` setter and its parameter).
+#
+# The exemption is sound ONLY because every entry has a getter twin whose `.pyi`
+# property TYPE the `python_pyi` lane checks directly — verified per setter:
+#   setFlushMode        → `flushMode`           (Literal["batched", "immediate"])
+#   setWaitStrategy     → `waitStrategy`        (Literal[...] wait-strategy set)
+#   setWaitSpinIters    → `waitSpinIters`       (int)
+#   setWaitYieldIters   → `waitYieldIters`      (int)
+#   setWaitParkUs       → `waitParkUs`          (int)
+#   setConsumerCpu      → `consumerCpu`         (Optional[int])
+#   setReconnectPolicy  → `reconnectPolicy`     (str)
+#   setStreamingRingSize→ `streamingRingSize`   (int)  ← getter row added so the
+#       property type is checked; before it, `streaming_ring_size` had no pinned
+#       getter twin and a stub drift to a non-integer would have passed.
+#   setWorkerThreads    → `workerThreads`       (Optional[int])
+# `_case_sig_python_pyi_setter_property_degrade` asserts each twin is extracted.
 # A setter NOT listed here whose `set_<name>` is dropped from a fully-enumerated
 # stub class still fails (the absence-promotion rule), so this is an explicit,
 # bounded exemption — not a blanket "missing setter is fine".
@@ -6345,11 +6359,12 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "String": {
         "python": ("String", "&str"),
-        # The stub spells a string return / param as `str`; a Config knob that
-        # constrains the value set spells it as a `Literal["a", "b", ...]` of
-        # string members, which `_sig_canon_type` folds to `str` (the constraint
-        # is documentation, not a cross-binding type difference). So only `str`
-        # is enrolled here — the Literal folds to it.
+        # The stub spells a free string return / param as `str`. A Config knob
+        # that CONSTRAINS the value set spells it as a `Literal["a", "b", ...]`;
+        # that is NOT folded to `str` here — its row pins the exact value set via
+        # a `python_pyi_returns` Literal override (compared by value set in
+        # `_sig_type_agrees`). So a bare `String` spec accepts only `str`, and a
+        # Literal actual against a bare `String` fails closed (forcing the pin).
         "python_pyi": ("str",),
         "ts_napi": ("String", "&str"),
         "ts_dts": ("string",),
@@ -6730,26 +6745,44 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
 _PYI_STR_LITERAL_RE = re.compile(
     r"Literal\[\s*(?:\"[^\"]*\"|'[^']*')(?:\s*,\s*(?:\"[^\"]*\"|'[^']*'))*\s*\]"
 )
+# One quoted member inside a `Literal[...]` — double- or single-quoted.
+_PYI_LITERAL_MEMBER_RE = re.compile(r"\"([^\"]*)\"|'([^']*)'")
+
+
+def _sig_literal_value_set(spelling: str) -> frozenset[str] | None:
+    """The set of string members of a `.pyi` `Literal["a", "b", ...]`, or None
+    when `spelling` is not such a Literal. The set is order-insensitive —
+    `Literal["a", "b"]` and `Literal["b", "a"]` are the same Python type — so a
+    Literal spec and a Literal actual compare by VALUE SET, catching an added,
+    removed, or renamed member that a fold-to-`str` would hide."""
+    if not _PYI_STR_LITERAL_RE.fullmatch(spelling.strip()):
+        return None
+    return frozenset(d or s for d, s in _PYI_LITERAL_MEMBER_RE.findall(spelling))
 
 
 def _sig_canon_type(raw: str) -> str:
     """Fold a type spelling to its comparison form: drop Rust lifetimes
     (`&'static str` → `&str`), drop the napi prelude module path
-    (`napi::bindgen_prelude::BigInt` → `BigInt`), collapse a `.pyi`
-    `Literal["a", "b"]` of string members to `str`, then whitespace-fold. The
+    (`napi::bindgen_prelude::BigInt` → `BigInt`), then whitespace-fold. The
     lifetime / napi-path qualifiers are surface noise the binding adds, never a
-    cross-binding type difference; a stub `Literal[...]` of string members
-    (the Config knob value sets — `flush_mode: Literal["batched",
-    "immediate"]`) is a documentation constraint over the underlying `str`,
-    not a distinct cross-binding type, so it folds to `str` and agrees with a
-    `String` spec."""
-    # Fold a string `Literal[...]` to `str` BEFORE the lifetime strip — the
-    # lifetime pattern (`'\w+`) would otherwise consume a single-quoted member
-    # (`Literal['a', 'b']`) and corrupt the spelling.
-    s = _PYI_STR_LITERAL_RE.sub("str", raw.strip())
-    s = re.sub(r"'\w+\s*", "", s)
-    s = re.sub(r"\bnapi::bindgen_prelude::", "", s)
-    return re.sub(r"\s+", "", s)
+    cross-binding type difference.
+
+    A `.pyi` `Literal["a", "b"]` is NOT folded to `str`: a constrained Config
+    knob (`flush_mode: Literal["batched", "immediate"]`) carries an exact value
+    set that is part of the client-facing contract, and folding it would hide a
+    value-set drift (adding / removing / renaming a member). Such rows pin the
+    Literal directly via a `python_pyi_returns` override, and `_sig_type_agrees`
+    compares the two Literals by value set. The whitespace-fold below still
+    normalises spacing inside the `Literal[...]`, so `Literal["a","b"]` and
+    `Literal["a", "b"]` canonicalise identically."""
+    # Strip the lifetime pattern with the Literal members masked out, so a
+    # single-quoted member (`Literal['a', 'b']`) is never consumed by the
+    # lifetime regex (`'\w+`) and corrupted.
+    s = raw.strip()
+    masked = _PYI_STR_LITERAL_RE.sub(lambda m: m.group(0).replace("'", '"'), s)
+    masked = re.sub(r"'\w+\s*", "", masked)
+    masked = re.sub(r"\bnapi::bindgen_prelude::", "", masked)
+    return re.sub(r"\s+", "", masked)
 
 
 def _sig_unwrap_result(spelling: str) -> str:
@@ -6823,6 +6856,15 @@ def _sig_type_agrees(canonical: str, actual: str, lang: str) -> bool:
     name, or an `actual` outside the cell, fails closed so an unmapped
     divergence can never silently pass.
     """
+    # A `Literal["a", "b", ...]` canonical (a `python_pyi_returns` override on a
+    # value-constrained Config knob) pins the EXACT value set: the actual stub
+    # type must be a Literal over the same members (order-insensitive). A drift
+    # that adds, removes, or renames a member fails — the coverage the old
+    # fold-to-`str` discarded. A non-Literal actual (the stub widened the knob
+    # to a bare `str`) fails too: the constraint is part of the contract.
+    spec_set = _sig_literal_value_set(canonical)
+    if spec_set is not None:
+        return _sig_literal_value_set(actual) == spec_set
     cm = re.fullmatch(r"Option\s*<\s*(.+)\s*>", canonical.strip())
     if cm:
         unwrapped = _sig_option_inner(actual, lang)
@@ -12254,15 +12296,30 @@ def _run_selftest() -> int:
 
     def _case_sig_python_pyi_type_map_and_literal() -> None:
         """The `python_pyi` type map agrees on the stub spellings and a
-        representable drift fails. A string `Literal[...]` folds to `str` (so a
-        `String` spec accepts a constrained Config knob); an `Optional[T]` /
+        representable drift fails. A `Literal["a", "b"]` canonical (a
+        `python_pyi_returns` override on a value-constrained Config knob) pins
+        the EXACT value set — order-insensitive — so an added / removed /
+        renamed member, or a widen to bare `str`, fails. An `Optional[T]` /
         `T | None` satisfies an `Option<T>` spec while the bare required form
         does NOT (optionality drift is visible)."""
         # Integer widths all read `int`; a non-integer drift fails.
         assert _sig_type_agrees("usize", "int", "python_pyi")
         assert not _sig_type_agrees("usize", "str", "python_pyi")
-        # `Literal["a", "b"]` of string members folds to `str`.
-        assert _sig_type_agrees("String", 'Literal["batched", "immediate"]', "python_pyi")
+        # A `Literal[...]` canonical compares by EXACT value set (the fold to
+        # `str` is gone): identity and reordering pass; add / remove / rename a
+        # member fails; widening to bare `str` fails. This is the FINDING-9 win.
+        lit = 'Literal["batched", "immediate"]'
+        assert _sig_type_agrees(lit, 'Literal["batched", "immediate"]', "python_pyi")
+        assert _sig_type_agrees(lit, 'Literal["immediate", "batched"]', "python_pyi")  # order-insensitive
+        assert not _sig_type_agrees(lit, 'Literal["batched", "immediate", "x"]', "python_pyi")  # added
+        assert not _sig_type_agrees(lit, 'Literal["batched"]', "python_pyi")  # removed
+        assert not _sig_type_agrees(lit, 'Literal["batched", "flush"]', "python_pyi")  # renamed
+        assert not _sig_type_agrees(lit, "str", "python_pyi")  # widened to bare str
+        # Single-quoted members canonicalise identically to double-quoted.
+        assert _sig_type_agrees("Literal['PROD', 'STAGE']", 'Literal["PROD", "STAGE"]', "python_pyi")
+        # A bare `String` spec no longer silently accepts a Literal actual (the
+        # fold is removed) — a genuine `str` property still passes.
+        assert not _sig_type_agrees("String", 'Literal["batched", "immediate"]', "python_pyi")
         assert _sig_type_agrees("String", "str", "python_pyi")
         assert not _sig_type_agrees("String", "int", "python_pyi")
         # Optionality: both `Optional[T]` and PEP 604 `T | None` satisfy the
@@ -12274,6 +12331,68 @@ def _run_selftest() -> int:
         # The wrapper return the stub presents (the coverage stubtest lacks).
         assert _sig_type_agrees("RecordBatchStream", "RecordBatchStream", "python_pyi")
         assert not _sig_type_agrees("RecordBatchStream", "Any", "python_pyi")
+
+    def _case_sig_python_pyi_literal_value_set_drift() -> None:
+        """FINDING-9 probe end-to-end: a `python_pyi_returns` Literal override
+        pins the EXACT value set through the orchestrator. The correct set
+        passes; adding, removing, or changing one member of the `.pyi` property
+        FAILS the `python_pyi` lane (while ts / cpp keep checking the canonical
+        `String`). Drives the real `_sig_check_method_signatures`."""
+        def _row():
+            return [{"class": "Config", "name": "flushMode", "python": True,
+                     "signature": {"returns": "String",
+                                   "python_pyi_returns": 'Literal["batched", "immediate"]'}}]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            py = root / "py"; py.mkdir()
+            # pyo3 getter returns `&str` (the `python` lane stays clean).
+            (py / "m.rs").write_text(
+                "#[pymethods]\nimpl Config {\n"
+                "    #[getter] fn flush_mode(&self) -> &str { \"batched\" }\n}\n",
+                encoding="utf-8",
+            )
+            pyi = root / "__init__.pyi"
+            paths = dict(py_src=py, pyi_path=pyi, ts_src=root / "none_ts",
+                         ts_dts=root / "none.d.ts", cpp_hpp=root / "none.hpp",
+                         client_rs=root / "none.rs", ffi_src=root / "none_ffi")
+            # Correct value set → silent.
+            pyi.write_text(
+                'class Config:\n    flush_mode: Literal["batched", "immediate"]\n',
+                encoding="utf-8",
+            )
+            assert _sig_check_method_signatures(_row(), **paths) == [], \
+                _sig_check_method_signatures(_row(), **paths)
+            # Reordered set still passes (order-insensitive).
+            pyi.write_text(
+                'class Config:\n    flush_mode: Literal["immediate", "batched"]\n',
+                encoding="utf-8",
+            )
+            assert _sig_check_method_signatures(_row(), **paths) == [], \
+                _sig_check_method_signatures(_row(), **paths)
+            # ADD a member → return mismatch on the `python_pyi` lane.
+            pyi.write_text(
+                'class Config:\n    flush_mode: Literal["batched", "immediate", "bogus"]\n',
+                encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "return mismatch" in e for e in errs), errs
+            # REMOVE a member → fails.
+            pyi.write_text(
+                'class Config:\n    flush_mode: Literal["batched"]\n', encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "return mismatch" in e for e in errs), errs
+            # CHANGE a member value → fails.
+            pyi.write_text(
+                'class Config:\n    flush_mode: Literal["batched", "flush"]\n',
+                encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "return mismatch" in e for e in errs), errs
+            # WIDEN to bare `str` (drop the constraint) → fails.
+            pyi.write_text("class Config:\n    flush_mode: str\n", encoding="utf-8")
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "return mismatch" in e for e in errs), errs
 
     def _case_sig_python_pyi_lane_drifts_and_presence() -> None:
         """The orchestrator's `.pyi` lane: a return drift, a param drift, an
@@ -12382,6 +12501,39 @@ def _run_selftest() -> int:
         assert _sig_extract_python_pyi(PY_PYI, "Config", "flush_mode") == (
             [], 'Literal["batched", "immediate"]'
         ), _sig_extract_python_pyi(PY_PYI, "Config", "flush_mode")
+        # FINDING-8 closure: the exemption is sound ONLY if EVERY exempt setter
+        # has a getter twin whose `.pyi` property type the `python_pyi` lane
+        # checks. Resolve each setter's twin from the real spec and assert (a) a
+        # checked getter `[[method]]` row exists for it and (b) the stub declares
+        # the property — so no exempt setter rides on an unchecked property.
+        # `setStreamingRingSize` → `streamingRingSize` was the gap this closes.
+        setter_to_getter = {
+            "setFlushMode": ("flushMode", "flush_mode"),
+            "setWaitStrategy": ("waitStrategy", "wait_strategy"),
+            "setWaitSpinIters": ("waitSpinIters", "wait_spin_iters"),
+            "setWaitYieldIters": ("waitYieldIters", "wait_yield_iters"),
+            "setWaitParkUs": ("waitParkUs", "wait_park_us"),
+            "setConsumerCpu": ("consumerCpu", "consumer_cpu"),
+            "setReconnectPolicy": ("reconnectPolicy", "reconnect_policy"),
+            "setStreamingRingSize": ("streamingRingSize", "streaming_ring_size"),
+            "setWorkerThreads": ("workerThreads", "worker_threads"),
+        }
+        assert {("Config", s) for s in setter_to_getter} == PYI_SETTER_PROPERTY_ROWS, (
+            "the setter→getter twin table must cover exactly the exempt setters"
+        )
+        getter_rows = {
+            (r.get("class"), r.get("name")): r for r in data.get("method", [])
+        }
+        for setter, (getter, prop) in setter_to_getter.items():
+            row = getter_rows.get(("Config", getter))
+            assert row is not None and row.get("python") and "signature" in row, (
+                f"{setter}'s twin getter `{getter}` must be a python-checked "
+                f"`[[method]]` row so its property type is pinned"
+            )
+            assert _sig_extract_python_pyi(PY_PYI, "Config", prop) is not None, (
+                f"the stub must declare the `{prop}` property the `{getter}` "
+                f"getter row pins"
+            )
 
     def _case_sig_extract_cpp() -> None:
         """C++ extractor reads the in-class decl, return type bounded by the
@@ -12883,7 +13035,8 @@ def _run_selftest() -> int:
     _case("sig gate — TS .d.ts pinned surface forms all parse + drift fails", _case_sig_ts_dts_surface_forms)
     _case("sig gate — TS .d.ts absence promoted for public member", _case_sig_ts_dts_absence_promotion)
     _case("sig extractor — Python .pyi stub declaration forms", _case_sig_extract_python_pyi_forms)
-    _case("sig type-map — python_pyi spellings + Literal/Optional folds", _case_sig_python_pyi_type_map_and_literal)
+    _case("sig type-map — python_pyi spellings + Literal exact value set", _case_sig_python_pyi_type_map_and_literal)
+    _case("sig gate — python_pyi Literal value-set drift (add/remove/change) fails", _case_sig_python_pyi_literal_value_set_drift)
     _case("sig gate — Python .pyi lane drifts fail + presence degrades", _case_sig_python_pyi_lane_drifts_and_presence)
     _case("sig gate — Python .pyi setter-property rows degrade, getter checked", _case_sig_python_pyi_setter_property_degrade)
     _case("sig extractor — C++ in-class decl", _case_sig_extract_cpp)

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -2299,6 +2299,23 @@ METHOD_BINDING_OVERRIDES: dict[tuple[str, str], dict[str, tuple[str, str]]] = {
 }
 
 
+# `[[method]]` rows that carry NO `[method.signature]` by design: their
+# per-binding shapes are structurally divergent binding machinery with no
+# comparable cross-binding signature to pin. Every other `[[method]]` row MUST
+# carry a `[method.signature]` (the gate fails closed for any name-only row
+# absent from this set), so a NEW row can never be silently name-only — it is
+# either pinned or it is enrolled here with a stated reason.
+NAME_ONLY_METHOD_ALLOWLIST: dict[tuple[str, str], str] = {
+    ("Config", "setReconnectCallback"): (
+        "Reconnect-callback registration is structurally divergent per binding "
+        "with no comparable signature: Python takes an optional callable, the "
+        "napi side a five-type-argument ThreadsafeFunction, C++ a C function "
+        "pointer plus a void* userdata (two params, not one). There is no "
+        "cross-binding param/return contract to pin."
+    ),
+}
+
+
 # Parity-toml `class` field → the Rust struct the Rust method collector
 # keys on. The flat-file namespace is the borrowed `FlatFiles` view
 # returned by `Client::flat_files()`; the unified entry-point client is
@@ -6210,19 +6227,31 @@ def _check_request_options_types(
 # cross-check) are distinct columns over the one TypeScript binding.
 SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # canonical Rust type → {signature-lang: (accepted spelling, ...)}.
+    # `usize` is platform-width. Its C++ / C-ABI cells accept ONLY the
+    # platform-width spellings (`size_t` / `usize`), never the fixed-width
+    # `uint64_t` / `u64` — those belong to `u64` below, and accepting them
+    # here would let a `usize` row that drifts to a fixed-width return pass.
+    # A binding that DELIBERATELY widens `usize` to a fixed-width boundary
+    # type (the C ABI is fixed-width by design; C++ mirrors the ABI it wraps)
+    # pins `u64` for that lang via a per-row `<lang>_returns` override, not a
+    # loose cell here.
     "usize": {
         "python": ("usize",),
         "ts_napi": ("f64", "BigInt", "u32", "i64"),
         "ts_dts": ("number", "bigint"),
-        "cpp": ("size_t", "std::size_t", "uint64_t"),
+        "cpp": ("size_t", "std::size_t"),
         "rust": ("usize",),
-        "ffi": ("usize", "u64", "size_t"),
+        "ffi": ("usize", "size_t"),
     },
+    # `u64` is fixed-width. Its C++ / C-ABI cells accept ONLY the fixed-width
+    # spellings (`uint64_t` / `u64`), never the platform-width `size_t` /
+    # `usize` — those belong to `usize` above. Zero overlap with `usize` so a
+    # `u64` row that drifts to a platform-width return fails closed.
     "u64": {
         "python": ("u64",),
         "ts_napi": ("BigInt", "f64"),
         "ts_dts": ("bigint", "number"),
-        "cpp": ("uint64_t", "size_t"),
+        "cpp": ("uint64_t", "std::uint64_t"),
         "rust": ("u64",),
         "ffi": ("u64", "uint64_t"),
     },
@@ -6294,12 +6323,36 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     "Contract": {
         "python": ("PyContract",),
         "ts_napi": ("ContractRef",),
-        "ts_dts": ("Contract",),
+        # The napi `.d.ts` spells the fluent contract `ContractRef` (the
+        # `Contract` symbol is the streaming event-payload class); the wrapper
+        # re-exports `Contract = ContractRef`, so both names denote the surface.
+        "ts_dts": ("Contract", "ContractRef"),
     },
     "SecType": {
         "python": ("PySecType",),
         "ts_napi": ("SecType",),
         "ts_dts": ("SecType",),
+    },
+    # The flat-file request dispatcher's typed enum params on the Rust core
+    # only: `FlatFiles::request(SecType, ReqType, &str)`. The managed bindings
+    # pass plain Strings (no typed-enum twin), so these carry a `rust` cell
+    # alone — used by the `rust_params` override on the `request` row.
+    "FlatFileSecType": {
+        "rust": ("crate::flatfiles::SecType", "SecType"),
+    },
+    "FlatFileReqType": {
+        "rust": ("crate::flatfiles::ReqType", "ReqType"),
+    },
+    # The wire-format selector on `flatFileToPath`'s last param: a String on the
+    # managed bindings (the format name, optional on Python / TypeScript), the
+    # typed `FlatFileFormat` enum on the Rust core. Per-lang param override only.
+    "FlatFileFormat": {
+        "rust": ("crate::flatfiles::FlatFileFormat", "FlatFileFormat"),
+    },
+    # The destination-path param on `flatFileToPath` (the Rust core takes an
+    # `impl AsRef<Path>`; the managed / C++ bindings take their String spelling).
+    "DestPath": {
+        "rust": ("impl AsRef<std::path::Path>", "impl AsRef<Path>"),
     },
     # C++-only typed enums on `FluentSubscription`: the full/per-contract
     # `scope()` discriminant the managed bindings model as the `isFull` bool
@@ -6341,6 +6394,16 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     "Callback": {
         "python": ("Py<PyAny>", "PyObject"),
         "cpp": ("std::function<void(const StreamEvent&)>",),
+        # The `.d.ts` per-event handler type. napi-rs generates the parameter
+        # name `arg`; the cross-binding contract is the `StreamEvent` payload
+        # shape, so a drift to a different event type still fails closed. The
+        # hand-written `streaming(...)` wrapper names the same type via its
+        # `StreamEventCallback` alias.
+        "ts_dts": (
+            "((arg: StreamEvent) => void)",
+            "(arg: StreamEvent) => void",
+            "StreamEventCallback",
+        ),
     },
     # The optional batch-reader tuning bag on `StreamView.batches`. The managed
     # bindings pass a single options object (the napi / `.d.ts` `BatchesOptions`
@@ -6407,6 +6470,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     "Credentials": {
         "python": ("Self", "PyResult<Self>", "Credentials", "PyResult<Credentials>"),
         "ts_napi": ("Credentials", "napi::Result<Credentials>"),
+        "ts_dts": ("Credentials",),
         "cpp": ("Credentials",),
     },
     # The per-contract active-subscription snapshot. Each binding returns its
@@ -6448,6 +6512,109 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
         "ts_dts": ("Promise<RecordBatchStream>", "RecordBatchStream"),
         "cpp": ("std::shared_ptr<RecordBatchStream>",),
     },
+    # The three `Client` data-plane VIEW accessors. Each is a zero-arg getter
+    # whose RETURN TYPE is the cross-binding contract — the view the binding
+    # hands back. The type name differs per binding (the managed bindings name
+    # the view directly; the Rust core returns a borrowed view), so each is a
+    # per-binding cell. A drop / rename of the returned view on any binding
+    # trips the gate.
+    "HistoricalView": {
+        "python": ("HistoricalView",),
+        "ts_napi": ("HistoricalView",),
+        "ts_dts": ("HistoricalView",),
+        "cpp": ("Historical",),
+        "rust": ("&HistoricalClient",),
+    },
+    "StreamView": {
+        "python": ("StreamView",),
+        "ts_napi": ("StreamView",),
+        "ts_dts": ("StreamView",),
+        "cpp": ("Stream",),
+        "rust": ("StreamSurface<>",),
+    },
+    "FlatFilesNamespace": {
+        "python": ("FlatFilesNamespace",),
+        "ts_napi": ("FlatFilesNamespace",),
+        "ts_dts": ("FlatFilesNamespace",),
+        "cpp": ("FlatFiles",),
+        "rust": ("FlatFiles<>",),
+    },
+    # The fluent client builder returned by `Client::builder()`. C++ + Rust
+    # only (the managed bindings reach the same surface through the inline
+    # constructor / options-object factory, not a builder), so no managed cell.
+    "ClientBuilder": {
+        "cpp": ("ClientBuilder",),
+        "rust": ("crate::client_builder::ClientBuilder", "ClientBuilder"),
+    },
+    # The decoded flat-file row collection returned by the `FlatFilesNamespace`
+    # fetch methods. The managed bindings return the `FlatFileRowList` value
+    # object (wrapped in the binding's fallible result, unwrapped before the
+    # compare); the Rust core returns the owned `Vec<FlatFileRow>`.
+    "FlatFileRowList": {
+        "python": ("FlatFileRowList",),
+        "ts_napi": ("FlatFileRowList",),
+        "ts_dts": ("FlatFileRowList",),
+        "cpp": ("FlatFileRowList",),
+        "rust": ("Vec<crate::flatfiles::FlatFileRow>", "Vec<FlatFileRow>"),
+    },
+    # The built fluent subscription returned by the per-contract / full-stream
+    # builders (`Contract.quote()`, `SecType.fullTrades()`). Each binding hands
+    # back its own subscription value object. Distinct from the `Subscription`
+    # PARAM canonical (the handle passed to subscribe), which carries the
+    # by-reference spellings — this is the by-value return shape.
+    "BuiltSubscription": {
+        "python": ("PySubscription",),
+        "ts_napi": ("Subscription",),
+        "ts_dts": ("Subscription",),
+        "cpp": ("FluentSubscription",),
+    },
+    # The `flatFileToPath` blob-to-disk return. The managed bindings hand back
+    # the written path as a String; C++ writes in place and returns `void`; the
+    # Rust core returns the owned `PathBuf`.
+    "WrittenPath": {
+        "python": ("String",),
+        "ts_napi": ("String",),
+        "ts_dts": ("string",),
+        "cpp": ("void",),
+        "rust": ("std::path::PathBuf", "PathBuf"),
+    },
+    # The context-managed streaming session returned by `Client.streaming`.
+    # Python hands back the `StreamingSession` pyclass (`Py<StreamingSession>`,
+    # the `PyResult` unwrapped before the compare); the hand-written `.d.ts`
+    # wrapper returns the `StreamingSession` interface. The napi layer has no
+    # `fn` (the session is a JS wrapper), so the row skips `ts_napi`.
+    "StreamingSession": {
+        "python": ("Py<StreamingSession>", "StreamingSession"),
+        "ts_dts": ("StreamingSession",),
+    },
+    # The inline-construction options object + its `Client` return on the
+    # TypeScript `connectWith` factory (TypeScript-only — Python uses the
+    # constructor kwargs, Rust / C++ the fluent builder).
+    "ClientConnectOptions": {
+        "ts_napi": ("ClientConnectOptions",),
+        "ts_dts": ("ClientConnectOptions",),
+    },
+    "Client": {
+        "ts_napi": ("Client",),
+        "ts_dts": ("Client",),
+    },
+    # The active-subscription snapshot returned by `Client.subscriptionInfo`
+    # (Python + Rust only). Python materialises it as a `Vec<(root, kind)>`
+    # tuple list; the Rust core returns the opaque `SubscriptionInfo` struct.
+    "SubscriptionInfo": {
+        "python": ("Vec<(String, String)>", "Vec<(String,String)>"),
+        "rust": ("SubscriptionInfo",),
+    },
+    # A `Config` factory return (the env-tier presets `production` / `dev` /
+    # `stage`, the `fromDotenv` loader). Python / TypeScript spell it `Self`
+    # (the pyo3 / napi constructor return), the napi `.d.ts` resolves the
+    # `Self` to the concrete `Config`, C++ the value type `Config`.
+    "Config": {
+        "python": ("Self", "Config"),
+        "ts_napi": ("Self", "Config"),
+        "ts_dts": ("Config",),
+        "cpp": ("Config",),
+    },
 }
 
 
@@ -6470,11 +6637,24 @@ def _sig_unwrap_result(spelling: str) -> str:
     the binding spells the path. Fallibility is a per-binding surface property
     (pyo3 `PyResult`, a thrown napi error), not a cross-binding return-type
     difference the signature gate pins. A non-wrapped spelling is returned
-    unchanged."""
-    m = re.fullmatch(
-        r"(?:[A-Za-z_][\w:]*::)?(?:Py)?Result\s*<\s*(.+)\s*>", spelling.strip()
-    )
-    return m.group(1).strip() if m else spelling.strip()
+    unchanged.
+
+    A `.d.ts` async method returns `Promise<T>`; the promise is the TypeScript
+    fallible/async wrapper (the same role `napi::Result` plays on the napi
+    side), so it is unwrapped too — the awaited `T` is the cross-binding
+    return contract, not the promise envelope."""
+    s = spelling.strip()
+    pm = re.fullmatch(r"Promise\s*<\s*(.+)\s*>", s)
+    if pm:
+        s = pm.group(1).strip()
+    m = re.fullmatch(r"(?:[A-Za-z_][\w:]*::)?(?:Py)?Result\s*<\s*(.+)\s*>", s)
+    if not m:
+        return s
+    inner = m.group(1).strip()
+    # A Rust `Result<T, E>` carries the error arm explicitly; the cross-binding
+    # contract is the ok type `T`, so drop a trailing `, E` at top level (commas
+    # inside `T`'s own generics are not split — depth-aware).
+    return _sig_split_params(inner)[0].strip()
 
 
 def _sig_option_inner(spelling: str, lang: str) -> str | None:
@@ -6492,7 +6672,10 @@ def _sig_option_inner(spelling: str, lang: str) -> str | None:
         if m:
             return m.group(1).strip()
     elif lang == "ts_dts":
-        m = re.fullmatch(r"(.+?)\s*\|\s*null", s)
+        # `.d.ts` optionals are `T | null`, and napi-rs emits a nullable PARAM
+        # as `T | undefined | null` (either union order). Strip the trailing
+        # `| null` / `| undefined` members to recover the inner `T`.
+        m = re.fullmatch(r"(.+?)\s*(?:\|\s*(?:null|undefined)\s*)+", s)
         if m:
             return m.group(1).strip()
     return None
@@ -6588,12 +6771,22 @@ def _sig_rust_param_type(param: str) -> str:
 
 def _sig_is_rust_receiver(param: str) -> bool:
     """True for a `self` receiver or a `py: Python<...>` GIL token — neither is
-    a cross-binding parameter, so both are stripped before the type compare."""
+    a cross-binding parameter, so both are stripped before the type compare.
+
+    pyo3 also spells the receiver by VALUE as the bound-instance smart pointers
+    `Py<Self>` / `PyRef<'_, Self>` / `PyRefMut<'_, Self>` / `Bound<'_, Self>`
+    (a `#[pymethods] fn streaming(slf: Py<Self>, ...)`), which carry the
+    instance the same way `&self` does — they are receivers, not cross-binding
+    params, so they are stripped too."""
     s = param.strip()
     if s in ("self", "&self", "&mut self") or s.startswith(("&self", "&mut self", "self")):
         return True
-    if ":" in s and re.search(r"\bPython\b", s.split(":", 1)[1]):
-        return True
+    if ":" in s:
+        ty = s.split(":", 1)[1]
+        if re.search(r"\bPython\b", ty):
+            return True
+        if re.search(r"\b(?:Py|PyRef|PyRefMut|Bound)\s*<[^>]*\bSelf\b", ty):
+            return True
     return False
 
 
@@ -6671,33 +6864,110 @@ def _sig_extract_ts_napi(ts_src: pathlib.Path, cls: str, method_camel: str) -> t
     return None
 
 
-def _sig_extract_ts_dts(dts: pathlib.Path, cls: str, method_camel: str) -> tuple[list[str], str] | None:
-    """TypeScript `.d.ts` signature (secondary cross-check): the
-    `methodCamel(<params>): <ret>` declaration inside `class cls` /
-    `interface cls`. Returns None when the `.d.ts` is absent or the class /
-    method is not found, so the check degrades to napi-only rather than
-    failing — the napi Rust fn is the authority."""
+def _ts_dts_files(dts: pathlib.Path) -> list[pathlib.Path]:
+    """The package `.d.ts` entry plus every sibling it re-exports with
+    `export * from './X'`. The published entry (`streaming-session.d.ts`)
+    layers its augmentations on top of the napi-generated `index.d.ts` via
+    `export * from './index'`, so the public type surface a consumer imports
+    is the UNION of both — the gate must read both to see a method the napi
+    layer declares but the wrapper does not redeclare."""
     if not dts.is_file():
-        return None
+        return []
+    out = [dts]
+    seen = {dts.resolve()}
     text = _read_source(dts)
+    for rel in re.findall(r"""export\s+\*\s+from\s+['"](\.[^'"]+)['"]""", text):
+        cand = (dts.parent / rel).with_suffix(".d.ts")
+        if cand.is_file() and cand.resolve() not in seen:
+            out.append(cand)
+            seen.add(cand.resolve())
+    return out
+
+
+def _ts_dts_class_bodies(dts: pathlib.Path, cls: str) -> list[str]:
+    """Every `class cls` / `interface cls` body across the public `.d.ts`
+    surface (entry + re-exported siblings). A class can appear more than once
+    — the napi `index.d.ts` declaration plus a `declare module` augmentation
+    in the wrapper — so all bodies are returned and the member is looked up in
+    each."""
+    bodies: list[str] = []
     cls_re = re.compile(r"\b(?:class|interface)\s+" + re.escape(cls) + r"\b[^{]*\{")
-    m = cls_re.search(text)
-    if not m:
-        return None
-    body = _balanced_body(text, m.end())
-    decl_re = re.compile(r"\b" + re.escape(method_camel) + r"\s*\(")
-    dm = decl_re.search(body)
-    if not dm:
-        return None
-    arglist, after = _sig_balanced_parens(body, dm.end())
-    rm = re.match(r"\s*:\s*([^;{\n]+)", body[after:])
-    ret = rm.group(1).strip() if rm else "void"
-    params: list[str] = []
-    for p in _sig_split_params(arglist):
-        # `name: Type` / `name?: Type` — keep the Type half.
-        pm = re.match(r"\s*[A-Za-z_]\w*\s*\??\s*:\s*(.+)", p)
-        params.append(pm.group(1).strip() if pm else p.strip())
-    return params, ret
+    for f in _ts_dts_files(dts):
+        text = _read_source(f)
+        for m in cls_re.finditer(text):
+            bodies.append(_balanced_body(text, m.end()))
+    return bodies
+
+
+# A member declaration in DECLARATION position inside a `.d.ts` class body:
+# line-leading (after any leading modifiers), never a member-access
+# (`foo.method`). The napi `index.d.ts` separates members by newline (no `;`),
+# the hand-written augmentations by `;`, so the anchor is line-start under
+# MULTILINE rather than a fixed terminator char. The modifier prefix covers
+# every shape napi-rs / the augmentations emit: `static` factories
+# (`static fromFile(...)`), `get`/`set` accessors (`get kind(): string` — the
+# napi `#[getter]` form), and `readonly` properties. The char right after the
+# name picks the form: `(` → method (a `get`/`set` accessor reads as a zero-arg
+# method, which is the correct property shape), `?`/`:` → bare property.
+def _ts_dts_member_decl_re(method_camel: str) -> re.Pattern[str]:
+    return re.compile(
+        r"(?m)^\s*(?:(?:static|readonly|get|set|public|abstract|declare)\s+)*"
+        + re.escape(method_camel)
+        + r"\s*(?P<kind>[(?:])"
+    )
+
+
+def _sig_extract_ts_dts(dts: pathlib.Path, cls: str, method_camel: str) -> tuple[list[str], str] | None:
+    """TypeScript `.d.ts` signature: the member named `method_camel` inside
+    `class cls` / `interface cls`, anywhere across the public `.d.ts` surface
+    (the package entry plus the `index.d.ts` it re-exports), in either form —
+
+      * a method call:    `methodCamel(<params>): <ret>` → those params + ret,
+      * a property:       `[readonly] methodCamel: <Type>` → a zero-arg
+        signature returning `<Type>` (the columnar reader's `readonly schema`
+        / `readonly dropped` accessors are properties, not `fn`s).
+
+    Returns None when the `.d.ts` is absent or the class / member is not
+    found. Absence is NOT silently a pass: `_sig_dts_public_member_missing`
+    promotes a missing declaration to an error for a row whose member IS part
+    of the public `.d.ts` surface, so dropping a declaration fails the gate;
+    only a member genuinely absent from the public `.d.ts` (a napi-only
+    streaming row whose `.d.ts` shape is not redeclared) degrades to
+    napi-as-authority."""
+    decl_re = _ts_dts_member_decl_re(method_camel)
+    for body in _ts_dts_class_bodies(dts, cls):
+        dm = decl_re.search(body)
+        if not dm:
+            continue
+        if dm.group("kind") == "(":
+            arglist, after = _sig_balanced_parens(body, dm.end())
+            rm = re.match(r"\s*:\s*([^;{\n]+)", body[after:])
+            ret = rm.group(1).strip() if rm else "void"
+            params: list[str] = []
+            for p in _sig_split_params(arglist):
+                # `name: Type` / `name?: Type` — keep the Type half.
+                pm = re.match(r"\s*[A-Za-z_]\w*\s*\??\s*:\s*(.+)", p)
+                params.append(pm.group(1).strip() if pm else p.strip())
+            return params, ret
+        # Property form: a zero-arg accessor. The match ended on `?`/`:`; the
+        # type runs from the `:` to the line / statement terminator.
+        colon = body.index(":", dm.start())
+        rm = re.match(r"\s*([^;{\n]+)", body[colon + 1 :])
+        return [], (rm.group(1).strip() if rm else "void")
+    return None
+
+
+def _sig_dts_public_member_missing(dts: pathlib.Path, cls: str, method_camel: str) -> bool:
+    """Is `cls.method_camel` part of the public `.d.ts` surface yet missing
+    its declaration? True only when the CLASS is declared somewhere in the
+    public surface but the MEMBER is not — i.e. a member that belongs in the
+    `.d.ts` was dropped. False when the class itself is absent (a row that is
+    legitimately napi-only at the `.d.ts` level — its class is not part of the
+    declared surface, so there is nothing to drop and the check degrades to
+    napi-as-authority)."""
+    return bool(_ts_dts_class_bodies(dts, cls)) and (
+        _sig_extract_ts_dts(dts, cls, method_camel) is None
+    )
 
 
 def _sig_extract_cpp(hpp: pathlib.Path, cls: str, method: str) -> tuple[list[str], str] | None:
@@ -6897,12 +7167,13 @@ def _sig_check_method_signatures(
     client_rs: pathlib.Path,
     ffi_src: pathlib.Path,
 ) -> list[str]:
-    """Signature-level gate for `[[method]]` rows carrying a `[method.signature]`
-    sub-table (opt-in). For each such row, extract every enrolled binding's
-    declared signature and verify it satisfies the spec through the TYPE_MAP +
-    per-binding overrides. A row WITHOUT a `[method.signature]` is skipped, so
-    this is a no-op on the un-enrolled surface — the name-only check is
-    unchanged for every existing row.
+    """Signature-level gate for `[[method]]` rows. FAIL-CLOSED enrollment: every
+    `[[method]]` row MUST carry a `[method.signature]` sub-table OR a
+    `NAME_ONLY_METHOD_ALLOWLIST` entry — a row with neither fails the gate, so a
+    new row can never be silently name-only (its signature drift would otherwise
+    hide while the gate stays green). For each row WITH a sub-table, extract
+    every enrolled binding's declared signature and verify it satisfies the spec
+    through the TYPE_MAP + per-binding overrides.
 
     A row's enrolled signature-langs are derived from its presence booleans
     (`python` → python, `typescript` → ts_napi + ts_dts, `cpp` → cpp, `rust`
@@ -6914,11 +7185,24 @@ def _sig_check_method_signatures(
     """
     errors: list[str] = []
     for row in method_rows:
-        signature = row.get("signature")
-        if not signature:
-            continue
         class_name = row.get("class")
         camel = row.get("name")
+        signature = row.get("signature")
+        if not signature:
+            # Fail-closed: a name-only row is allowed ONLY if it is explicitly
+            # enrolled in the allowlist (with its stated reason). Otherwise its
+            # signature is unpinned and a drift would hide — that is a gate
+            # failure, so the row must either grow a `[method.signature]` or
+            # earn an allowlist entry.
+            if (class_name, camel) not in NAME_ONLY_METHOD_ALLOWLIST:
+                errors.append(
+                    f"  {class_name}.{camel}: `[[method]]` row has neither a "
+                    f"`[method.signature]` sub-table nor a "
+                    f"`NAME_ONLY_METHOD_ALLOWLIST` entry — pin its signature "
+                    f"(preferred) or allowlist it with a documented reason so "
+                    f"no row is silently name-only."
+                )
+            continue
         if not class_name or not camel:
             errors.append(
                 f"  [[method]] row with `[method.signature]` missing `class`/"
@@ -6954,10 +7238,19 @@ def _sig_check_method_signatures(
             spec_dts = _sig_spec_for(signature, "ts_dts")
             if spec_dts is not None:
                 actual_dts = _sig_extract_ts_dts(ts_dts, ts_cls, ts_member)
-                # The `.d.ts` is a secondary cross-check: a present declaration
-                # is verified, an absent one is not an error (napi is authority).
                 if actual_dts is not None:
                     errors += _sig_compare_one(label, spec_dts, actual_dts, "ts_dts")
+                elif _sig_dts_public_member_missing(ts_dts, ts_cls, ts_member):
+                    # The class IS part of the public `.d.ts` surface but the
+                    # member's declaration is gone — dropping a pinned public
+                    # declaration fails the gate. (A row whose class is not in
+                    # the declared surface degrades to napi-as-authority.)
+                    errors.append(
+                        f"  {label}.ts_dts: `[method.signature]` pins this "
+                        f"binding and `{ts_cls}` is declared in the public "
+                        f".d.ts, but no `{ts_member}` declaration was found — "
+                        f"a removed public declaration must fail the gate."
+                    )
         if row.get("cpp"):
             spec = _sig_spec_for(signature, "cpp")
             if spec is not None:
@@ -11138,6 +11431,16 @@ def _run_selftest() -> int:
         assert not _sig_type_agrees("i32", "f64", "ts_napi"), "wrong-cell spelling"
         assert not _sig_type_agrees("usize", "HashMap<u8, u8>", "cpp"), "unmapped"
         assert not _sig_type_agrees("MysteryType", "size_t", "cpp"), "unknown canon"
+        # Zero overlap between platform-width `usize` and fixed-width `u64` on
+        # the C++ / C-ABI cells: a `u64` row that drifts to the platform-width
+        # spelling fails closed, and vice-versa. Before the split both spellings
+        # were accepted for both canonicals, so either drift passed silently.
+        assert _sig_type_agrees("u64", "uint64_t", "cpp")
+        assert not _sig_type_agrees("u64", "size_t", "cpp"), "u64 ≠ size_t (cpp)"
+        assert not _sig_type_agrees("usize", "uint64_t", "cpp"), "usize ≠ uint64_t (cpp)"
+        assert _sig_type_agrees("u64", "u64", "ffi")
+        assert not _sig_type_agrees("u64", "size_t", "ffi"), "u64 ≠ size_t (ffi)"
+        assert not _sig_type_agrees("usize", "u64", "ffi"), "usize ≠ u64 (ffi)"
 
     def _case_sig_option_structural() -> None:
         """`Option<T>` agrees with each binding's idiomatic optional wrapping;
@@ -11160,6 +11463,31 @@ def _run_selftest() -> int:
             )
             got = _sig_extract_python(src, "Foo", "bar")
             assert got == (["usize", "String"], "PyResult<()>"), got
+
+    def _case_sig_extract_python_py_self_receiver() -> None:
+        """A pyo3 by-value bound-self receiver (`slf: Py<Self>`) is stripped
+        like `&self` — it carries the instance, not a cross-binding param. The
+        `Client.streaming(slf: Py<Self>, py, callback)` shape surfaced this."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = pathlib.Path(tmp)
+            (src / "m.rs").write_text(
+                "#[pymethods]\nimpl Foo {\n"
+                "    fn streaming(slf: Py<Self>, py: Python<'_>, callback: Py<PyAny>)"
+                " -> PyResult<Py<Bar>> { todo!() }\n}\n",
+                encoding="utf-8",
+            )
+            got = _sig_extract_python(src, "Foo", "streaming")
+            assert got == (["Py<PyAny>"], "PyResult<Py<Bar>>"), got
+
+    def _case_sig_result_two_arg_unwrap() -> None:
+        """A Rust `Result<T, E>` return unwraps to the ok type `T` (the error
+        arm is a per-binding surface property), depth-aware so a comma inside
+        `T`'s generics is not split. Single-arg `Result<T>` / `Promise<T>` also
+        unwrap. The flat-file `Result<Vec<FlatFileRow>, Error>` surfaced this."""
+        assert _sig_unwrap_result("Result<Vec<crate::flatfiles::FlatFileRow>, Error>") == "Vec<crate::flatfiles::FlatFileRow>"
+        assert _sig_unwrap_result("Result<std::path::PathBuf, Error>") == "std::path::PathBuf"
+        assert _sig_unwrap_result("PyResult<()>") == "()"
+        assert _sig_unwrap_result("Promise<boolean>") == "boolean"
 
     def _case_sig_extract_ts_napi() -> None:
         """TS-napi extractor reads the napi Rust `fn`, matching the camelCased
@@ -11187,6 +11515,70 @@ def _run_selftest() -> int:
             )
             got = _sig_extract_ts_dts(dts, "Foo", "barBaz")
             assert got == (["number"], "void"), got
+
+    def _case_sig_extract_ts_dts_property_and_modifiers() -> None:
+        """The `.d.ts` extractor reads PROPERTY declarations (`readonly name:
+        T`) as zero-arg accessors, follows napi's getter / static modifiers,
+        and unwraps a `Promise<T>` async return. Without these the columnar
+        reader's `readonly dropped: number` / a `get`-accessor / a `static`
+        factory all returned None and the gate passed on absence."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dts = pathlib.Path(tmp) / "index.d.ts"
+            dts.write_text(
+                "export class Foo {\n"
+                "  readonly dropped: number\n"
+                "  get kind(): string\n"
+                "  static fromFile(path: string): Foo\n"
+                "  awaitDrain(timeoutMs: number): Promise<boolean>\n"
+                "  setCpu(n: number | undefined | null): void\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            assert _sig_extract_ts_dts(dts, "Foo", "dropped") == ([], "number")
+            assert _sig_extract_ts_dts(dts, "Foo", "kind") == ([], "string")
+            assert _sig_extract_ts_dts(dts, "Foo", "fromFile") == (["string"], "Foo")
+            # `Promise<boolean>` unwraps to `boolean`, agreeing with a `bool` spec.
+            assert _sig_type_agrees(
+                "bool", _sig_unwrap_result(_sig_extract_ts_dts(dts, "Foo", "awaitDrain")[1]), "ts_dts"
+            )
+            # `number | undefined | null` is the idiomatic `Option<usize>` param.
+            assert _sig_type_agrees(
+                "Option<usize>", _sig_extract_ts_dts(dts, "Foo", "setCpu")[0][0], "ts_dts"
+            )
+
+    def _case_sig_ts_dts_follows_reexport() -> None:
+        """The extractor reads the package entry AND the `index.d.ts` it
+        re-exports with `export * from './index'`, so a member declared only on
+        the napi layer is still found (the real surface is the union)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            (d / "index.d.ts").write_text(
+                "export class Config {\n  get workerThreads(): number | null\n}\n",
+                encoding="utf-8",
+            )
+            (d / "entry.d.ts").write_text(
+                "export * from './index'\n", encoding="utf-8"
+            )
+            got = _sig_extract_ts_dts(d / "entry.d.ts", "Config", "workerThreads")
+            assert got == ([], "number | null"), got
+
+    def _case_sig_ts_dts_absence_promotion() -> None:
+        """A MISSING `.d.ts` declaration is an error when the class IS part of
+        the public surface (a dropped public member), but degrades to
+        napi-as-authority when the class itself is absent (a legitimately
+        napi-only row). This is the FINDING-2 fail-on-absence rule."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            (d / "index.d.ts").write_text(
+                "export class StreamView {\n  isStreaming(): boolean\n}\n",
+                encoding="utf-8",
+            )
+            # Class present, member present → not missing.
+            assert not _sig_dts_public_member_missing(d / "index.d.ts", "StreamView", "isStreaming")
+            # Class present, member dropped → missing (must fail the gate).
+            assert _sig_dts_public_member_missing(d / "index.d.ts", "StreamView", "ringCapacity")
+            # Class absent entirely → NOT promoted (napi-only degradation).
+            assert not _sig_dts_public_member_missing(d / "index.d.ts", "RecordBatchStream", "dropped")
 
     def _case_sig_extract_cpp() -> None:
         """C++ extractor reads the in-class decl, return type bounded by the
@@ -11551,20 +11943,29 @@ def _run_selftest() -> int:
             bad = _sig_check_method_signatures(_sig_row(), **paths)
             assert any("ffi" in e and "arity mismatch" in e for e in bad), bad
 
-    def _case_sig_no_subtable_is_noop() -> None:
-        """A `[[method]]` row WITHOUT a `[method.signature]` is never signature-
-        checked — the opt-in guarantee that keeps the real surface a no-op."""
+    def _case_sig_name_only_fails_closed() -> None:
+        """FINDING-1 fail-closed enrollment: a `[[method]]` row WITHOUT a
+        `[method.signature]` FAILS unless it is in `NAME_ONLY_METHOD_ALLOWLIST`.
+        A synthetic unpinned + unlisted row trips; the same row listed passes.
+        This is the guarantee that no NEW row can be silently name-only."""
         rows = [{"class": "Widget", "name": "resize",
                  "python": True, "typescript": True, "cpp": True}]
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
-            # Deliberately broken sources; must be ignored (no signature).
             paths = _write_sig_tree(
                 root, py_params="n: bool", ts_ret="x", cpp_params="x y",
                 rust_ret="()", ffi_params="z: bool",
             )
+            # Not pinned, not allowlisted → must fail closed.
             errs = _sig_check_method_signatures(rows, **paths)
-            assert errs == [], f"row without [method.signature] must be a no-op; got {errs!r}"
+            assert any("neither a `[method.signature]`" in e for e in errs), errs
+            # Allowlisted → passes (no signature checked, enrollment satisfied).
+            NAME_ONLY_METHOD_ALLOWLIST[("Widget", "resize")] = "selftest fixture"
+            try:
+                ok = _sig_check_method_signatures(rows, **paths)
+            finally:
+                del NAME_ONLY_METHOD_ALLOWLIST[("Widget", "resize")]
+            assert ok == [], f"allowlisted name-only row must pass; got {ok!r}"
 
     def _case_sig_skip_langs_opts_lang_out() -> None:
         """`skip_langs` opts a present binding out of the signature check even
@@ -11662,8 +12063,13 @@ def _run_selftest() -> int:
     _case("sig type-map — forward map + usize→f64 sanction + fail-closed", _case_sig_type_map_forward_and_sanction)
     _case("sig type-map — Option<T> structural per binding", _case_sig_option_structural)
     _case("sig extractor — Python pyo3 fn sig", _case_sig_extract_python)
+    _case("sig extractor — Python Py<Self> receiver stripped", _case_sig_extract_python_py_self_receiver)
+    _case("sig type-map — Result<T,E> / Promise<T> return unwrap", _case_sig_result_two_arg_unwrap)
     _case("sig extractor — TS napi Rust fn sig", _case_sig_extract_ts_napi)
     _case("sig extractor — TS .d.ts decl", _case_sig_extract_ts_dts)
+    _case("sig extractor — TS .d.ts property + getter/static/Promise", _case_sig_extract_ts_dts_property_and_modifiers)
+    _case("sig extractor — TS .d.ts follows export-* re-export", _case_sig_ts_dts_follows_reexport)
+    _case("sig gate — TS .d.ts absence promoted for public member", _case_sig_ts_dts_absence_promotion)
     _case("sig extractor — C++ in-class decl", _case_sig_extract_cpp)
     _case("sig extractor — Rust core impl fn", _case_sig_extract_rust)
     _case("sig extractor — FFI extern fn", _case_sig_extract_ffi)
@@ -11682,7 +12088,7 @@ def _run_selftest() -> int:
     _case("sig orchestrator — param-ORDER drift fails", _case_sig_order_drift_fails)
     _case("sig orchestrator — RETURN drift fails", _case_sig_return_drift_fails)
     _case("sig orchestrator — per-binding override honoured", _case_sig_override_honoured)
-    _case("sig orchestrator — row without sub-table is a no-op", _case_sig_no_subtable_is_noop)
+    _case("sig orchestrator — name-only row fails closed unless allowlisted", _case_sig_name_only_fails_closed)
     _case("sig orchestrator — skip_langs opts a present lang out", _case_sig_skip_langs_opts_lang_out)
     _case("sig orchestrator — [ffi_symbol.signature] checked + drift fails", _case_ffi_symbol_signature_checked)
     _case("sig orchestrator — live method surface engaged + clean", _case_sig_live_surface_is_clean)

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -6956,22 +6956,46 @@ def _sig_parse_dts_member(body: str, dm: "re.Match[str]") -> tuple[list[str], st
     """Parse the `(params, ret)` of the member matched by `dm` inside a single
     `.d.ts` class body — the method (`name(p: T): R`) or property (`name: T`,
     zero-arg) form. Shared by the single-decl extractor and the all-decls
-    conflict scan so both read the surface identically."""
+    conflict scan so both read the surface identically.
+
+    A `?` optional marker is canonicalised to the `T | undefined` union so it
+    flows through the SAME `_sig_option_inner` path the napi-emitted
+    `T | undefined | null` already uses: an `Option<T>` spec then agrees with
+    `name?: T` while a `name: T` (required) stays bare and fails it. Preserving
+    optionality is what makes a required-vs-optional drift visible — without it
+    `options?: T` and `options: T` both reduce to `T`."""
     if dm.group("kind") == "(":
         arglist, after = _sig_balanced_parens(body, dm.end())
         rm = re.match(r"\s*:\s*([^;{\n]+)", body[after:])
         ret = rm.group(1).strip() if rm else "void"
         params: list[str] = []
         for p in _sig_split_params(arglist):
-            # `name: Type` / `name?: Type` — keep the Type half.
-            pm = re.match(r"\s*[A-Za-z_]\w*\s*\??\s*:\s*(.+)", p)
-            params.append(pm.group(1).strip() if pm else p.strip())
+            # `name: Type` / `name?: Type` / `...name: Type` (rest). Keep the
+            # Type half; carry the `?` as `| undefined` so optionality survives.
+            pm = re.match(r"\s*(?:\.\.\.)?[A-Za-z_]\w*\s*(\??)\s*:\s*(.+)", p)
+            if pm:
+                params.append(_sig_dts_apply_optional(pm.group(2).strip(), bool(pm.group(1))))
+            else:
+                params.append(p.strip())
         return params, ret
-    # Property form: a zero-arg accessor. The match ended on `?`/`:`; the
-    # type runs from the `:` to the line / statement terminator.
+    # Property form: a zero-arg accessor (`name: T`, optionally `readonly` /
+    # `name?: T`). The match's `kind` group is `?` or `:`; an optional property
+    # carries the same `| undefined` so a required→optional property drift fails.
     colon = body.index(":", dm.start())
     rm = re.match(r"\s*([^;{\n]+)", body[colon + 1 :])
-    return [], (rm.group(1).strip() if rm else "void")
+    ret = rm.group(1).strip() if rm else "void"
+    return [], _sig_dts_apply_optional(ret, dm.group("kind") == "?")
+
+
+def _sig_dts_apply_optional(ty: str, optional: bool) -> str:
+    """Canonicalise an optional `.d.ts` type to `T | undefined` so it flows
+    through `_sig_option_inner`. A type that already ends in a nullable union
+    member (`T | undefined` / `T | null`, the napi spelling) is left as-is — the
+    `?` is redundant with the explicit union, and a doubled `| undefined` would
+    be noise."""
+    if optional and not re.search(r"\|\s*(?:undefined|null)\s*$", ty):
+        return f"{ty} | undefined"
+    return ty
 
 
 def _sig_dts_all_decls(
@@ -6984,12 +7008,17 @@ def _sig_dts_all_decls(
     can legitimately resolve to its entry-augmentation while a stale generated
     overload of a different return still rides along in `index.d.ts`. Returning
     all of them lets the gate enforce that the surviving public surface carries
-    no conflicting declaration."""
+    no conflicting declaration.
+
+    EVERY declaration in each body is collected (`finditer`, not `search`):
+    overloads of one method can sit in the same `interface`/`class` body
+    (`batches(o?): Promise<RecordBatchStream>;` then a stale
+    `batches(o?): Promise<Handle>;`), so a per-body single match would examine
+    only the first and let a conflicting in-body sibling pass."""
     decl_re = _ts_dts_member_decl_re(method_camel)
     out: list[tuple[pathlib.Path, tuple[list[str], str]]] = []
     for src, body in _ts_dts_class_bodies_with_src(dts, cls):
-        dm = decl_re.search(body)
-        if dm:
+        for dm in decl_re.finditer(body):
             out.append((src, _sig_parse_dts_member(body, dm)))
     return out
 
@@ -11648,8 +11677,10 @@ def _run_selftest() -> int:
         drifts to a non-client-facing return must be reported as a conflict even
         though the resolved type looks correct. Mirrors the `StreamView.batches`
         leak: the entry presents `Promise<RecordBatchStream>` while a generated
-        `index.d.ts` overload returns the raw `Promise<RecordBatchStreamHandle>`."""
-        spec = (["BatchesOptions"], "RecordBatchStream")
+        `index.d.ts` overload returns the raw `Promise<RecordBatchStreamHandle>`.
+        The optional `options?` param canonicalises to `BatchesOptions |
+        undefined`, so the spec pins it as `Option<BatchesOptions>`."""
+        spec = (["Option<BatchesOptions>"], "RecordBatchStream")
         with tempfile.TemporaryDirectory() as tmp:
             d = pathlib.Path(tmp)
             entry = d / "entry.d.ts"
@@ -11672,9 +11703,10 @@ def _run_selftest() -> int:
                 "}\n",
                 encoding="utf-8",
             )
-            # Precedence winner is the entry augmentation (the wrapper return).
+            # Precedence winner is the entry augmentation (the wrapper return);
+            # the optional param survives as `BatchesOptions | undefined`.
             assert _sig_extract_ts_dts(entry, "StreamView", "batches") == (
-                ["BatchesOptions"], "Promise<RecordBatchStream>"
+                ["BatchesOptions | undefined"], "Promise<RecordBatchStream>"
             )
             conflicts = _sig_dts_conflicting_decls(entry, "StreamView", "batches", spec)
             assert len(conflicts) == 1, conflicts
@@ -11682,13 +11714,135 @@ def _run_selftest() -> int:
             assert conflicts[0][1] == (
                 ["BatchesOptions | undefined | null"], "Promise<RecordBatchStreamHandle>"
             ), conflicts
-            # FIX case: the generated declaration is suppressed (skip_typescript),
-            # so the augmentation is the SOLE declaration — no conflict.
+            # FINDING 5: a SECOND overload in the SAME entry interface body (not a
+            # cross-file sibling) — `finditer` must collect it so the conflict
+            # scan sees the in-body drift, which `search` (first-match-only) hid.
+            entry.write_text(
+                "export * from './index'\n"
+                "declare module './index' {\n"
+                "  interface StreamView {\n"
+                "    batches(options?: BatchesOptions): Promise<RecordBatchStream>;\n"
+                "    batches(options?: BatchesOptions): Promise<RecordBatchStreamHandle>;\n"
+                "  }\n"
+                "}\n",
+                encoding="utf-8",
+            )
             (d / "index.d.ts").write_text(
                 "export declare class StreamView {\n  isStreaming(): boolean\n}\n",
                 encoding="utf-8",
             )
+            assert len(_sig_dts_all_decls(entry, "StreamView", "batches")) == 2
+            in_body = _sig_dts_conflicting_decls(entry, "StreamView", "batches", spec)
+            assert len(in_body) == 1, in_body
+            assert in_body[0][1][1] == "Promise<RecordBatchStreamHandle>", in_body
+            # FIX case: the generated declaration is suppressed (skip_typescript)
+            # and only the wrapper overload remains — no conflict.
+            entry.write_text(
+                "export * from './index'\n"
+                "declare module './index' {\n"
+                "  interface StreamView {\n"
+                "    batches(options?: BatchesOptions): Promise<RecordBatchStream>;\n"
+                "  }\n"
+                "}\n",
+                encoding="utf-8",
+            )
             assert _sig_dts_conflicting_decls(entry, "StreamView", "batches", spec) == []
+
+    def _case_sig_ts_dts_param_optionality() -> None:
+        """FINDING 6: the `?` optional-param marker is preserved as `T |
+        undefined`, so a required-vs-optional drift on a `.d.ts` param FAILS the
+        type compare instead of collapsing both spellings to `T`. Pins the
+        `StreamView.batches(options?: BatchesOptions)` row: `Option<...>` spec
+        accepts the optional form and rejects the required form (and vice
+        versa)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            dts = d / "index.d.ts"
+            spec_opt = (["Option<BatchesOptions>"], "()")
+            spec_req = (["BatchesOptions"], "()")
+            # Optional declaration → `BatchesOptions | undefined`.
+            dts.write_text(
+                "export class StreamView {\n  batches(options?: BatchesOptions): void\n}\n",
+                encoding="utf-8",
+            )
+            opt = _sig_extract_ts_dts(dts, "StreamView", "batches")
+            assert opt == (["BatchesOptions | undefined"], "void"), opt
+            # Required declaration → bare `BatchesOptions`.
+            dts.write_text(
+                "export class StreamView {\n  batches(options: BatchesOptions): void\n}\n",
+                encoding="utf-8",
+            )
+            req = _sig_extract_ts_dts(dts, "StreamView", "batches")
+            assert req == (["BatchesOptions"], "void"), req
+            # The two are now DISTINGUISHED (the FINDING-6 bug collapsed them).
+            assert opt != req
+            # Legitimate matches pass; the representable drift fails.
+            assert _sig_compare_one("X.batches", spec_opt, opt, "ts_dts") == []
+            assert _sig_compare_one("X.batches", spec_req, req, "ts_dts") == []
+            assert _sig_compare_one("X.batches", spec_opt, req, "ts_dts")  # required ≠ optional
+            assert _sig_compare_one("X.batches", spec_req, opt, "ts_dts")  # optional ≠ required
+
+    def _case_sig_ts_dts_surface_forms() -> None:
+        """Every `.d.ts` declaration FORM present in the pinned public TS surface
+        parses, and a representable drift in each fails. Bounds the hardening to
+        the forms actually in use (enumerated from the `ts_dts`-pinned rows);
+        forms that never appear (e.g. TS rest params, generic methods) are noted
+        below as deliberately unhandled."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            dts = d / "index.d.ts"
+            dts.write_text(
+                "export class Foo {\n"
+                # plain method, Promise return
+                "  awaitDrain(timeoutMs: number): Promise<boolean>\n"
+                # nullable PARAM (napi union spelling) — the Option<usize> form
+                "  setCpu(n: number | undefined | null): void\n"
+                # nullable RETURN — Option<...> in return position
+                "  contract(): ContractRef | null\n"
+                # readonly property (RecordBatchStream.schema/dropped shape)
+                "  readonly dropped: number\n"
+                # getter accessor (napi #[getter])
+                "  get kind(): string\n"
+                # static factory (Credentials.fromFile shape)
+                "  static fromFile(path: string): Foo\n"
+                # callback / fn-type param (startStreaming shape)
+                "  startStreaming(cb: (e: StreamEvent) => void): Promise<void>\n"
+                # Array<T> param (subscribeMany shape)
+                "  subscribeMany(subs: Array<Subscription>): void\n"
+                # import-type return (RecordBatchStream.schema shape)
+                "  schema(): import('apache-arrow').Schema\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            E = _sig_extract_ts_dts
+            # Each form parses to the expected (params, ret).
+            assert E(dts, "Foo", "awaitDrain") == (["number"], "Promise<boolean>")
+            assert E(dts, "Foo", "setCpu") == (["number | undefined | null"], "void")
+            assert E(dts, "Foo", "contract") == ([], "ContractRef | null")
+            assert E(dts, "Foo", "dropped") == ([], "number")
+            assert E(dts, "Foo", "kind") == ([], "string")
+            assert E(dts, "Foo", "fromFile") == (["string"], "Foo")
+            assert E(dts, "Foo", "startStreaming") == (["(e: StreamEvent) => void"], "Promise<void>")
+            assert E(dts, "Foo", "subscribeMany") == (["Array<Subscription>"], "void")
+            assert E(dts, "Foo", "schema") == ([], "import('apache-arrow').Schema")
+            # A representable drift in each form FAILS its compare. (TS has no
+            # integer-width distinction, so an int-vs-int param is NOT drift —
+            # the probes pin types that genuinely disagree under the map.)
+            assert _sig_compare_one("Foo.awaitDrain", (["number"], "String"),
+                                    E(dts, "Foo", "awaitDrain"), "ts_dts")  # bool return ≠ String
+            assert _sig_compare_one("Foo.setCpu", (["String"], "()"),
+                                    E(dts, "Foo", "setCpu"), "ts_dts")  # wrong inner type
+            assert _sig_compare_one("Foo.contract", ([], "SecType"),
+                                    E(dts, "Foo", "contract"), "ts_dts")  # wrong return enum
+            assert _sig_compare_one("Foo.dropped", ([], "String"),
+                                    E(dts, "Foo", "dropped"), "ts_dts")  # number ≠ String cell
+            assert _sig_compare_one("Foo.subscribeMany", (["Subscription"], "()"),
+                                    E(dts, "Foo", "subscribeMany"), "ts_dts")  # Array<T> ≠ scalar
+            # ponytail: TS rest params (`...args: T[]`) and generic methods
+            # (`m<T>()`) do not appear in the pinned surface; the param regex
+            # carries a `...` prefix so a rest param's type is still extracted,
+            # but no row pins one, so there is no probe. Add when a pinned row
+            # introduces one.
 
     def _case_sig_ts_dts_absence_promotion() -> None:
         """A MISSING `.d.ts` declaration is an error when the class IS part of
@@ -12198,6 +12352,8 @@ def _run_selftest() -> int:
     _case("sig extractor — TS .d.ts property + getter/static/Promise", _case_sig_extract_ts_dts_property_and_modifiers)
     _case("sig extractor — TS .d.ts follows export-* re-export", _case_sig_ts_dts_follows_reexport)
     _case("sig gate — TS .d.ts conflicting merged overload fails", _case_sig_ts_dts_conflicting_overload)
+    _case("sig gate — TS .d.ts param optionality (?) drift fails", _case_sig_ts_dts_param_optionality)
+    _case("sig gate — TS .d.ts pinned surface forms all parse + drift fails", _case_sig_ts_dts_surface_forms)
     _case("sig gate — TS .d.ts absence promoted for public member", _case_sig_ts_dts_absence_promotion)
     _case("sig extractor — C++ in-class decl", _case_sig_extract_cpp)
     _case("sig extractor — Rust core impl fn", _case_sig_extract_rust)

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -89,6 +89,9 @@ from typing import Any
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 PARITY_TOML = REPO_ROOT / "sdks" / "parity.toml"
 PY_SRC = REPO_ROOT / "sdks" / "python" / "src"
+# The shipped PEP 561 stub — the client-facing Python type surface
+# (mypy / pyright) the `python_pyi` signature lane checks against the spec.
+PY_PYI = REPO_ROOT / "sdks" / "python" / "python" / "thetadatadx" / "__init__.pyi"
 TS_PKG_DIR = REPO_ROOT / "sdks" / "typescript"
 
 
@@ -2314,6 +2317,36 @@ NAME_ONLY_METHOD_ALLOWLIST: dict[tuple[str, str], str] = {
         "cross-binding param/return contract to pin."
     ),
 }
+
+
+# `[[method]]` setter rows whose Python `.pyi` surface is the assignable
+# read-write PROPERTY, not a `def set_<name>(...)` method. pyo3 exposes a
+# `#[setter] fn set_x(value)` as the attribute `config.x = value`, and the
+# hand-written stub models it as the bare read-write annotation `x: T` — there
+# is no `set_x` declaration to extract. The MATCHING getter row (`x`) already
+# pins that property's type through the `.pyi` lane (return = T), which is the
+# same `T` this setter's param would check, so re-checking it off a synthetic
+# `set_x` is redundant and would false-fail on the (correctly) absent `set_x`.
+# So these rows DEGRADE in the `.pyi` lane to the pyo3-source `python` lane +
+# stubtest (which DO see the runtime `set_x` setter and its parameter). Every
+# entry's getter twin is `.pyi`-checked, so the property type stays pinned.
+# A setter NOT listed here whose `set_<name>` is dropped from a fully-enumerated
+# stub class still fails (the absence-promotion rule), so this is an explicit,
+# bounded exemption — not a blanket "missing setter is fine".
+PYI_SETTER_PROPERTY_ROWS: frozenset[tuple[str, str]] = frozenset(
+    ("Config", name)
+    for name in (
+        "setFlushMode",
+        "setWaitStrategy",
+        "setWaitSpinIters",
+        "setWaitYieldIters",
+        "setWaitParkUs",
+        "setConsumerCpu",
+        "setReconnectPolicy",
+        "setStreamingRingSize",
+        "setWorkerThreads",
+    )
+)
 
 
 # Parity-toml `class` field → the Rust struct the Rust method collector
@@ -6237,6 +6270,14 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # loose cell here.
     "usize": {
         "python": ("usize",),
+        # The `.pyi` stub spells every integer width as Python's unbounded
+        # `int` — the runtime exposes no NewType per width, so `usize` / `u64`
+        # / `i64` / `u32` / `i32` all read `int` in the stub. A width drift is
+        # therefore invisible to THIS lane (it is the pyo3-source `python`
+        # lane's job, which carries the exact width); the stub lane pins that
+        # the parameter / return stays an integer at all and does not drift to
+        # a non-integer Python type.
+        "python_pyi": ("int",),
         "ts_napi": ("f64", "BigInt", "u32", "i64"),
         "ts_dts": ("number", "bigint"),
         "cpp": ("size_t", "std::size_t"),
@@ -6249,6 +6290,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # `u64` row that drifts to a platform-width return fails closed.
     "u64": {
         "python": ("u64",),
+        "python_pyi": ("int",),
         "ts_napi": ("BigInt", "f64"),
         "ts_dts": ("bigint", "number"),
         "cpp": ("uint64_t", "std::uint64_t"),
@@ -6257,6 +6299,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "i64": {
         "python": ("i64",),
+        "python_pyi": ("int",),
         "ts_napi": ("i64", "BigInt"),
         "ts_dts": ("number", "bigint"),
         "cpp": ("int64_t",),
@@ -6265,6 +6308,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "u32": {
         "python": ("u32",),
+        "python_pyi": ("int",),
         "ts_napi": ("u32",),
         "ts_dts": ("number",),
         "cpp": ("uint32_t",),
@@ -6273,6 +6317,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "i32": {
         "python": ("i32",),
+        "python_pyi": ("int",),
         "ts_napi": ("i32",),
         "ts_dts": ("number",),
         "cpp": ("int32_t", "int"),
@@ -6281,6 +6326,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "f64": {
         "python": ("f64",),
+        "python_pyi": ("float", "int"),
         "ts_napi": ("f64",),
         "ts_dts": ("number",),
         "cpp": ("double",),
@@ -6289,6 +6335,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "bool": {
         "python": ("bool",),
+        "python_pyi": ("bool",),
         "ts_napi": ("bool",),
         "ts_dts": ("boolean",),
         "cpp": ("bool",),
@@ -6298,6 +6345,12 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "String": {
         "python": ("String", "&str"),
+        # The stub spells a string return / param as `str`; a Config knob that
+        # constrains the value set spells it as a `Literal["a", "b", ...]` of
+        # string members, which `_sig_canon_type` folds to `str` (the constraint
+        # is documentation, not a cross-binding type difference). So only `str`
+        # is enrolled here — the Literal folds to it.
+        "python_pyi": ("str",),
         "ts_napi": ("String", "&str"),
         "ts_dts": ("string",),
         "cpp": ("std::string", "const std::string&"),
@@ -6308,6 +6361,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # carry the integer / chrono spelling they expose to users.
     "Duration": {
         "python": ("u64", "f64", "Duration"),
+        "python_pyi": ("int", "float"),
         "ts_napi": ("f64", "BigInt"),
         "ts_dts": ("number",),
         "cpp": ("uint64_t", "std::chrono::milliseconds", "double"),
@@ -6322,6 +6376,10 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # no cell here.
     "Contract": {
         "python": ("PyContract",),
+        # The stub names the fluent contract by its public Python class
+        # `Contract` (the inner type of `Subscription.contract`'s
+        # `Optional[Contract]`), not the Rust pyclass `PyContract`.
+        "python_pyi": ("Contract",),
         "ts_napi": ("ContractRef",),
         # The napi `.d.ts` spells the fluent contract `ContractRef` (the
         # `Contract` symbol is the streaming event-payload class); the wrapper
@@ -6330,6 +6388,7 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "SecType": {
         "python": ("PySecType",),
+        "python_pyi": ("SecType",),
         "ts_napi": ("SecType",),
         "ts_dts": ("SecType",),
     },
@@ -6368,6 +6427,9 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # C++ `const FluentSubscription&`.
     "Subscription": {
         "python": ("&Bound<'_, PyAny>", "PyObject", "Py<PyAny>"),
+        # The pyo3 source takes the polymorphic `&Bound<PyAny>` it coerces, but
+        # the stub presents the typed `Subscription` the user actually passes.
+        "python_pyi": ("Subscription",),
         "ts_napi": ("&fluent::Subscription", "&Subscription"),
         "ts_dts": ("Subscription",),
         "cpp": ("const class FluentSubscription&", "const FluentSubscription&"),
@@ -6378,6 +6440,9 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # the C++ `std::initializer_list<FluentSubscription>`.
     "SubscriptionList": {
         "python": ("&Bound<'_, PyAny>",),
+        # The stub presents the iterable as a typed `List[Subscription]`
+        # (a `Sequence[Subscription]` is the equally-valid read-only spelling).
+        "python_pyi": ("List[Subscription]", "Sequence[Subscription]"),
         "ts_napi": ("Vec<&fluent::Subscription>", "Vec<&Subscription>"),
         "ts_dts": ("Array<Subscription>",),
         "cpp": (
@@ -6393,6 +6458,10 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # here — there is no cross-binding contract in those generics.
     "Callback": {
         "python": ("Py<PyAny>", "PyObject"),
+        # The stub names the per-event handler via its `EventCallback` alias
+        # (`Callable[[<event-union>], None]`), the documented streaming-callback
+        # type; the alias is the cross-binding handler contract.
+        "python_pyi": ("EventCallback",),
         "cpp": ("std::function<void(const StreamEvent&)>",),
         # The `.d.ts` per-event handler type. napi-rs generates the parameter
         # name `arg`; the cross-binding contract is the `StreamEvent` payload
@@ -6426,6 +6495,9 @@ SIGNATURE_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
 SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     "()": {
         "python": ("()", "PyResult<()>"),
+        # A no-result method's stub return annotation is `None` (the extractor
+        # also yields `None` for a `def`-with-no-`->`, the pyo3 unit method).
+        "python_pyi": ("None",),
         "ts_napi": ("()", "Result<()>", "napi::Result<()>"),
         "ts_dts": ("void", "Promise<void>"),
         "cpp": ("void",),
@@ -6439,6 +6511,10 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # reader, `ThetaDataDxFlatFileBytes` for the flat-file rows).
     "Bytes": {
         "python": ("PyResult<Py<PyAny>>", "Py<PyAny>"),
+        # The stub types the opaque owned-bytes object as `Any` (the runtime
+        # hands back a `bytes` / `memoryview`); `bytes` is accepted for a stub
+        # that names the concrete container.
+        "python_pyi": ("Any", "bytes"),
         "ts_napi": ("napi::Result<Buffer>", "Buffer"),
         "ts_dts": ("Buffer", "Uint8Array"),
         "cpp": ("std::vector<uint8_t>", "std::vector<std::uint8_t>"),
@@ -6450,6 +6526,9 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # pointer.
     "Schema": {
         "python": ("PyResult<Py<PyAny>>", "Py<PyAny>"),
+        # The stub types the Arrow schema object as `Any` (it is a runtime
+        # `pyarrow.Schema`, not statically modelled).
+        "python_pyi": ("Any",),
         "ts_napi": ("Schema",),
         "ts_dts": ("Schema", "import('apache-arrow').Schema"),
         "cpp": ("std::shared_ptr<arrow::Schema>",),
@@ -6460,6 +6539,10 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # closed.
     "PyObject": {
         "python": ("PyResult<Py<PyAny>>", "Py<PyAny>"),
+        # The stub types the arbitrary-object materialiser as `Any`
+        # (`to_pandas` / `to_polars` — a frame) or `List[Any]` (`to_list` — a
+        # list of row dicts); both are the opaque Python-object return.
+        "python_pyi": ("Any", "List[Any]"),
     },
     # A `Credentials` factory return: the auth handle itself. Python spells it
     # `Self` (or `PyResult<Self>` for the fallible file / env factories),
@@ -6469,6 +6552,9 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # contract the signature gate pins.
     "Credentials": {
         "python": ("Self", "PyResult<Self>", "Credentials", "PyResult<Credentials>"),
+        # The stub resolves the factory return to the concrete `Credentials`
+        # (it does not spell `Self` on a `@staticmethod`).
+        "python_pyi": ("Credentials",),
         "ts_napi": ("Credentials", "napi::Result<Credentials>"),
         "ts_dts": ("Credentials",),
         "cpp": ("Credentials",),
@@ -6481,6 +6567,8 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # divergence is encoded per binding here rather than forced symmetric.
     "Subscriptions": {
         "python": ("Vec<crate::fluent::PySubscription>", "Vec<PySubscription>"),
+        # The stub types the active-subscription snapshot as `List[Subscription]`.
+        "python_pyi": ("List[Subscription]",),
         "ts_napi": ("serde_json::Value",),
         "ts_dts": ("any",),
         "cpp": ("std::vector<Subscription>",),
@@ -6491,6 +6579,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # tree as the per-contract variant).
     "FullSubscriptions": {
         "python": ("Vec<crate::fluent::PySubscription>", "Vec<PySubscription>"),
+        "python_pyi": ("List[Subscription]",),
         "ts_napi": ("serde_json::Value",),
         "ts_dts": ("any",),
         "cpp": ("std::vector<FullSubscription>",),
@@ -6505,6 +6594,11 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
             "crate::streaming_batches::RecordBatchStream",
             "RecordBatchStream",
         ),
+        # The stub presents the public `RecordBatchStream` wrapper class — the
+        # coverage stubtest cannot give (a compiled pyo3 return carries no
+        # runtime annotation), so a stub drift on this return is THIS lane's
+        # to catch.
+        "python_pyi": ("RecordBatchStream",),
         "ts_napi": (
             "crate::streaming_batches::RecordBatchStreamHandle",
             "RecordBatchStreamHandle",
@@ -6520,6 +6614,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # trips the gate.
     "HistoricalView": {
         "python": ("HistoricalView",),
+        "python_pyi": ("HistoricalView",),
         "ts_napi": ("HistoricalView",),
         "ts_dts": ("HistoricalView",),
         "cpp": ("Historical",),
@@ -6527,6 +6622,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "StreamView": {
         "python": ("StreamView",),
+        "python_pyi": ("StreamView",),
         "ts_napi": ("StreamView",),
         "ts_dts": ("StreamView",),
         "cpp": ("Stream",),
@@ -6534,6 +6630,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "FlatFilesNamespace": {
         "python": ("FlatFilesNamespace",),
+        "python_pyi": ("FlatFilesNamespace",),
         "ts_napi": ("FlatFilesNamespace",),
         "ts_dts": ("FlatFilesNamespace",),
         "cpp": ("FlatFiles",),
@@ -6552,6 +6649,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # compare); the Rust core returns the owned `Vec<FlatFileRow>`.
     "FlatFileRowList": {
         "python": ("FlatFileRowList",),
+        "python_pyi": ("FlatFileRowList",),
         "ts_napi": ("FlatFileRowList",),
         "ts_dts": ("FlatFileRowList",),
         "cpp": ("FlatFileRowList",),
@@ -6564,6 +6662,9 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # by-reference spellings — this is the by-value return shape.
     "BuiltSubscription": {
         "python": ("PySubscription",),
+        # The stub presents the built subscription as the public `Subscription`
+        # class (not the Rust pyclass `PySubscription`).
+        "python_pyi": ("Subscription",),
         "ts_napi": ("Subscription",),
         "ts_dts": ("Subscription",),
         "cpp": ("FluentSubscription",),
@@ -6573,6 +6674,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # Rust core returns the owned `PathBuf`.
     "WrittenPath": {
         "python": ("String",),
+        "python_pyi": ("str",),
         "ts_napi": ("String",),
         "ts_dts": ("string",),
         "cpp": ("void",),
@@ -6585,6 +6687,7 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # `fn` (the session is a JS wrapper), so the row skips `ts_napi`.
     "StreamingSession": {
         "python": ("Py<StreamingSession>", "StreamingSession"),
+        "python_pyi": ("StreamingSession",),
         "ts_dts": ("StreamingSession",),
     },
     # The inline-construction options object + its `Client` return on the
@@ -6603,6 +6706,9 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # tuple list; the Rust core returns the opaque `SubscriptionInfo` struct.
     "SubscriptionInfo": {
         "python": ("Vec<(String, String)>", "Vec<(String,String)>"),
+        # The stub materialises the snapshot as `List[Tuple[str, str]]`
+        # (whitespace-folded before the compare).
+        "python_pyi": ("List[Tuple[str,str]]",),
         "rust": ("SubscriptionInfo",),
     },
     # A `Config` factory return (the env-tier presets `production` / `dev` /
@@ -6611,6 +6717,9 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
     # `Self` to the concrete `Config`, C++ the value type `Config`.
     "Config": {
         "python": ("Self", "Config"),
+        # The stub resolves the env-tier factory return to the concrete
+        # `Config` (a `@staticmethod` does not spell `Self`).
+        "python_pyi": ("Config",),
         "ts_napi": ("Self", "Config"),
         "ts_dts": ("Config",),
         "cpp": ("Config",),
@@ -6618,13 +6727,27 @@ SIGNATURE_RETURN_TYPE_MAP: dict[str, dict[str, tuple[str, ...]]] = {
 }
 
 
+_PYI_STR_LITERAL_RE = re.compile(
+    r"Literal\[\s*(?:\"[^\"]*\"|'[^']*')(?:\s*,\s*(?:\"[^\"]*\"|'[^']*'))*\s*\]"
+)
+
+
 def _sig_canon_type(raw: str) -> str:
     """Fold a type spelling to its comparison form: drop Rust lifetimes
     (`&'static str` → `&str`), drop the napi prelude module path
-    (`napi::bindgen_prelude::BigInt` → `BigInt`), then whitespace-fold. The
+    (`napi::bindgen_prelude::BigInt` → `BigInt`), collapse a `.pyi`
+    `Literal["a", "b"]` of string members to `str`, then whitespace-fold. The
     lifetime / napi-path qualifiers are surface noise the binding adds, never a
-    cross-binding type difference."""
-    s = re.sub(r"'\w+\s*", "", raw.strip())
+    cross-binding type difference; a stub `Literal[...]` of string members
+    (the Config knob value sets — `flush_mode: Literal["batched",
+    "immediate"]`) is a documentation constraint over the underlying `str`,
+    not a distinct cross-binding type, so it folds to `str` and agrees with a
+    `String` spec."""
+    # Fold a string `Literal[...]` to `str` BEFORE the lifetime strip — the
+    # lifetime pattern (`'\w+`) would otherwise consume a single-quoted member
+    # (`Literal['a', 'b']`) and corrupt the spelling.
+    s = _PYI_STR_LITERAL_RE.sub("str", raw.strip())
+    s = re.sub(r"'\w+\s*", "", s)
     s = re.sub(r"\bnapi::bindgen_prelude::", "", s)
     return re.sub(r"\s+", "", s)
 
@@ -6676,6 +6799,15 @@ def _sig_option_inner(spelling: str, lang: str) -> str | None:
         # as `T | undefined | null` (either union order). Strip the trailing
         # `| null` / `| undefined` members to recover the inner `T`.
         m = re.fullmatch(r"(.+?)\s*(?:\|\s*(?:null|undefined)\s*)+", s)
+        if m:
+            return m.group(1).strip()
+    elif lang == "python_pyi":
+        # The stub spells an optional as `Optional[T]` or the PEP 604 union
+        # `T | None`. Either recovers the inner `T`.
+        m = re.fullmatch(r"Optional\s*\[\s*(.+)\s*\]", s)
+        if m:
+            return m.group(1).strip()
+        m = re.fullmatch(r"(.+?)\s*\|\s*None", s)
         if m:
             return m.group(1).strip()
     return None
@@ -6831,6 +6963,153 @@ def _sig_extract_python(py_src: pathlib.Path, cls: str, method: str) -> tuple[li
             if sig is not None:
                 return sig
     return None
+
+
+def _pyi_class_bodies(pyi_path: pathlib.Path, cls: str) -> list[str]:
+    """Every `class cls(...):` body text in the PEP 561 stub. A class body runs
+    from the header line to the next column-0 non-blank line (the file's top
+    level), so the indented members — and any nested `class`/`def` — are
+    captured. A class is rarely redeclared in a stub, but all bodies are
+    returned for symmetry with the `.d.ts` surface scan."""
+    if not pyi_path.is_file():
+        return []
+    text = pyi_path.read_text(encoding="utf-8")
+    out: list[str] = []
+    cls_re = re.compile(r"(?m)^class\s+" + re.escape(cls) + r"\b[^\n]*:[ \t]*$")
+    for m in cls_re.finditer(text):
+        nl = text.find("\n", m.start())
+        if nl == -1:
+            continue
+        body_lines: list[str] = []
+        for line in text[nl + 1 :].splitlines(keepends=True):
+            if line.strip() and not line[0].isspace():
+                break
+            body_lines.append(line)
+        out.append("".join(body_lines))
+    return out
+
+
+def _sig_pyi_member(body: str, member: str) -> tuple[list[str], str] | None:
+    """Parse `(params, ret)` for `member` inside a single stub class `body`, in
+    either form the pinned Python surface uses:
+
+      * a method  `def member(self, p: T, ...) -> R:` (the receiver `self`/`cls`
+        and any `*` / `/` separator and `*args`/`**kwargs` are dropped; a
+        default `= ...` is stripped off the param type; a `def` with no `->`
+        defaults to the `None` unit return), or
+      * a `@property` / bare read-write annotation `member: T` → a zero-arg
+        signature returning `T` (the `Config` knobs and the `Subscription`
+        accessors are stub properties, not methods).
+
+    The method body may span lines (the keyword-only `batches(self, *, ...)`
+    form), so the param list is read with a balanced-paren scan. Returns None
+    when the member is absent from this body."""
+    dm = re.search(r"(?m)^[ \t]+def[ \t]+" + re.escape(member) + r"[ \t]*\(", body)
+    if dm:
+        open_paren = body.index("(", dm.start())
+        arglist, after = _sig_balanced_parens(body, open_paren + 1)
+        rm = re.match(r"\s*->\s*(.+?)\s*:", body[after:], re.DOTALL)
+        ret = rm.group(1).strip() if rm else "None"
+        params: list[str] = []
+        for p in _sig_split_params(arglist):
+            tok = p.strip()
+            # Drop the receiver, the keyword-only / positional-only markers, and
+            # any *args / **kwargs — none is a cross-binding parameter.
+            if not tok or tok in ("self", "cls", "*", "/") or tok.startswith("*"):
+                continue
+            if ":" in tok:
+                ty = tok.split(":", 1)[1]
+                if "=" in ty:  # strip a default value off the annotation
+                    ty = ty.split("=", 1)[0]
+                params.append(ty.strip())
+            else:
+                params.append(tok)
+        return params, ret
+    # Property / bare read-write annotation. Scan a copy with every `(...)` run
+    # blanked so a deeper-indented `def` PARAMETER that happens to share the
+    # member's name (`def batches(self, batch_size: Optional[int] = None)`
+    # while looking up a `batch_size` property) cannot be misread as a class
+    # property — only a genuine class-level `member: T` survives the mask.
+    pm = re.search(
+        r"(?m)^[ \t]+" + re.escape(member) + r"[ \t]*:[ \t]*(.+?)[ \t]*$",
+        _pyi_blank_parens(body),
+    )
+    if pm:
+        # Read the annotation from the ORIGINAL body at the matched span (the
+        # mask only gates WHERE a property may match, never its text).
+        return [], body[pm.start(1) : pm.end(1)].strip()
+    return None
+
+
+def _pyi_blank_parens(text: str) -> str:
+    """Replace every balanced `(...)` run with spaces of equal length (newlines
+    preserved), so a member-property scan never descends into a `def`'s
+    parameter list. Length / line structure is preserved so match offsets line
+    up with the original text."""
+    out = list(text)
+    depth = 0
+    for i, ch in enumerate(text):
+        if ch == "(":
+            depth += 1
+            out[i] = " "
+        elif ch == ")":
+            if depth > 0:
+                out[i] = " "
+                depth -= 1
+        elif depth > 0 and ch != "\n":
+            out[i] = " "
+    return "".join(out)
+
+
+def _sig_extract_python_pyi(
+    pyi_path: pathlib.Path, cls: str, member_snake: str
+) -> tuple[list[str], str] | None:
+    """Python `.pyi` stub signature: the member `member_snake` inside
+    `class cls` of the shipped PEP 561 stub — a method or a property
+    (zero-arg). The stub is the client-facing type surface mypy / pyright
+    consumers see.
+
+    This lane verifies the stub against the cross-binding SPEC (the
+    `python_pyi` type-map column), which is a DIFFERENT axis from Gate 6's
+    stubtest: stubtest compares the stub against the RUNTIME and pins the
+    parameter list / arity, but a compiled pyo3 method exposes no runtime
+    return annotation, so stubtest cannot see a stub RETURN drift. This lane
+    pins both the params (defence in depth with stubtest) AND the return (the
+    coverage stubtest lacks) against the spec.
+
+    Returns None when the stub is absent or the member is not declared in the
+    class; `_sig_pyi_public_member_missing` then decides whether the absence is
+    a dropped public member (fail) or a member legitimately served off the
+    stub (degrades to the pyo3-source `python` lane + stubtest as authority)."""
+    for body in _pyi_class_bodies(pyi_path, cls):
+        sig = _sig_pyi_member(body, member_snake)
+        if sig is not None:
+            return sig
+    return None
+
+
+def _sig_pyi_public_member_missing(
+    pyi_path: pathlib.Path, cls: str, member_snake: str
+) -> bool:
+    """Is `cls.member_snake` part of the hand-maintained public stub surface yet
+    missing its declaration? True only when the CLASS is declared in the stub,
+    carries NO class-level `__getattr__` escape, and the MEMBER is absent — a
+    member that belongs on a fully-enumerated stub class was dropped.
+
+    False when the class is absent from the stub (a generator-emitted class the
+    stub deliberately omits — the 100+ historical builders / `<Tick>List`
+    wrappers reached via the module-level `__getattr__ -> Any`), OR when the
+    class carries its own `__getattr__` fallback (`AsyncClient`,
+    `HistoricalClient`, `StreamingSession` route extras to `Any`). In both
+    degrade cases the pyo3-source `python` lane + stubtest remain the authority
+    — exactly the way `_sig_dts_public_member_missing` degrades a class absent
+    from the `.d.ts` surface to napi-as-authority."""
+    bodies = _pyi_class_bodies(pyi_path, cls)
+    if not bodies:
+        return False
+    if any(re.search(r"(?m)^[ \t]+def[ \t]+__getattr__\b", b) for b in bodies):
+        return False
+    return _sig_extract_python_pyi(pyi_path, cls, member_snake) is None
 
 
 def _sig_extract_ts_napi(ts_src: pathlib.Path, cls: str, method_camel: str) -> tuple[list[str], str] | None:
@@ -7193,8 +7472,23 @@ def _sig_extract_ffi(ffi_src: pathlib.Path, symbol: str) -> tuple[list[str], str
 def _sig_spec_for(signature: dict[str, Any], lang: str) -> tuple[list[str], str] | None:
     if lang in signature.get("skip_langs", ()):
         return None
-    params = signature.get(f"{lang}_params", signature.get("params"))
-    returns = signature.get(f"{lang}_returns", signature.get("returns"))
+    # Override-key precedence per lang. `python_pyi` (the stub lane) shares the
+    # one TypeScript-like split with the pyo3-source `python` lane: a
+    # `python_*` override is a per-binding divergence both python views inherit,
+    # so the stub lane falls back `python_pyi_*` → `python_*` → canonical. Every
+    # other lang reads `<lang>_*` → canonical.
+    key_chain = (
+        ("python_pyi", "python") if lang == "python_pyi" else (lang,)
+    )
+
+    def _resolve(suffix: str) -> Any:
+        for key in key_chain:
+            if f"{key}_{suffix}" in signature:
+                return signature[f"{key}_{suffix}"]
+        return signature.get(suffix)
+
+    params = _resolve("params")
+    returns = _resolve("returns")
     if params is None and returns is None:
         return None
     return list(params or []), returns if returns is not None else "()"
@@ -7250,6 +7544,7 @@ def _sig_check_method_signatures(
     method_rows: list[dict[str, Any]],
     *,
     py_src: pathlib.Path,
+    pyi_path: pathlib.Path,
     ts_src: pathlib.Path,
     ts_dts: pathlib.Path,
     cpp_hpp: pathlib.Path,
@@ -7265,12 +7560,19 @@ def _sig_check_method_signatures(
     through the TYPE_MAP + per-binding overrides.
 
     A row's enrolled signature-langs are derived from its presence booleans
-    (`python` → python, `typescript` → ts_napi + ts_dts, `cpp` → cpp, `rust`
-    → rust) intersected with what the spec actually pins (canonical or a
-    `<lang>_params`/`<lang>_returns` override). The FFI symbol is checked only
-    when the row supplies an `ffi_symbol` key naming the extern (a method row
-    has no FFI presence boolean — its C-ABI shape is a `[[ffi_symbol]]`
+    (`python` → python + python_pyi, `typescript` → ts_napi + ts_dts, `cpp` →
+    cpp, `rust` → rust) intersected with what the spec actually pins (canonical
+    or a `<lang>_params`/`<lang>_returns` override). The FFI symbol is checked
+    only when the row supplies an `ffi_symbol` key naming the extern (a method
+    row has no FFI presence boolean — its C-ABI shape is a `[[ffi_symbol]]`
     concern), so an FFI signature is opt-in within the opt-in.
+
+    The `python` flag drives TWO lanes: `python` reads the pyo3 Rust source
+    (the runtime contract), `python_pyi` reads the shipped PEP 561 stub (the
+    client-facing type surface). The stub lane checks params + RETURN against
+    the cross-binding spec; its return check is coverage Gate 6's stubtest
+    cannot give (a compiled pyo3 method has no runtime return annotation, so
+    stubtest validates only the stub-vs-runtime parameter list / arity).
     """
     errors: list[str] = []
     for row in method_rows:
@@ -7314,6 +7616,39 @@ def _sig_check_method_signatures(
                 errors += _sig_compare_one(
                     label, spec, _sig_extract_python(py_src, py_cls, py_member), "python"
                 )
+            # The PEP 561 stub lane. The stub uses the PUBLIC Python class
+            # names (`Contract`, not the pyo3 pyclass `PyContract`), so resolve
+            # against the parity-toml class directly; a `python` override
+            # already targets the public stub class + member (e.g.
+            # `flatFileToPath` → `Client.flatfile_to_path`,
+            # `count` → `FlatFileRowList.__len__`), so reuse it when present.
+            # DIVISION OF LABOUR: Gate 6's stubtest checks the stub against the
+            # RUNTIME (params + arity); this lane checks it against the
+            # cross-binding SPEC (params + RETURN) — the return is the coverage
+            # stubtest lacks, since a compiled pyo3 method exposes no runtime
+            # return annotation.
+            spec_pyi = _sig_spec_for(signature, "python_pyi")
+            if spec_pyi is not None and (class_name, camel) not in PYI_SETTER_PROPERTY_ROWS:
+                pyi_cls, pyi_member = (
+                    override["python"] if override and "python" in override
+                    else (class_name, snake)
+                )
+                actual_pyi = _sig_extract_python_pyi(pyi_path, pyi_cls, pyi_member)
+                if actual_pyi is not None:
+                    errors += _sig_compare_one(label, spec_pyi, actual_pyi, "python_pyi")
+                elif _sig_pyi_public_member_missing(pyi_path, pyi_cls, pyi_member):
+                    # The class is a fully-enumerated public stub class (no
+                    # `__getattr__` escape) but the member's declaration is
+                    # gone — a dropped public stub member fails the gate. (A
+                    # class absent from the stub, or one with a `__getattr__`
+                    # fallback, degrades to the `python` lane + stubtest.)
+                    errors.append(
+                        f"  {label}.python_pyi: `[method.signature]` pins this "
+                        f"binding and `{pyi_cls}` is a fully-enumerated public "
+                        f"stub class, but no `{pyi_member}` declaration was "
+                        f"found in `__init__.pyi` — a removed public stub "
+                        f"declaration must fail the gate."
+                    )
         if row.get("typescript"):
             ts_cls, ts_member = (
                 override["typescript"] if override and "typescript" in override
@@ -7485,6 +7820,7 @@ def main(argv: list[str] | None = None) -> int:
     method_signature_errors = _sig_check_method_signatures(
         method_rows,
         py_src=PY_SRC,
+        pyi_path=PY_PYI,
         ts_src=TS_SRC,
         ts_dts=TS_DTS,
         cpp_hpp=CPP_HPP,
@@ -11862,6 +12198,191 @@ def _run_selftest() -> int:
             # Class absent entirely → NOT promoted (napi-only degradation).
             assert not _sig_dts_public_member_missing(d / "index.d.ts", "RecordBatchStream", "dropped")
 
+    def _case_sig_extract_python_pyi_forms() -> None:
+        """The `.pyi` extractor reads every declaration FORM the pinned Python
+        surface uses: a multi-line keyword-only method (`batches(self, *, ...)
+        -> RecordBatchStream`), a `@property` / bare read-write annotation
+        (zero-arg returning the annotated type), a `@staticmethod`, an
+        `Optional[T]` / `T | None` return, and a `def` with no `->` (the unit
+        `None` return). Each form must parse to the right `(params, ret)`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pyi = pathlib.Path(tmp) / "__init__.pyi"
+            pyi.write_text(
+                "class Foo:\n"
+                "    def batches(\n"
+                "        self,\n"
+                "        *,\n"
+                "        batch_size: Optional[int] = None,\n"
+                "        backpressure: Optional[str] = None,\n"
+                "    ) -> RecordBatchStream:\n"
+                "        ...\n"
+                "    @property\n"
+                "    def contract(self) -> Optional[Contract]:\n"
+                "        ...\n"
+                "    kind: Literal[\"quote\", \"trade\"]\n"
+                "    consumer_cpu: Optional[int]\n"
+                "    @staticmethod\n"
+                "    def from_file(path: str) -> Credentials:\n"
+                "        ...\n"
+                "    def stop(self) -> None:\n"
+                "        ...\n"
+                "    def reconnect(self):\n"
+                "        ...\n",
+                encoding="utf-8",
+            )
+            assert _sig_extract_python_pyi(pyi, "Foo", "batches") == (
+                ["Optional[int]", "Optional[str]"], "RecordBatchStream"
+            ), _sig_extract_python_pyi(pyi, "Foo", "batches")
+            # `@property def` form → zero-arg returning the annotated type.
+            assert _sig_extract_python_pyi(pyi, "Foo", "contract") == ([], "Optional[Contract]")
+            # Bare read-write annotations (the Config-knob property shape).
+            assert _sig_extract_python_pyi(pyi, "Foo", "kind") == ([], 'Literal["quote", "trade"]')
+            assert _sig_extract_python_pyi(pyi, "Foo", "consumer_cpu") == ([], "Optional[int]")
+            # `@staticmethod` → no receiver to strip; the lone `str` param survives.
+            assert _sig_extract_python_pyi(pyi, "Foo", "from_file") == (["str"], "Credentials")
+            # `-> None` and a `def` with no `->` both yield the unit `None`.
+            assert _sig_extract_python_pyi(pyi, "Foo", "stop") == ([], "None")
+            assert _sig_extract_python_pyi(pyi, "Foo", "reconnect") == ([], "None")
+            # A member genuinely absent from the class → None.
+            assert _sig_extract_python_pyi(pyi, "Foo", "missing") is None
+            # REGRESSION: a deeper-indented `def` PARAMETER that shares a
+            # member's name (`batch_size` inside `batches(...)`) must NOT be
+            # misread as a class property — the paren-mask gates it out, so a
+            # lookup of a name that exists ONLY as a param returns None.
+            assert _sig_extract_python_pyi(pyi, "Foo", "batch_size") is None
+            assert _sig_extract_python_pyi(pyi, "Foo", "backpressure") is None
+
+    def _case_sig_python_pyi_type_map_and_literal() -> None:
+        """The `python_pyi` type map agrees on the stub spellings and a
+        representable drift fails. A string `Literal[...]` folds to `str` (so a
+        `String` spec accepts a constrained Config knob); an `Optional[T]` /
+        `T | None` satisfies an `Option<T>` spec while the bare required form
+        does NOT (optionality drift is visible)."""
+        # Integer widths all read `int`; a non-integer drift fails.
+        assert _sig_type_agrees("usize", "int", "python_pyi")
+        assert not _sig_type_agrees("usize", "str", "python_pyi")
+        # `Literal["a", "b"]` of string members folds to `str`.
+        assert _sig_type_agrees("String", 'Literal["batched", "immediate"]', "python_pyi")
+        assert _sig_type_agrees("String", "str", "python_pyi")
+        assert not _sig_type_agrees("String", "int", "python_pyi")
+        # Optionality: both `Optional[T]` and PEP 604 `T | None` satisfy the
+        # `Option<T>` spec; the required form does not, and vice versa.
+        assert _sig_type_agrees("Option<String>", "Optional[str]", "python_pyi")
+        assert _sig_type_agrees("Option<u64>", "int | None", "python_pyi")
+        assert not _sig_type_agrees("Option<String>", "str", "python_pyi")  # required ≠ optional
+        assert not _sig_type_agrees("String", "Optional[str]", "python_pyi")  # optional ≠ required
+        # The wrapper return the stub presents (the coverage stubtest lacks).
+        assert _sig_type_agrees("RecordBatchStream", "RecordBatchStream", "python_pyi")
+        assert not _sig_type_agrees("RecordBatchStream", "Any", "python_pyi")
+
+    def _case_sig_python_pyi_lane_drifts_and_presence() -> None:
+        """The orchestrator's `.pyi` lane: a return drift, a param drift, an
+        optionality drift, and a dropped pinned declaration each FAIL; a clean
+        stub passes; a member served only via a class `__getattr__` (or a class
+        absent from the stub) does NOT false-fail. Proves the lane is wired and
+        its presence policy mirrors the `.d.ts` degrade-to-authority rule."""
+        def _row(**sig):
+            base = {"params": ["Option<usize>"], "returns": "RecordBatchStream"}
+            base.update(sig)
+            return [{"class": "StreamView", "name": "batches",
+                     "python": True, "signature": base}]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            # Minimal pyo3 source so the `python` lane stays clean while we probe
+            # the `.pyi` lane (StreamView → no PY_CLASS_ALIASES entry, member
+            # `batches`).
+            py = root / "py"; py.mkdir()
+            (py / "m.rs").write_text(
+                "#[pymethods]\nimpl StreamView {\n"
+                "    pub fn batches(&self, n: Option<usize>) -> "
+                "PyResult<crate::streaming_batches::RecordBatchStream> { todo!() }\n}\n",
+                encoding="utf-8",
+            )
+            pyi = root / "__init__.pyi"
+            paths = dict(py_src=py, pyi_path=pyi, ts_src=root / "none_ts",
+                         ts_dts=root / "none.d.ts", cpp_hpp=root / "none.hpp",
+                         client_rs=root / "none.rs", ffi_src=root / "none_ffi")
+            # Clean stub → silent.
+            pyi.write_text(
+                "class StreamView:\n"
+                "    def batches(self, n: Optional[int]) -> RecordBatchStream:\n"
+                "        ...\n",
+                encoding="utf-8",
+            )
+            assert _sig_check_method_signatures(_row(), **paths) == [], \
+                _sig_check_method_signatures(_row(), **paths)
+            # RETURN drift (the stubtest-blind axis) → fails.
+            pyi.write_text(
+                "class StreamView:\n"
+                "    def batches(self, n: Optional[int]) -> Any:\n        ...\n",
+                encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "return mismatch" in e for e in errs), errs
+            # PARAM-TYPE drift → fails.
+            pyi.write_text(
+                "class StreamView:\n"
+                "    def batches(self, n: Optional[str]) -> RecordBatchStream:\n        ...\n",
+                encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "param #0 type mismatch" in e for e in errs), errs
+            # OPTIONALITY drift (required where Optional pinned) → fails.
+            pyi.write_text(
+                "class StreamView:\n"
+                "    def batches(self, n: int) -> RecordBatchStream:\n        ...\n",
+                encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "param #0 type mismatch" in e for e in errs), errs
+            # DROPPED pinned declaration on a fully-enumerated stub class → fails.
+            pyi.write_text(
+                "class StreamView:\n"
+                "    def is_streaming(self) -> bool:\n        ...\n",
+                encoding="utf-8",
+            )
+            errs = _sig_check_method_signatures(_row(), **paths)
+            assert any("python_pyi" in e and "removed public stub" in e for e in errs), errs
+            # Class carries a `__getattr__` escape → the absent member degrades
+            # to the `python` lane + stubtest (no `.pyi` false-fail).
+            pyi.write_text(
+                "class StreamView:\n"
+                "    def is_streaming(self) -> bool:\n        ...\n"
+                "    def __getattr__(self, name: str) -> Any:\n        ...\n",
+                encoding="utf-8",
+            )
+            assert _sig_check_method_signatures(_row(), **paths) == [], \
+                _sig_check_method_signatures(_row(), **paths)
+            # Class wholly absent from the stub (a generator-emitted class) →
+            # degrades too.
+            pyi.write_text("class Unrelated:\n    ...\n", encoding="utf-8")
+            assert _sig_check_method_signatures(_row(), **paths) == [], \
+                _sig_check_method_signatures(_row(), **paths)
+
+    def _case_sig_python_pyi_setter_property_degrade() -> None:
+        """A Config `#[setter]` row's `.pyi` surface is the assignable property,
+        not a `def set_x`; such rows are in `PYI_SETTER_PROPERTY_ROWS` and the
+        `.pyi` lane does NOT fail on the (correctly) absent `set_x`, while the
+        matching GETTER row IS `.pyi`-checked. Uses the live stub so the real
+        property annotation is exercised."""
+        # The 9 enrolled setters are the only pinned-python rows absent from the
+        # real stub — assert that membership matches reality (a NEW absent
+        # pinned setter must be enrolled or it fails).
+        data = tomllib.loads(PARITY_TOML.read_text(encoding="utf-8"))
+        setter_errs = _sig_check_method_signatures(
+            [r for r in data.get("method", [])
+             if (r.get("class"), r.get("name")) in PYI_SETTER_PROPERTY_ROWS],
+            py_src=PY_SRC, pyi_path=PY_PYI, ts_src=TS_SRC, ts_dts=TS_DTS,
+            cpp_hpp=CPP_HPP, client_rs=CORE_CLIENT_RS, ffi_src=FFI_SRC,
+        )
+        # The setter rows still get their pyo3-source `python` / ts / cpp / ffi
+        # checks; only the `.pyi` lane is exempt. So no `python_pyi` error.
+        assert not any("python_pyi" in e for e in setter_errs), setter_errs
+        # The matching getter (`flushMode` → property `flush_mode`) IS checked.
+        assert _sig_extract_python_pyi(PY_PYI, "Config", "flush_mode") == (
+            [], 'Literal["batched", "immediate"]'
+        ), _sig_extract_python_pyi(PY_PYI, "Config", "flush_mode")
+
     def _case_sig_extract_cpp() -> None:
         """C++ extractor reads the in-class decl, return type bounded by the
         prior access specifier (no `public:` leak into the return)."""
@@ -12094,7 +12615,12 @@ def _run_selftest() -> int:
             f'pub extern "C" fn thetadatadx_widget_resize({ffi_params}) -> i32 {{ 0 }}\n',
             encoding="utf-8",
         )
-        return dict(py_src=py, ts_src=ts, ts_dts=root / "none.d.ts",
+        # The `.pyi` lane is inert in these orchestrator cases (no stub written
+        # → extractor returns None → degrades), keeping them focused on the
+        # pyo3-source / napi / cpp / rust / ffi axes; the `.pyi` lane has its
+        # own dedicated cases.
+        return dict(py_src=py, pyi_path=root / "none.pyi", ts_src=ts,
+                    ts_dts=root / "none.d.ts",
                     cpp_hpp=hpp, client_rs=client, ffi_src=ffi)
 
     def _sig_row(**sig_extra) -> list[dict]:
@@ -12322,8 +12848,9 @@ def _run_selftest() -> int:
             "must carry a [method.signature] sub-table against the real sources."
         )
         errs = _sig_check_method_signatures(
-            method_rows, py_src=PY_SRC, ts_src=TS_SRC, ts_dts=TS_DTS,
-            cpp_hpp=CPP_HPP, client_rs=CORE_CLIENT_RS, ffi_src=FFI_SRC,
+            method_rows, py_src=PY_SRC, pyi_path=PY_PYI, ts_src=TS_SRC,
+            ts_dts=TS_DTS, cpp_hpp=CPP_HPP, client_rs=CORE_CLIENT_RS,
+            ffi_src=FFI_SRC,
         )
         assert errs == [], f"live signature gate must be clean; got {errs!r}"
 
@@ -12355,6 +12882,10 @@ def _run_selftest() -> int:
     _case("sig gate — TS .d.ts param optionality (?) drift fails", _case_sig_ts_dts_param_optionality)
     _case("sig gate — TS .d.ts pinned surface forms all parse + drift fails", _case_sig_ts_dts_surface_forms)
     _case("sig gate — TS .d.ts absence promoted for public member", _case_sig_ts_dts_absence_promotion)
+    _case("sig extractor — Python .pyi stub declaration forms", _case_sig_extract_python_pyi_forms)
+    _case("sig type-map — python_pyi spellings + Literal/Optional folds", _case_sig_python_pyi_type_map_and_literal)
+    _case("sig gate — Python .pyi lane drifts fail + presence degrades", _case_sig_python_pyi_lane_drifts_and_presence)
+    _case("sig gate — Python .pyi setter-property rows degrade, getter checked", _case_sig_python_pyi_setter_property_degrade)
     _case("sig extractor — C++ in-class decl", _case_sig_extract_cpp)
     _case("sig extractor — Rust core impl fn", _case_sig_extract_rust)
     _case("sig extractor — FFI extern fn", _case_sig_extract_ffi)

--- a/scripts/ci/tests/test_check_binding_parity.py
+++ b/scripts/ci/tests/test_check_binding_parity.py
@@ -1336,6 +1336,51 @@ def test_sig_orchestrator_return_drift_trips(tmp: pathlib.Path) -> None:
     assert any("cpp" in e and "return mismatch" in e for e in errs), errs
 
 
+def test_sig_dts_conflicting_overload_trips(tmp: pathlib.Path) -> None:
+    """The `.d.ts` gate FAILS when the package-entry augmentation matches the
+    spec but a re-exported generated declaration drifts to a non-client-facing
+    return. The two MERGE as overloads, so the raw return re-leaks even though
+    the resolved type resolves to the wrapper. Mirrors the `StreamView.batches`
+    leak the re-audit found."""
+    entry = tmp / "entry.d.ts"
+    entry.write_text(
+        "export * from './index'\n"
+        "declare module './index' {\n"
+        "  interface StreamView {\n"
+        "    batches(options?: BatchesOptions): Promise<RecordBatchStream>;\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    index = tmp / "index.d.ts"
+    index.write_text(
+        "export declare class StreamView {\n"
+        "  batches(options?: BatchesOptions | undefined | null): "
+        "Promise<RecordBatchStreamHandle>\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    row = [{
+        "class": "StreamView", "name": "batches", "typescript": True,
+        "signature": {
+            "ts_dts_params": ["BatchesOptions"], "returns": "RecordBatchStream",
+            # ts_napi has no source here; restrict the row to the .d.ts lang.
+            "skip_langs": ("ts_napi",),
+        },
+    }]
+    paths = dict(py_src=tmp / "none", ts_src=tmp / "none", ts_dts=entry,
+                 cpp_hpp=tmp / "none.hpp", client_rs=tmp / "none.rs", ffi_src=tmp / "none")
+    errs = cbp._sig_check_method_signatures(row, **paths)
+    assert any("conflicting public declaration" in e and "index.d.ts" in e for e in errs), errs
+    # Suppressing the generated declaration (skip_typescript) leaves the
+    # augmentation as the sole declaration — the gate goes silent.
+    index.write_text(
+        "export declare class StreamView {\n  isStreaming(): boolean\n}\n",
+        encoding="utf-8",
+    )
+    assert cbp._sig_check_method_signatures(row, **paths) == []
+
+
 def test_sig_name_only_fails_closed(tmp: pathlib.Path) -> None:
     """Fail-closed enrollment: a `[[method]]` row without `[method.signature]`
     FAILS unless it is in `NAME_ONLY_METHOD_ALLOWLIST`; the allowlisted row

--- a/scripts/ci/tests/test_check_binding_parity.py
+++ b/scripts/ci/tests/test_check_binding_parity.py
@@ -1336,11 +1336,19 @@ def test_sig_orchestrator_return_drift_trips(tmp: pathlib.Path) -> None:
     assert any("cpp" in e and "return mismatch" in e for e in errs), errs
 
 
-def test_sig_no_subtable_is_noop(tmp: pathlib.Path) -> None:
-    """A `[[method]]` row without `[method.signature]` is never checked."""
-    paths = _sig_tree(tmp, py_params="n: bool")  # would drift IF checked
+def test_sig_name_only_fails_closed(tmp: pathlib.Path) -> None:
+    """Fail-closed enrollment: a `[[method]]` row without `[method.signature]`
+    FAILS unless it is in `NAME_ONLY_METHOD_ALLOWLIST`; the allowlisted row
+    passes. No new row can be silently name-only."""
+    paths = _sig_tree(tmp, py_params="n: bool")
     rows = [{"class": "W", "name": "resize", "python": True}]
-    assert cbp._sig_check_method_signatures(rows, **paths) == []
+    errs = cbp._sig_check_method_signatures(rows, **paths)
+    assert any("neither a `[method.signature]`" in e for e in errs), errs
+    cbp.NAME_ONLY_METHOD_ALLOWLIST[("W", "resize")] = "test fixture"
+    try:
+        assert cbp._sig_check_method_signatures(rows, **paths) == []
+    finally:
+        del cbp.NAME_ONLY_METHOD_ALLOWLIST[("W", "resize")]
 
 
 def test_sig_extractor_getter_prefix_and_decl_position() -> None:
@@ -1540,7 +1548,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         _check("sig orchestrator RETURN drift trips", lambda: test_sig_orchestrator_return_drift_trips(pathlib.Path(tmp)))
     with tempfile.TemporaryDirectory() as tmp:
-        _check("sig no sub-table is a no-op", lambda: test_sig_no_subtable_is_noop(pathlib.Path(tmp)))
+        _check("sig name-only fails closed unless allowlisted", lambda: test_sig_name_only_fails_closed(pathlib.Path(tmp)))
     # Route-B signature specs ENGAGED (Phase 4a): extractor fixes + opaque/FFI
     # type handling + skip_langs + the live engaged-and-clean surface.
     _check("sig extractor get_ prefix + decl position", test_sig_extractor_getter_prefix_and_decl_position)

--- a/scripts/ci/tests/test_check_binding_parity.py
+++ b/scripts/ci/tests/test_check_binding_parity.py
@@ -1254,6 +1254,17 @@ def test_sig_extractors_read_each_binding(tmp: pathlib.Path) -> None:
     dts.write_text("export class W {\n  doIt(n: number): void\n}\n", encoding="utf-8")
     assert cbp._sig_extract_ts_dts(dts, "W", "doIt") == (["number"], "void")
 
+    pyi = tmp / "__init__.pyi"
+    pyi.write_text(
+        "class W:\n"
+        "    def do_it(self, n: Optional[int]) -> RecordBatchStream:\n        ...\n"
+        "    schema: Optional[int]\n",
+        encoding="utf-8",
+    )
+    assert cbp._sig_extract_python_pyi(pyi, "W", "do_it") == (["Optional[int]"], "RecordBatchStream")
+    # Bare-annotation property → zero-arg returning the annotation.
+    assert cbp._sig_extract_python_pyi(pyi, "W", "schema") == ([], "Optional[int]")
+
     hpp = tmp / "w.hpp"
     hpp.write_text(
         "class W {\npublic:\n    void f(size_t n, const std::string& s);\n};\n",
@@ -1294,7 +1305,8 @@ def _sig_tree(tmp: pathlib.Path, *, py_params: str, cpp_ret: str = "void") -> di
     (tmp / "ffi" / "f.rs").write_text(
         'pub extern "C" fn thetadatadx_w_resize(n: usize) -> i32 { 0 }\n', encoding="utf-8"
     )
-    return dict(py_src=tmp / "py", ts_src=tmp / "ts", ts_dts=tmp / "none.d.ts",
+    return dict(py_src=tmp / "py", pyi_path=tmp / "none.pyi",
+                ts_src=tmp / "ts", ts_dts=tmp / "none.d.ts",
                 cpp_hpp=hpp, client_rs=tmp / "none.rs", ffi_src=tmp / "ffi")
 
 
@@ -1368,7 +1380,8 @@ def test_sig_dts_conflicting_overload_trips(tmp: pathlib.Path) -> None:
             "skip_langs": ("ts_napi",),
         },
     }]
-    paths = dict(py_src=tmp / "none", ts_src=tmp / "none", ts_dts=entry,
+    paths = dict(py_src=tmp / "none", pyi_path=tmp / "none.pyi",
+                 ts_src=tmp / "none", ts_dts=entry,
                  cpp_hpp=tmp / "none.hpp", client_rs=tmp / "none.rs", ffi_src=tmp / "none")
     errs = cbp._sig_check_method_signatures(row, **paths)
     assert any("conflicting public declaration" in e and "index.d.ts" in e for e in errs), errs
@@ -1394,6 +1407,42 @@ def test_sig_name_only_fails_closed(tmp: pathlib.Path) -> None:
         assert cbp._sig_check_method_signatures(rows, **paths) == []
     finally:
         del cbp.NAME_ONLY_METHOD_ALLOWLIST[("W", "resize")]
+
+
+def test_sig_python_pyi_lane(tmp: pathlib.Path) -> None:
+    """The `.pyi` lane checks the stub against the cross-binding spec: a clean
+    stub passes; a RETURN drift (the axis Gate 6's stubtest cannot see) FAILS;
+    a dropped pinned declaration on a fully-enumerated stub class FAILS; a
+    member behind a class `__getattr__` degrades (no false-fail)."""
+    paths = _sig_tree(tmp, py_params="n: bool")
+    pyi = tmp / "__init__.pyi"
+    row = [{"class": "W", "name": "resize", "python": True,
+            "signature": {"params": ["bool"], "returns": "RecordBatchStream"}}]
+    pyi.write_text(
+        "class W:\n    def resize(self, n: bool) -> RecordBatchStream:\n        ...\n",
+        encoding="utf-8",
+    )
+    paths["pyi_path"] = pyi
+    assert cbp._sig_check_method_signatures(row, **paths) == [], \
+        cbp._sig_check_method_signatures(row, **paths)
+    # Stub return drift → fails (stubtest is blind to this).
+    pyi.write_text(
+        "class W:\n    def resize(self, n: bool) -> Any:\n        ...\n", encoding="utf-8"
+    )
+    errs = cbp._sig_check_method_signatures(row, **paths)
+    assert any("python_pyi" in e and "return mismatch" in e for e in errs), errs
+    # Dropped declaration on a fully-enumerated class → fails.
+    pyi.write_text("class W:\n    def other(self) -> bool:\n        ...\n", encoding="utf-8")
+    errs = cbp._sig_check_method_signatures(row, **paths)
+    assert any("python_pyi" in e and "removed public stub" in e for e in errs), errs
+    # Behind a class `__getattr__` → degrades, no false-fail.
+    pyi.write_text(
+        "class W:\n    def other(self) -> bool:\n        ...\n"
+        "    def __getattr__(self, name: str) -> Any:\n        ...\n",
+        encoding="utf-8",
+    )
+    assert cbp._sig_check_method_signatures(row, **paths) == [], \
+        cbp._sig_check_method_signatures(row, **paths)
 
 
 def test_sig_extractor_getter_prefix_and_decl_position() -> None:
@@ -1495,8 +1544,9 @@ def test_sig_live_surface_engaged_and_clean() -> None:
         "[method.signature] sub-tables"
     )
     errs = cbp._sig_check_method_signatures(
-        method_rows, py_src=cbp.PY_SRC, ts_src=cbp.TS_SRC, ts_dts=cbp.TS_DTS,
-        cpp_hpp=cbp.CPP_HPP, client_rs=cbp.CORE_CLIENT_RS, ffi_src=cbp.FFI_SRC,
+        method_rows, py_src=cbp.PY_SRC, pyi_path=cbp.PY_PYI, ts_src=cbp.TS_SRC,
+        ts_dts=cbp.TS_DTS, cpp_hpp=cbp.CPP_HPP, client_rs=cbp.CORE_CLIENT_RS,
+        ffi_src=cbp.FFI_SRC,
     )
     assert errs == [], f"live method signature gate must be clean; got {errs!r}"
     ffi_rows = data.get("ffi_symbol", [])

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1355,7 +1355,9 @@ cpp = true
 params = ["Option<usize>", "Option<u64>", "Option<String>", "Option<usize>"]
 returns = "RecordBatchStream"
 ts_napi_params = ["Option<BatchesOptions>"]
-ts_dts_params = ["BatchesOptions"]
+# The options bag is OPTIONAL on the `.d.ts` (`batches(options?: BatchesOptions)`);
+# pin it as `Option<...>` so a required-vs-optional drift on the param fails.
+ts_dts_params = ["Option<BatchesOptions>"]
 cpp_params = ["usize", "Duration", "Backpressure", "usize"]
 
 [[method]]

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -2004,6 +2004,10 @@ cpp = true
 [method.signature]
 returns = "String"
 cpp_returns = "i32"
+# The Python stub constrains the knob to its exact value set; pin the Literal
+# so adding / removing / renaming a member fails (the bare `String` would hide
+# the value-set drift). The pyo3-source `python` lane still reads `&str`.
+python_pyi_returns = 'Literal["batched", "immediate"]'
 
 [[method]]
 class = "Config"
@@ -2025,6 +2029,7 @@ cpp = true
 [method.signature]
 returns = "String"
 cpp_returns = "i32"
+python_pyi_returns = 'Literal["low_latency", "balanced", "efficient", "busy_spin"]'
 
 [[method]]
 class = "Config"
@@ -2155,6 +2160,7 @@ cpp = true
 # Reads back the selector string (`"PROD"` / `"STAGE"`); C++ `std::string`.
 [method.signature]
 returns = "String"
+python_pyi_returns = 'Literal["PROD", "STAGE"]'
 
 [[method]]
 class = "Config"
@@ -2164,6 +2170,38 @@ typescript = true
 cpp = true
 [method.signature]
 returns = "String"
+python_pyi_returns = 'Literal["PROD", "DEV"]'
+
+# The reconnect-jitter and streaming-host-selection readbacks. Both are
+# value-constrained enums exposed as readback getters on every binding: Python
+# (`Config.reconnect_jitter` / `Config.streaming_host_selection` properties),
+# TypeScript (`get reconnectJitter()` / `get streamingHostSelection()`), C++
+# (`Config::get_reconnect_jitter()` / `Config::get_streaming_host_selection()`,
+# each returning the enum's `int` discriminant). The `.pyi` constrains each to
+# its exact value set, pinned via `python_pyi_returns` so a value-set drift
+# fails — without these getter rows the constrained knobs were presence-tracked
+# only (the config-field roster), never type-checked on the stub.
+[[method]]
+class = "Config"
+name = "reconnectJitter"
+python = true
+typescript = true
+cpp = true
+[method.signature]
+returns = "String"
+cpp_returns = "i32"
+python_pyi_returns = 'Literal["full", "equal", "decorrelated", "none"]'
+
+[[method]]
+class = "Config"
+name = "streamingHostSelection"
+python = true
+typescript = true
+cpp = true
+[method.signature]
+returns = "String"
+cpp_returns = "i32"
+python_pyi_returns = 'Literal["shuffled", "fixed_order"]'
 
 # Custom reconnect-policy callback registration. A field-shaped getter
 # is meaningless for a callback, so the registration is tracked as a
@@ -2523,6 +2561,23 @@ cpp = true
 [method.signature]
 params = ["usize"]
 returns = "()"
+
+# The ring-size readback, exposed on every binding: Python
+# (`Config.streaming_ring_size` property), TypeScript
+# (`get streamingRingSize(): bigint`), C++ (`Config::get_streaming_ring_size()`
+# over the `thetadatadx_config_get_streaming_ring_size` FFI symbol). This row
+# pins the readback's TYPE on the `.pyi` lane — the `setStreamingRingSize`
+# setter above degrades that lane to the assignable property, so without this
+# getter row a `streaming_ring_size` stub drift to a non-integer would pass.
+[[method]]
+class = "Config"
+name = "streamingRingSize"
+python = true
+typescript = true
+cpp = true
+# usize element count: napi widens to BigInt, C++ to size_t, the stub to int.
+[method.signature]
+returns = "usize"
 
 [[method]]
 class = "Config"

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1034,6 +1034,10 @@ python = true
 typescript = true
 cpp = true
 rust = true         # `Client::historical()` view accessor
+# Zero-arg accessor; the returned historical view IS the cross-binding
+# contract (a rename / drop of the view trips the gate).
+[method.signature]
+returns = "HistoricalView"
 
 [[method]]
 class = "Client"
@@ -1042,6 +1046,8 @@ python = true
 typescript = true
 cpp = true
 rust = true         # `Client::stream()` view accessor
+[method.signature]
+returns = "StreamView"
 
 [[method]]
 class = "Client"
@@ -1050,6 +1056,8 @@ python = true
 typescript = true
 cpp = true
 rust = true         # `Client::flat_files()` view accessor
+[method.signature]
+returns = "FlatFilesNamespace"
 
 # Context-managed streaming session opener. A managed-binding ergonomic that
 # pairs `start_streaming` with a scope-exit `stop_streaming` + drain barrier:
@@ -1068,6 +1076,13 @@ python = true       # `with client.streaming(callback) as session:` context mana
 typescript = true   # `await using session = await client.streaming(callback)` wrapper
 cpp = false         # C++ uses the `Client` RAII destructor, no `streaming()` factory
 rust = false        # Rust uses scoped streaming APIs, no `streaming()` factory
+# Per-event callback in, context-managed session out. The TypeScript session
+# is the hand-written `.d.ts` wrapper with no napi `fn`, so `ts_napi` is
+# skipped (mirroring `startStreaming`); the `.d.ts` shape is cross-checked.
+[method.signature]
+params = ["Callback"]
+returns = "StreamingSession"
+skip_langs = ["ts_napi"]
 
 # ── Inline client construction (first-class API-key entry points) ──
 #
@@ -1100,6 +1115,9 @@ python = false      # Python uses the `Client(api_key=...)` constructor kwargs
 typescript = false  # TypeScript uses the `connectWith` options-object factory
 cpp = true          # `Client::builder()` fluent builder
 rust = true         # `Client::builder()` fluent builder
+# Zero-arg fluent entry; the returned `ClientBuilder` is the contract.
+[method.signature]
+returns = "ClientBuilder"
 
 [[method]]
 class = "Client"
@@ -1108,6 +1126,12 @@ python = false      # Python uses the `Client(api_key=...)` constructor kwargs
 typescript = true   # `Client.connectWith({ apiKey, historicalType, ... })` napi factory
 cpp = false         # C++ uses the `Client::builder()` fluent builder
 rust = false        # Rust uses the `Client::builder()` fluent builder
+# TypeScript-only inline factory: options object in, connected `Client` out.
+# The other bindings reach the surface through their own inline entry points
+# (tracked by `builder` / the constructor), so the row pins TypeScript alone.
+[method.signature]
+params = ["ClientConnectOptions"]
+returns = "Client"
 
 # Two Rust-core ergonomic conveniences carry no binding twin by design,
 # so they are intentional asymmetries rather than parity gaps:
@@ -1152,6 +1176,11 @@ rust = false        # Rust uses the `Client::builder()` fluent builder
 # orphan scan over this namespace fails if a binding grows a fetch method with no
 # enrolling row, so a future dataset accessor cannot ship untracked.
 
+# The five named fetch convenience methods share one shape: a single
+# date-string param, returning the decoded row collection. Rust takes `&str`
+# and returns the owned `Vec<FlatFileRow>` (the `FlatFileRowList` return
+# canonical carries that per-binding split); the managed bindings take their
+# String spelling and return the `FlatFileRowList` value object.
 [[method]]
 class = "FlatFilesNamespace"
 name = "optionTradeQuote"
@@ -1159,6 +1188,9 @@ python = true
 typescript = true
 cpp = true
 rust = true
+[method.signature]
+params = ["String"]
+returns = "FlatFileRowList"
 
 [[method]]
 class = "FlatFilesNamespace"
@@ -1167,6 +1199,9 @@ python = true
 typescript = true
 cpp = true
 rust = true
+[method.signature]
+params = ["String"]
+returns = "FlatFileRowList"
 
 [[method]]
 class = "FlatFilesNamespace"
@@ -1175,6 +1210,9 @@ python = true
 typescript = true
 cpp = true
 rust = true
+[method.signature]
+params = ["String"]
+returns = "FlatFileRowList"
 
 [[method]]
 class = "FlatFilesNamespace"
@@ -1183,6 +1221,9 @@ python = true
 typescript = true
 cpp = true
 rust = true
+[method.signature]
+params = ["String"]
+returns = "FlatFileRowList"
 
 [[method]]
 class = "FlatFilesNamespace"
@@ -1191,7 +1232,15 @@ python = true
 typescript = true
 cpp = true
 rust = true
+[method.signature]
+params = ["String"]
+returns = "FlatFileRowList"
 
+# The generic string-keyed dispatcher. The managed bindings take three String
+# params (sec-type, req-type, date); the Rust core takes the typed
+# `(SecType, ReqType, &str)` enums, so its param list is a per-lang override
+# (typed enums have no managed twin to pin canonically). Same row-collection
+# return as the named convenience methods.
 [[method]]
 class = "FlatFilesNamespace"
 name = "request"
@@ -1199,6 +1248,10 @@ python = true
 typescript = true
 cpp = true
 rust = true
+[method.signature]
+params = ["String", "String", "String"]
+returns = "FlatFileRowList"
+rust_params = ["FlatFileSecType", "FlatFileReqType", "String"]
 
 # The blob-to-disk helper writes a flat-file blob straight to a path in the vendor
 # wire format (csv / jsonl) without decoding into rows. Its home class and method
@@ -1216,6 +1269,17 @@ python = true
 typescript = true
 cpp = true
 rust = true         # `FlatFiles::to_path` on the `Client::flat_files()` view
+# Five params (sec-type, req-type, date, dest-path, wire-format). The first
+# three are Strings everywhere; the dest-path + format diverge per binding
+# (typed `impl AsRef<Path>` + `FlatFileFormat` enum on Rust; an optional
+# format String on the managed bindings), so the param list is pinned per
+# lang. The return is the written path (managed String / Rust `PathBuf`) or
+# `void` (C++ writes in place) — carried by the `WrittenPath` canonical.
+[method.signature]
+params = ["String", "String", "String", "String", "Option<String>"]
+returns = "WrittenPath"
+cpp_params = ["String", "String", "String", "String", "String"]
+rust_params = ["FlatFileSecType", "FlatFileReqType", "String", "DestPath", "FlatFileFormat"]
 
 # ── StreamView signature specs (the `client.stream()` lifecycle view) ──
 #
@@ -1401,8 +1465,12 @@ name = "ringOccupancy"
 python = true
 typescript = true
 cpp = true
+# Core / Python return the platform-width `usize`; the C++ binding mirrors the
+# fixed-width `uint64_t` of the C ABI accessor it wraps, so the C++ return is
+# pinned to the fixed-width canonical for that lang alone.
 [method.signature]
 returns = "usize"
+cpp_returns = "u64"
 
 [[method]]
 class = "StreamView"
@@ -1412,6 +1480,7 @@ typescript = true
 cpp = true
 [method.signature]
 returns = "usize"
+cpp_returns = "u64"
 
 [[method]]
 class = "StreamView"
@@ -1648,8 +1717,12 @@ name = "ringOccupancy"
 python = true
 typescript = true
 cpp = true
+# Core / Python return the platform-width `usize`; the C++ binding mirrors the
+# fixed-width `uint64_t` of the C ABI accessor it wraps (see the StreamView
+# twin), so the C++ return is pinned to the fixed-width canonical for that lang.
 [method.signature]
 returns = "usize"
+cpp_returns = "u64"
 
 [[method]]
 class = "StreamingClient"
@@ -1659,6 +1732,7 @@ typescript = true
 cpp = true
 [method.signature]
 returns = "usize"
+cpp_returns = "u64"
 
 [[method]]
 class = "StreamingClient"
@@ -1860,6 +1934,10 @@ name = "production"
 python = true
 typescript = true
 cpp = true
+# Zero-arg env-tier preset factory; returns a `Config` (`Self` on the managed
+# constructors, the value type in C++).
+[method.signature]
+returns = "Config"
 
 [[method]]
 class = "Config"
@@ -1867,6 +1945,8 @@ name = "dev"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "Config"
 
 [[method]]
 class = "Config"
@@ -1874,6 +1954,8 @@ name = "stage"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "Config"
 
 # Dotenv sourcing for the configuration: read the cluster selector
 # (`THETADATA_HISTORICAL_TYPE`) and the documented host overrides from a
@@ -1890,13 +1972,26 @@ name = "fromDotenv"
 python = true
 typescript = true   # `Config.fromDotenv(path)` napi factory
 cpp = true
+# `.env` path in, `Config` out.
+[method.signature]
+params = ["String"]
+returns = "Config"
 
+# The wait-strategy / flush-mode knobs diverge on C++: the managed bindings
+# pass / return the mode as a String name, while C++ uses the integer enum
+# code (`int`), so those cells are per-lang overrides. The iteration-count and
+# park-microsecond knobs are plain integers everywhere (napi widens the small
+# counts to `f64`, its native number type — the `usize`→`f64` sanction family).
 [[method]]
 class = "Config"
 name = "setFlushMode"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["String"]
+returns = "()"
+cpp_params = ["i32"]
 
 [[method]]
 class = "Config"
@@ -1904,6 +1999,9 @@ name = "flushMode"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "String"
+cpp_returns = "i32"
 
 [[method]]
 class = "Config"
@@ -1911,6 +2009,10 @@ name = "setWaitStrategy"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["String"]
+returns = "()"
+cpp_params = ["i32"]
 
 [[method]]
 class = "Config"
@@ -1918,6 +2020,9 @@ name = "waitStrategy"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "String"
+cpp_returns = "i32"
 
 [[method]]
 class = "Config"
@@ -1925,6 +2030,10 @@ name = "setWaitSpinIters"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["u32"]
+returns = "()"
+ts_napi_params = ["f64"]
 
 [[method]]
 class = "Config"
@@ -1932,6 +2041,8 @@ name = "waitSpinIters"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u32"
 
 [[method]]
 class = "Config"
@@ -1939,6 +2050,10 @@ name = "setWaitYieldIters"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["u32"]
+returns = "()"
+ts_napi_params = ["f64"]
 
 [[method]]
 class = "Config"
@@ -1946,6 +2061,8 @@ name = "waitYieldIters"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u32"
 
 [[method]]
 class = "Config"
@@ -1953,6 +2070,9 @@ name = "setWaitParkUs"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["u64"]
+returns = "()"
 
 [[method]]
 class = "Config"
@@ -1960,13 +2080,23 @@ name = "waitParkUs"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "u64"
 
+# The consumer-CPU pin is an optional core index. The managed bindings carry
+# it as an optional integer (`Option<usize>` / `Option<f64>` / `Option<u32>`);
+# C++ sentinel-encodes the option as a bare `int64_t` (-1 = unpinned), so the
+# C++ param + return are per-lang `i64` overrides.
 [[method]]
 class = "Config"
 name = "setConsumerCpu"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+params = ["Option<usize>"]
+returns = "()"
+cpp_params = ["i64"]
 
 [[method]]
 class = "Config"
@@ -1974,6 +2104,9 @@ name = "consumerCpu"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "Option<usize>"
+cpp_returns = "i64"
 
 # The `flushMode` / `deriveOhlcvc` readback getters are exposed on
 # every binding: Python (`Config.flush_mode` / `.derive_ohlcvc`
@@ -1991,6 +2124,8 @@ name = "deriveOhlcvc"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "bool"
 
 # The historical (MDDS) and streaming (FPSS) environments are read back
 # through two independent getters. The two channels are selected
@@ -2015,6 +2150,9 @@ name = "historicalEnvironment"
 python = true
 typescript = true
 cpp = true
+# Reads back the selector string (`"PROD"` / `"STAGE"`); C++ `std::string`.
+[method.signature]
+returns = "String"
 
 [[method]]
 class = "Config"
@@ -2022,6 +2160,8 @@ name = "streamingEnvironment"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "String"
 
 # Custom reconnect-policy callback registration. A field-shaped getter
 # is meaningless for a callback, so the registration is tracked as a
@@ -2048,12 +2188,17 @@ cpp = true
 # collector's struct key. Dropping or renaming a builder on any binding
 # trips the per-method gate.
 
+# Each builder is zero-arg and returns the built fluent subscription value
+# object (`PySubscription` / napi `Subscription` / C++ `FluentSubscription`),
+# carried by the `BuiltSubscription` return canonical.
 [[method]]
 class = "Contract"
 name = "quote"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "BuiltSubscription"
 
 [[method]]
 class = "Contract"
@@ -2061,6 +2206,8 @@ name = "trade"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "BuiltSubscription"
 
 [[method]]
 class = "Contract"
@@ -2068,6 +2215,8 @@ name = "openInterest"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "BuiltSubscription"
 
 [[method]]
 class = "Contract"
@@ -2075,6 +2224,8 @@ name = "marketValue"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "BuiltSubscription"
 
 [[method]]
 class = "SecType"
@@ -2082,6 +2233,8 @@ name = "fullTrades"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "BuiltSubscription"
 
 [[method]]
 class = "SecType"
@@ -2089,6 +2242,8 @@ name = "fullOpenInterest"
 python = true
 typescript = true
 cpp = true
+[method.signature]
+returns = "BuiltSubscription"
 
 # ── Subscription getters (the built fluent subscription handle) ──
 #
@@ -2407,6 +2562,9 @@ python = true
 typescript = false
 cpp = false
 rust = true         # `pub fn session_uuid` on the Rust unified client
+# Zero-arg readback of the session UUID string (Python + Rust).
+[method.signature]
+returns = "String"
 
 [[method]]
 class = "Client"
@@ -2415,6 +2573,10 @@ python = true
 typescript = false
 cpp = false
 rust = true         # `pub fn subscription_info` on the Rust unified client
+# Active-subscription snapshot: Python a `Vec<(root, kind)>` tuple list, the
+# Rust core the opaque `SubscriptionInfo` struct (per-binding return shapes).
+[method.signature]
+returns = "SubscriptionInfo"
 
 # ─── Value-field TYPE parity ──────────────────────────────────────────
 #

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2907,24 +2907,6 @@ export declare class StreamView {
   startStreaming(callback: ((arg: StreamEvent) => void)): Promise<void>
   /** Whether the streaming connection is active. */
   isStreaming(): boolean
-  /**
-   * Open a pull-based columnar reader over the live stream, a sibling to the per-event callback. Returns a reader of Apache Arrow record batches under a fixed schema; the same subscriptions feed it. Tune batch_size, linger, and backpressure on the returned builder/reader.
-   * Open a pull-based columnar reader over the live stream.
-   *
-   * Returns a reader handle — a sibling to the per-event
-   * `startStreaming(callback)`. The same subscriptions feed it,
-   * but market-data events arrive as apache-arrow `RecordBatch`
-   * values under a fixed schema, consumed with `for await`. The
-   * reader closes (unsubscribes + tears down) on `close()` or
-   * `Symbol.asyncDispose`. Subscribe on this same surface first,
-   * then open the reader.
-   *
-   * `batchSize` rows per batch (default 65536); `lingerMs`
-   * flushes a partial batch on a quiet stream (default 50);
-   * `backpressure` is `"block"` (default, lossless) or
-   * `"dropOldest"`; `capacity` bounds the drop-oldest buffer.
-   */
-  batches(options?: BatchesOptions | undefined | null): Promise<RecordBatchStreamHandle>
   /** Get a snapshot of currently active subscriptions. */
   activeSubscriptions(): any
   /**

--- a/sdks/typescript/src/_generated/streaming_methods.rs
+++ b/sdks/typescript/src/_generated/streaming_methods.rs
@@ -154,7 +154,7 @@ impl StreamView {
     /// flushes a partial batch on a quiet stream (default 50);
     /// `backpressure` is `"block"` (default, lossless) or
     /// `"dropOldest"`; `capacity` bounds the drop-oldest buffer.
-    #[napi(js_name = "batches")]
+    #[napi(js_name = "batches", skip_typescript)]
     pub async fn batches(&self, options: Option<crate::streaming_batches::BatchesOptions>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {
         let options = options.unwrap_or_default();
         crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), options.batch_size, options.linger_ms, options.backpressure, options.capacity).await


### PR DESCRIPTION
An independent audit of the cross-SDK parity signature guard (`scripts/ci/check_binding_parity.py` + `sdks/parity.toml`) found three false-guarantee gaps where a real binding drift would pass while the gate stayed green. This closes all three.

## Exact-width integer type-map (was unsound for C++ and FFI)

Both `uint64_t`/`size_t` were accepted for `u64` AND `usize` on the C++/FFI cells, so a `u64`-pinned method that drifted to `size_t` (or a `usize` method that drifted to `uint64_t`) passed. The cells are now split with zero overlap: `u64` accepts the fixed-width spellings only (`uint64_t`/`std::uint64_t`; ffi `u64`/`uint64_t`), `usize` the platform-width only (`size_t`/`std::size_t`; ffi `usize`/`size_t`). The split surfaced four real rows where the C++ binding deliberately widens the core's platform-width `usize` to the fixed-width `uint64_t` of the C ABI accessor it wraps (`StreamView`/`StreamingClient` `ringOccupancy`/`ringCapacity`); each now states that widening with a per-row `cpp_returns = "u64"` override rather than relying on a loose cell.

## `ts_dts` passed silently on absence and never compared properties

The `.d.ts` extractor only matched method-call declarations, so a property (`readonly dropped: number`) was never read, and an absent declaration was treated as success. The extractor now also parses property and getter/static/`readonly` forms, follows the `export * from './index'` re-export so it reads the full public surface (the wrapper augmentations plus the generated `index.d.ts`), and unwraps `Promise<T>` async returns. A missing declaration is now an error for a row whose class IS part of the public `.d.ts` surface (a dropped public member), while a row whose class is genuinely absent from the declared surface still degrades to napi-as-authority. Removing the `StreamView.batches` augmentation now fails the gate; a legitimately napi-only row still passes.

## 41 name-only rows could hide a signature drift

A `[method.signature]` was opt-in, so 41 of 120 `[[method]]` rows carried only presence booleans and a return/param drift on them stayed invisible. The gate now fails closed: every `[[method]]` row must carry a `[method.signature]` or an explicit `NAME_ONLY_METHOD_ALLOWLIST` entry, so no new row can be silently name-only. 40 of the 41 are pinned on their real signatures (the `Client` view accessors and builder, the `FlatFilesNamespace` fetch surface, the `Config` knobs and factories, the `Contract`/`SecType` builders, the `Client.streaming`/`connectWith`/`sessionUuid`/`subscriptionInfo` entries); the one row with no comparable cross-binding signature (`Config.setReconnectCallback`, structurally divergent callback-registration machinery) is allowlisted with a stated reason.

Pinning the real signatures surfaced two extractor mis-parses, both fixed with probes: the pyo3 by-value bound-self receiver (`slf: Py<Self>`) is now stripped like `&self`, and a Rust `Result<T, E>` return now unwraps to the ok type `T`.

## Verification

`python3 scripts/ci/check_binding_parity.py --selftest` (197 passed), `python3 scripts/ci/check_binding_parity.py` (clean: 120 method rows, 119 signature-pinned + 1 allowlisted), `python3 scripts/ci/tests/test_check_binding_parity.py` (54 passed), and `generate_sdk_surfaces --features config-file -- --check` (no drift) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)