### PR TITLE
chore(release): prepare 13.0.0-rc.6

### DIFF
--- a/.github/release-notes/v13.0.0-rc.6.md
+++ b/.github/release-notes/v13.0.0-rc.6.md
@@ -1,0 +1,23 @@
+## ThetaDataDx 13.0.0-rc.6
+
+This release candidate aligns the bundled HTTP server with the v3 contract (a breaking server change), closes a C++ use-after-free in async historical queries, hardens TypeScript input handling, and fixes two streaming-teardown deadlocks. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.6/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- The bundled HTTP server speaks the v3 `/v3` contract. Every REST and WebSocket route now matches the v3 request and response shapes: the bare v3 body without the legacy envelope, ISO local-datetime timestamps, `CALL` / `PUT` rights, option rows grouped under their contract, CSV as the default format, and a `410 Gone` that names the v3 replacement for a removed v2 parameter. The default bind address is `0.0.0.0`; pass `--bind 127.0.0.1` for loopback-only. This is a breaking change to the server surface; see the Breaking changes in the CHANGELOG.
+- A C++ lifetime fix. An async historical query launched from a temporary `client.historical()` view can no longer use the client after it is freed: the view and the client co-own the handle and the streaming callback state, so a returned future safely outlives the object it was launched from, and the handle is freed exactly once, after the last in-flight future completes.
+- Streaming robustness. Two teardown paths no longer hold the internal lock across the shutdown drain wait, so a user callback that re-enters a status read while events drain cannot deadlock stop, free, or reconnect. A streaming client whose delivery loop dies now reports unhealthy immediately rather than only after teardown.
+- TypeScript input safety. The config and drain-timeout setters reject a negative, fractional, non-finite, or out-of-range value as a typed error instead of silently rewriting it, and reconstructing a tick from an Arrow IPC stream rejects a `bigint` that does not fit its destination column instead of truncating it.
+- Routine dependency maintenance. The Cargo and npm lockfiles are refreshed across the workspace and the four standalone manifests, with no reported advisory outstanding.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.6"`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. If you sent something in and you do not see your name, that is on us, not you, and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.6] - 2026-06-28
+
+### Breaking changes
+
+- **Server:** the bundled HTTP server now speaks the v3 `/v3` contract on every REST and WebSocket route (#959). REST responses drop the `{header, response}` envelope for the bare v3 body, fold each date plus milliseconds-of-day pair into one ISO local-datetime string under the field name the v3 schema documents per endpoint (`timestamp`, `trade_timestamp` / `quote_timestamp`, `created` / `last_trade`, `underlying_timestamp`), spell the option right as `CALL` / `PUT`, rename `implied_volatility` to `implied_vol` (and the bid/ask variants), group option rows under their `(expiration, strike, right)` contract as `{"response":[{"contract":{...},"data":[...]}]}`, return list endpoints as single-key objects, default an absent `format` to CSV with the v3 column order and CRLF framing, and serve the v3 route and parameter spellings (the request-type path-segment routes, the `/v3/{sec_type}/flat_file/{req_type}` form, `/v3/calendar/today`, `/v3/calendar/year_holidays`, `/v3/interest_rate/history/eod`, and upstream parameter defaults), rejecting a deprecated v2 query parameter with `410 Gone` that names its v3 replacement. The default bind address changes to `0.0.0.0`; pass `--bind 127.0.0.1` for loopback-only.
+
+### Removed
+
+- A number of unused public API items with no in-tree callers were removed across the core, FFI, C++, Python, TypeScript, and server surfaces (#964, #965, #971, #975, #994). Each removed item had no functional caller and is not reachable through any documented client workflow.
+
+### Fixed
+
+- **C++:** an async historical query (`<endpoint>_async`) launched from a temporary `client.historical()` view can no longer use the client after it is freed (#997, #1001, #1002). The view and the owning client co-own the underlying handle and the streaming callback state, so a returned future may safely outlive the object it was launched from (including a client destroyed mid-query while streaming), and the handle is freed exactly once, only after the last in-flight future completes.
+- **Streaming:** stopping, freeing, or reconnecting a standalone streaming client no longer holds the internal lock across the shutdown drain wait, so a user callback that re-enters a status read while events drain cannot deadlock teardown (#979, #980). Both the live and the already-shut-down free paths release the lock before the drain wait.
+- **Streaming:** a streaming client whose delivery loop dies on an unexpected error now reports unhealthy immediately rather than only after teardown (#999). The dispatcher publishes a failed state from its own thread the moment an outer panic ends event iteration, so `is_streaming` / `is_authenticated` (Python and the C ABI) fold to false without waiting for a teardown that may never come; per-callback panic isolation is unchanged.
+- **TypeScript:** the streaming dispatcher publishes a failed state when its event loop ends on an outer panic, so `isStreaming()` / `isAuthenticated()` report a dead delivery loop even when no teardown is called; the process-wide async runtime build is fallible and surfaces a build failure as a typed error at connect rather than panicking (#998).
+- **TypeScript:** the config tuning setters and the drain-timeout arguments validate their numeric input at the binding boundary, so a negative, fractional, non-finite, or out-of-range value is rejected as `InvalidParameterError` instead of being silently rewritten; burst-size and attempt-budget knobs additionally reject `0` (#998).
+- **TypeScript:** reconstructing a tick from an Arrow IPC stream rejects a `bigint` whose magnitude does not fit the destination `i64` column with `InvalidParameterError`, naming the column, instead of silently truncating it (#1000).
+- **Server:** the WebSocket surface emits and accepts the option `strike` in dollars in both directions, matching the unit the SDK, REST, and documentation already speak (#981). A `$550.00` strike serializes as `550.0`, and a subscribe payload carries the strike as a dollars number; the wire's fixed-point integer never leaves the codec layer.
+- **Server:** a malformed (non-UTF-8 percent-encoded) flat-file path segment now returns the canonical JSON error envelope with status `400` and `Content-Type: application/json`, matching the query and POST siblings, instead of a plain-text rejection (#988).
+
+### Documentation
+
+- The reference Parameters table and the OpenAPI document now describe the `expiration=*` and `right=*` chain-wide wildcards on every option endpoint that accepts them, rendered from the endpoint capability so the note cannot drift from the served behavior; the nine endpoints that reject `expiration=*` keep the plain description (#960, #963).
+- The streaming guide pulls a synchronous record batch with `next_blocking` (#995).
+
+### Changed
+
+- **Branding:** the project logo is refreshed and shown at the top of every package README so it renders on GitHub and on the package registries (#961).
+
+### Security
+
+- Routine dependency maintenance refreshes the Cargo and npm lockfiles across the workspace and the four standalone manifests (#996): rustls 0.23.41 (synced across all five lockfiles), napi 3.9.4, time 0.3.51, zerocopy 0.8.52, zeroize 1.9.0, and wasm-bindgen 0.2.126, with patch and minor bumps elsewhere and a refreshed npm package-lock. These are version updates, not a fix for any reported advisory; the dependency advisory scan reports none.
+
 ## [13.0.0-rc.5] - 2026-06-24
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.5"
+thetadatadx = "13.0.0-rc.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.5"
+thetadatadx = "13.0.0-rc.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.5", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.6", features = ["polars"] }
 ```
 
 ## Quick start

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.5"
+thetadatadx = "13.0.0-rc.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.6] - 2026-06-28
+
+### Breaking changes
+
+- **Server:** the bundled HTTP server now speaks the v3 `/v3` contract on every REST and WebSocket route (#959). REST responses drop the `{header, response}` envelope for the bare v3 body, fold each date plus milliseconds-of-day pair into one ISO local-datetime string under the field name the v3 schema documents per endpoint (`timestamp`, `trade_timestamp` / `quote_timestamp`, `created` / `last_trade`, `underlying_timestamp`), spell the option right as `CALL` / `PUT`, rename `implied_volatility` to `implied_vol` (and the bid/ask variants), group option rows under their `(expiration, strike, right)` contract as `{"response":[{"contract":{...},"data":[...]}]}`, return list endpoints as single-key objects, default an absent `format` to CSV with the v3 column order and CRLF framing, and serve the v3 route and parameter spellings (the request-type path-segment routes, the `/v3/{sec_type}/flat_file/{req_type}` form, `/v3/calendar/today`, `/v3/calendar/year_holidays`, `/v3/interest_rate/history/eod`, and upstream parameter defaults), rejecting a deprecated v2 query parameter with `410 Gone` that names its v3 replacement. The default bind address changes to `0.0.0.0`; pass `--bind 127.0.0.1` for loopback-only.
+
+### Removed
+
+- A number of unused public API items with no in-tree callers were removed across the core, FFI, C++, Python, TypeScript, and server surfaces (#964, #965, #971, #975, #994). Each removed item had no functional caller and is not reachable through any documented client workflow.
+
+### Fixed
+
+- **C++:** an async historical query (`<endpoint>_async`) launched from a temporary `client.historical()` view can no longer use the client after it is freed (#997, #1001, #1002). The view and the owning client co-own the underlying handle and the streaming callback state, so a returned future may safely outlive the object it was launched from (including a client destroyed mid-query while streaming), and the handle is freed exactly once, only after the last in-flight future completes.
+- **Streaming:** stopping, freeing, or reconnecting a standalone streaming client no longer holds the internal lock across the shutdown drain wait, so a user callback that re-enters a status read while events drain cannot deadlock teardown (#979, #980). Both the live and the already-shut-down free paths release the lock before the drain wait.
+- **Streaming:** a streaming client whose delivery loop dies on an unexpected error now reports unhealthy immediately rather than only after teardown (#999). The dispatcher publishes a failed state from its own thread the moment an outer panic ends event iteration, so `is_streaming` / `is_authenticated` (Python and the C ABI) fold to false without waiting for a teardown that may never come; per-callback panic isolation is unchanged.
+- **TypeScript:** the streaming dispatcher publishes a failed state when its event loop ends on an outer panic, so `isStreaming()` / `isAuthenticated()` report a dead delivery loop even when no teardown is called; the process-wide async runtime build is fallible and surfaces a build failure as a typed error at connect rather than panicking (#998).
+- **TypeScript:** the config tuning setters and the drain-timeout arguments validate their numeric input at the binding boundary, so a negative, fractional, non-finite, or out-of-range value is rejected as `InvalidParameterError` instead of being silently rewritten; burst-size and attempt-budget knobs additionally reject `0` (#998).
+- **TypeScript:** reconstructing a tick from an Arrow IPC stream rejects a `bigint` whose magnitude does not fit the destination `i64` column with `InvalidParameterError`, naming the column, instead of silently truncating it (#1000).
+- **Server:** the WebSocket surface emits and accepts the option `strike` in dollars in both directions, matching the unit the SDK, REST, and documentation already speak (#981). A `$550.00` strike serializes as `550.0`, and a subscribe payload carries the strike as a dollars number; the wire's fixed-point integer never leaves the codec layer.
+- **Server:** a malformed (non-UTF-8 percent-encoded) flat-file path segment now returns the canonical JSON error envelope with status `400` and `Content-Type: application/json`, matching the query and POST siblings, instead of a plain-text rejection (#988).
+
+### Documentation
+
+- The reference Parameters table and the OpenAPI document now describe the `expiration=*` and `right=*` chain-wide wildcards on every option endpoint that accepts them, rendered from the endpoint capability so the note cannot drift from the served behavior; the nine endpoints that reject `expiration=*` keep the plain description (#960, #963).
+- The streaming guide pulls a synchronous record batch with `next_blocking` (#995).
+
+### Changed
+
+- **Branding:** the project logo is refreshed and shown at the top of every package README so it renders on GitHub and on the package registries (#961).
+
+### Security
+
+- Routine dependency maintenance refreshes the Cargo and npm lockfiles across the workspace and the four standalone manifests (#996): rustls 0.23.41 (synced across all five lockfiles), napi 3.9.4, time 0.3.51, zerocopy 0.8.52, zeroize 1.9.0, and wasm-bindgen 0.2.126, with patch and minor bumps elsewhere and a refreshed npm package-lock. These are version updates, not a fix for any reported advisory; the dependency advisory scan reports none.
+
 ## [13.0.0-rc.5] - 2026-06-24
 
 ### Breaking changes

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.5
+  version: 13.0.0-rc.6
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arrow",
  "disruptor",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.5",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.5",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.5"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.6",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.6",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.6"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Prepares the **13.0.0-rc.6** release candidate. Version-and-docs only — no source changes.

## What this PR does

Bumps every version pin from 13.0.0-rc.5 to 13.0.0-rc.6 via `scripts/release/bump_version.py` (the seven workspace and standalone Cargo manifests, the four npm package.json files plus optionalDependencies, all five Cargo.lock files), plus the README install snippets and the OpenAPI `info.version` that `check_version_sync.py` enforces. Adds the 13.0.0-rc.6 CHANGELOG entry (mirrored byte-identical to the docs-site changelog) and the release notes.

## What the release contains

Since rc.5: the bundled HTTP server v3 contract alignment (breaking), a C++ async-view use-after-free fix, two streaming-teardown deadlock fixes, TypeScript input validation and Arrow bigint safety, the removal of unused public API, and a routine dependency refresh. The full itemized list is in CHANGELOG.md. The cross-SDK signature-parity guarantee landed in #1003 through #1008 is internal CI tooling with no user-facing API delta and is not listed in the changelog.

## Gates

- `check_version_sync.py`: ok
- `check_docs_consistency.py`: ok (changelogs byte-identical)
- `check_client_facing_vocab.py`: clean
- Lockfile diff is the member version strings only — no dependency changes.

## Before tagging

- This PR is not to be auto-merged. The release tag is the maintainer's call.
- The live cross-language validation (`scripts/release/validate_release.sh`, which connects to the account) is the maintainer's pre-tag step, not run here.
- An independent codex review of the parity build (#1003 through #1008) ran to convergence: six rounds, nine false-guarantee paths found and fixed, final verdict sound end-to-end. The hardening (#1008) is merged and included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
