### PR TITLE
fix(python): allowlist __aexit__ in stubtest alongside __exit__

### DIFF
--- a/sdks/python/stubtest_allowlist.txt
+++ b/sdks/python/stubtest_allowlist.txt
@@ -63,11 +63,13 @@ thetadatadx\.HistoricalClient\.__new__
 thetadatadx\.HistoricalClient\.__getattr__
 thetadatadx\.StreamingSession\.__getattr__
 
-# `__exit__` on pyo3 context managers carries default values for
-# the three positional args at runtime (matching `Optional[...] = None`
-# semantics). The hand-written stub elides the defaults because the
-# user is never going to call `__exit__` directly. Allow the swap.
+# `__exit__` / `__aexit__` on pyo3 context managers carry default
+# values for the three positional args at runtime (matching
+# `Optional[...] = None` semantics). The hand-written stub elides the
+# defaults because the user is never going to call them directly, only
+# through `with` / `async with`. Allow the swap.
 thetadatadx\..*\.__exit__
+thetadatadx\..*\.__aexit__
 
 # `EventCallback` is a `Callable[..., None]` alias declared in the
 # stub for documentation purposes — it never appears at runtime


### PR DESCRIPTION
The pyo3 async context manager exposes `__aexit__` with default values on its three positional args, which the hand-written `__init__.pyi` stub elides exactly as it does for `__exit__`. stubtest (Gate 6) flags the swap as inconsistent. Allowlist `__aexit__` matching the existing `__exit__` carve-out — the user only reaches it through `async with`, never directly.

Surfaced on the rc.6 release PR (#1009) because its version bump touched a Python build path and re-triggered stubtest, which the parity-hardening PRs had skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)