### PR TITLE
docs(site): redesign the landing page around surfaces and developer experience

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -44,13 +44,8 @@ export default defineConfig({
       { text: 'Articles', link: '/articles/getting-started' },
       { text: 'API Reference', link: '/reference/' },
       { text: 'Streaming', link: '/streaming/' },
-      {
-        text: 'Tools',
-        items: [
-          { text: 'Server (HTTP/WS)', link: '/server/' },
-          { text: 'MCP Server', link: '/mcp' },
-        ],
-      },
+      { text: 'MCP', link: '/mcp' },
+      { text: 'Server', link: '/server/' },
       { text: 'ThetaData Docs', link: 'https://docs.thetadata.us/' },
     ],
 

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -1,31 +1,101 @@
 ---
 layout: home
 title: ThetaDataDx
-description: SDK for ThetaData market data — historical, streaming, and bulk flat files in Rust, Python, TypeScript, and C++.
+description: Every ThetaData endpoint, historical, streaming, and bulk, over REST, four native SDKs, or an MCP server for AI.
 
 hero:
   name: "ThetaDataDx"
-  text: "Market data. Four languages."
-  tagline: "Historical, real-time streaming, and bulk flat files from ThetaData — one SDK surface in Rust, Python, TypeScript, and C++."
+  text: "Every ThetaData endpoint, however you work."
+  tagline: "Historical, streaming, and bulk market data through whatever fits how you build: a REST API, four native SDKs, or an MCP server for your AI."
   actions:
     - theme: brand
-      text: Get Started
+      text: Quickstart
       link: /articles/getting-started
+    - theme: alt
+      text: Browse the REST API
+      link: /reference/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/userFRM/ThetaDataDx
 
 features:
   - icon:
       src: /icons/globe.svg
-    title: "API Reference"
-    details: "Every endpoint, one page: typed signatures and runnable samples in Rust, Python, TypeScript, C++, and HTTP."
+    title: "REST API"
+    details: "Every endpoint over plain HTTP. Curl it from the shell or call it from any stack. Typed JSON, CSV, or NDJSON responses."
     link: /reference/
   - icon:
       src: /icons/bolt.svg
     title: "Streaming"
-    details: "Real-time quotes, trades, and open interest with a typed callback in every language."
+    details: "Live quotes, trades, and open interest over WebSocket, delivered as typed events through a callback you register once."
     link: /streaming/
   - icon:
       src: /icons/terminal.svg
-    title: "Server & Tools"
-    details: "A local HTTP/WebSocket server speaking the v3 route surface, a CLI, and an MCP server for LLM clients."
+    title: "MCP for AI"
+    details: "Point Claude or any LLM at ThetaData and ask for an options chain in plain English. A tool per endpoint, no code to write."
+    link: /mcp
+  - icon:
+      src: /icons/rust.svg
+    title: "Native SDKs"
+    details: "Rust, Python, TypeScript, and C++ over one identical surface. Zero-copy decode, the same method names in every language."
+    link: /reference/
+  - icon:
+      src: /icons/chart.svg
+    title: "Self-host Server"
+    details: "Run the HTTP + WebSocket gateway yourself on the v3 route surface. Existing scripts point at it unchanged."
     link: /server/
 ---
+
+## A quote in seconds
+
+The latest NBBO quote for `AAPL`, four ways. Pick the one that fits your stack. Same data, same fields, from a [free or paid subscription](/articles/subscriptions).
+
+::: code-group
+
+```bash [cURL]
+# Start the server once: thetadatadx-server --api-key "$THETADATA_API_KEY" &
+curl 'http://127.0.0.1:25503/v3/stock/snapshot/quote?symbol=AAPL'
+```
+
+```python [Python]
+from thetadatadx import Client
+
+client = Client(api_key="your_api_key")
+[q] = client.historical.stock_snapshot_quote(["AAPL"])
+print(q.bid, q.ask)
+```
+
+```typescript [TypeScript]
+import { Client } from 'thetadatadx';
+
+const client = await Client.connectWith({ apiKey: 'your_api_key' });
+const [q] = await client.historical.stockSnapshotQuote(['AAPL']);
+console.log(q.bid, q.ask);
+```
+
+```rust [Rust]
+let client = thetadatadx::Client::builder().api_key("your_api_key").connect().await?;
+let rows = client.historical().stock_snapshot_quote(&["AAPL"]).await?;
+println!("{} {}", rows[0].bid, rows[0].ask);
+```
+
+:::
+
+## What are you building?
+
+| Goal | Start here |
+|---|---|
+| A research notebook | [Python SDK](/reference/): install, authenticate, pull history into pandas or polars. |
+| A live signal or dashboard | [Streaming](/streaming/): typed quote, trade, and open-interest events over WebSocket. |
+| An AI assistant or agent | [MCP for AI](/mcp): give any LLM client a tool per endpoint, no code. |
+| A backend or existing tool | [REST API](/reference/) or the [self-host server](/server/): plain HTTP on the v3 routes. |
+
+## Install
+
+```bash
+pip install thetadatadx      # Python 3.12+, prebuilt wheels
+npm install thetadatadx      # Node.js 20+, native binaries
+cargo add thetadatadx        # Rust, async over tokio
+```
+
+C++ links the same C ABI: build `thetadatadx-ffi`, then include `thetadatadx-cpp/include/thetadatadx.hpp`. Full steps in the [Quickstart](/articles/getting-started).

--- a/docs-site/docs/public/llms.txt
+++ b/docs-site/docs/public/llms.txt
@@ -2,7 +2,7 @@
 # SDK for ThetaData market data: Rust, Python, TypeScript, C++, plus a local HTTP/WebSocket server and an MCP server.
 # One line per page: path — summary. All paths are relative to the docs site root.
 
-/ — ThetaDataDx: SDK for ThetaData market data — historical, streaming, and bulk flat files in Rust, Python, TypeScript, and C++.
+/ — ThetaDataDx: Every ThetaData endpoint, historical, streaming, and bulk, over REST, four native SDKs, or an MCP server for AI.
 /articles/ai-llms — Building with AI / LLMs: Machine-readable entry points for coding assistants and LLM agents.
 /articles/concurrent-requests — Concurrent Requests: How many historical requests run in parallel per subscription tier.
 /articles/conditions — Trade & Quote Conditions: Condition code mapping for the condition fields on trade and quote rows.


### PR DESCRIPTION
Reworks the docs-site landing to route by surface and intent instead of by language.

The old hero led with "Market data. Four languages." and three generic cards that buried the real surfaces and still featured the deleted CLI. The new page leads with the data and the access variety, then routes a visitor to whatever fits how they work.

What changed:
- Hero now names the access variety (REST, four native SDKs, MCP) over the language count, with a primary Quickstart action plus Browse the REST API and a GitHub link.
- A runnable "A quote in seconds" code-group sits under the hero with cURL, Python, TypeScript, and Rust tabs, each making a real stock_snapshot_quote call read from the reference pages and the SDK surfaces.
- Five surface cards (REST API, Streaming, MCP for AI, Native SDKs, Self-host Server) reusing the existing icon set, keeping the no-code paths (REST and MCP) prominent for non-developers.
- A "What are you building?" intent router and copy-paste installs (pip / npm / cargo add plus the C++ header) verified against the package configs.
- Nav drops the now-dead CLI surface and promotes MCP to a top-level entry alongside Server.

No /cli link remains anywhere outside the historical changelog (which references the old tools/cli path in past release notes). npm run build passes with no broken-link errors and the home renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)