### PR TITLE
chore(release): prepare 13.0.0-rc.6

### DIFF
--- a/.github/release-notes/v13.0.0-rc.6.md
+++ b/.github/release-notes/v13.0.0-rc.6.md
@@ -1,0 +1,24 @@
+## ThetaDataDx 13.0.0-rc.6
+
+This release candidate moves the bundled HTTP server onto the v3 REST and WebSocket contract (a breaking change), removes the bundled CLI tool and the SDK's client-side Greeks calculator, and lands a round of correctness and robustness fixes across the C++, TypeScript, and server surfaces. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.6/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- The bundled server speaks the v3 contract. REST responses use the v3 `{response}` body with ISO datetimes, `CALL` / `PUT` rights, option rows grouped under their contract, a CSV default, and plain-text errors, and the WebSocket surface emits and parses the v3 stream shape. The server now binds `0.0.0.0` by default. This is a breaking change to the server's wire surface.
+- The bundled CLI tool and the SDK's client-side Black-Scholes Greeks calculator are removed. The local `all_greeks` / `implied_volatility` calculator is gone from every binding; ThetaData's own served Greeks (the eod, trade, and snapshot greeks endpoints and their tick types) are unchanged and still available.
+- A C++ async historical-view use-after-free is fixed. Async historical methods are now ref-qualified, the underlying handle and the streaming callback state are shared into the async future, and a call on a dangling temporary view is a compile error.
+- Two streaming-teardown deadlocks are fixed. Shutting down, freeing, or reconnecting a standalone streaming client no longer hangs when the user callback re-enters a status read on the same client.
+- TypeScript input hardening. Numeric inputs are validated at the boundary and reject a non-finite, negative, fractional, or out-of-range value, the Arrow path rejects a bigint that will not narrow losslessly, and a dead streaming dispatcher now reports an unhealthy state.
+- Routine dependency maintenance across the Rust and npm trees, with zero advisories outstanding.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.6"`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. The server v3 move and the CLI and Greeks-calculator removals change real surfaces, so if anything in the migration trips you up, open an issue and we will sort it out. If you sent something in and you do not see your name, that is on us, not you, and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.6] - 2026-06-29
+
+### Breaking changes
+
+- **Server:** the bundled HTTP server now speaks the v3 REST and WebSocket contract (#959). REST responses drop the older `{header, response}` envelope for the v3 `{response}` body, fold the separate date and ms-of-day columns into one ISO local-datetime per endpoint, spell the option right as `CALL` / `PUT`, group option rows under their `{expiration, strike, right}` contract, default an absent `format` to CSV with CRLF framing and the v3 column order, and return errors as a plain-text status. The WebSocket surface emits and parses the v3 stream shape. The server also now binds `0.0.0.0` by default.
+- **CLI tool removed:** the bundled `thetadatadx` command-line binary is removed (#1011). The SDKs and the bundled HTTP server are unaffected.
+- **Client-side Greeks calculator removed:** the SDK's local Black-Scholes Greeks calculator is removed across every binding (#1016): Rust `all_greeks` / `implied_volatility` and the per-Greek primitives, the TypeScript `allGreeks` / `impliedVolatility`, and the FFI, C++, and MCP equivalents. ThetaData's own served Greeks are unchanged and still available: the eod, trade, and snapshot greeks endpoints and their tick types are untouched. Only the client-computed calculator is gone. The option-right parser moves out of the greeks namespace to `thetadatadx::right`.
+
+### Removed
+
+- The client-side Black-Scholes Greeks calculator (#1016) and the bundled CLI tool (#1011), both listed under Breaking changes above.
+- A number of unused public API items with no callers, across the core and the FFI surface (#964, #965, #971, #975, #994).
+
+### Fixed
+
+- **C++:** an async historical-view use-after-free is fixed (#997, #1001, #1002). Async historical methods are ref-qualified so a call on a dangling temporary view is a compile error, the underlying handle is shared into the async future rather than captured by reference, and the streaming callback state is co-owned by the view so a future can no longer outlive the state it reads.
+- **Streaming teardown:** two teardown deadlocks are fixed. Shutting down, freeing, or reconnecting a standalone streaming client no longer hangs when the user callback, draining events, re-enters a status read on the same client; teardown now releases the lock that read needs before waiting for the drain (#979, #980).
+- **TypeScript:** numeric inputs are validated at the boundary (#998, #999, #1000). The config knobs, the drain timeouts, and the worker, CPU, and iteration setters reject a non-finite, negative, fractional, or out-of-range value as `InvalidParameterError` instead of silently coercing it; the Arrow reconstruct path rejects a bigint that would not narrow losslessly into an i64 column; and the streaming dispatcher publishes a failed state when its event loop dies, so `isStreaming()` and `isAuthenticated()` report the dead loop even if teardown is never called.
+- **Server:** the WebSocket subscribe and contract envelope carry the option strike in dollars, not thousandths, matching the unit the SDK, REST, and docs already use (#981).
+- **Server:** a malformed flat-file path segment now returns the canonical JSON error envelope its sibling routes return, rather than a default plain-text rejection (#988).
+
+### Documentation
+
+- The expiration and right chain wildcards are documented from the endpoint capability set (#960, #963).
+- The streaming guide uses the synchronous pull (`next_blocking`) for its blocking example (#995).
+- The documentation site landing page is redesigned around the SDK surfaces and the developer experience (#1015).
+
+### Security
+
+- A routine dependency refresh across the Rust and npm trees (#996), with zero advisories outstanding. This is maintenance, not a fix for any reported vulnerability.
+
 ## [13.0.0-rc.5] - 2026-06-24
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.5"
+thetadatadx = "13.0.0-rc.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.5"
+thetadatadx = "13.0.0-rc.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.6] - 2026-06-29
+
+### Breaking changes
+
+- **Server:** the bundled HTTP server now speaks the v3 REST and WebSocket contract (#959). REST responses drop the older `{header, response}` envelope for the v3 `{response}` body, fold the separate date and ms-of-day columns into one ISO local-datetime per endpoint, spell the option right as `CALL` / `PUT`, group option rows under their `{expiration, strike, right}` contract, default an absent `format` to CSV with CRLF framing and the v3 column order, and return errors as a plain-text status. The WebSocket surface emits and parses the v3 stream shape. The server also now binds `0.0.0.0` by default.
+- **CLI tool removed:** the bundled `thetadatadx` command-line binary is removed (#1011). The SDKs and the bundled HTTP server are unaffected.
+- **Client-side Greeks calculator removed:** the SDK's local Black-Scholes Greeks calculator is removed across every binding (#1016): Rust `all_greeks` / `implied_volatility` and the per-Greek primitives, the TypeScript `allGreeks` / `impliedVolatility`, and the FFI, C++, and MCP equivalents. ThetaData's own served Greeks are unchanged and still available: the eod, trade, and snapshot greeks endpoints and their tick types are untouched. Only the client-computed calculator is gone. The option-right parser moves out of the greeks namespace to `thetadatadx::right`.
+
+### Removed
+
+- The client-side Black-Scholes Greeks calculator (#1016) and the bundled CLI tool (#1011), both listed under Breaking changes above.
+- A number of unused public API items with no callers, across the core and the FFI surface (#964, #965, #971, #975, #994).
+
+### Fixed
+
+- **C++:** an async historical-view use-after-free is fixed (#997, #1001, #1002). Async historical methods are ref-qualified so a call on a dangling temporary view is a compile error, the underlying handle is shared into the async future rather than captured by reference, and the streaming callback state is co-owned by the view so a future can no longer outlive the state it reads.
+- **Streaming teardown:** two teardown deadlocks are fixed. Shutting down, freeing, or reconnecting a standalone streaming client no longer hangs when the user callback, draining events, re-enters a status read on the same client; teardown now releases the lock that read needs before waiting for the drain (#979, #980).
+- **TypeScript:** numeric inputs are validated at the boundary (#998, #999, #1000). The config knobs, the drain timeouts, and the worker, CPU, and iteration setters reject a non-finite, negative, fractional, or out-of-range value as `InvalidParameterError` instead of silently coercing it; the Arrow reconstruct path rejects a bigint that would not narrow losslessly into an i64 column; and the streaming dispatcher publishes a failed state when its event loop dies, so `isStreaming()` and `isAuthenticated()` report the dead loop even if teardown is never called.
+- **Server:** the WebSocket subscribe and contract envelope carry the option strike in dollars, not thousandths, matching the unit the SDK, REST, and docs already use (#981).
+- **Server:** a malformed flat-file path segment now returns the canonical JSON error envelope its sibling routes return, rather than a default plain-text rejection (#988).
+
+### Documentation
+
+- The expiration and right chain wildcards are documented from the endpoint capability set (#960, #963).
+- The streaming guide uses the synchronous pull (`next_blocking`) for its blocking example (#995).
+- The documentation site landing page is redesigned around the SDK surfaces and the developer experience (#1015).
+
+### Security
+
+- A routine dependency refresh across the Rust and npm trees (#996), with zero advisories outstanding. This is maintenance, not a fix for any reported vulnerability.
+
 ## [13.0.0-rc.5] - 2026-06-24
 
 ### Breaking changes

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.5
+  version: 13.0.0-rc.6
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.5"
+thetadatadx = "13.0.0-rc.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.5", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.6", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.6",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.5",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.5",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.5"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.6",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.6",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.6"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
@@ -10,6 +10,8 @@ repository = "https://github.com/userFRM/ThetaDataDx"
 # Binary — not published to crates.io. Only `thetadatadx` is published
 # per the publish-crate CI job.
 publish = false
+
+[workspace]
 
 [[bin]]
 name = "thetadatadx-mcp"
@@ -24,9 +26,10 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 zeroize = "1.8.2"
 
-# Match the main workspace's strict bar. This crate is `[workspace.exclude]`d
-# in the root `Cargo.toml` (standalone manifest, not a member), so it can't
-# inherit via `[lints] workspace = true` — mirror the rules locally.
+# Match the main workspace's strict bar. This crate declares its own
+# `[workspace]` table so it's an independent workspace — it can't inherit
+# via `[lints] workspace = true` from the parent repo. Mirror the rules
+# locally to keep `cargo clippy` parity.
 [lints.rust]
 warnings = "deny"
 unsafe_op_in_unsafe_fn = "deny"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.5"
+version = "13.0.0-rc.6"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Prepares the 13.0.0-rc.6 release candidate.

Bumps every Cargo manifest, lockfile, and npm package pin from 13.0.0-rc.5 to 13.0.0-rc.6 via the supported bump script, plus the README, getting-started, and OpenAPI version pins the script does not cover. Adds the CHANGELOG entry (copied byte-identical to the docs site) and the release notes.

The standalone mcp tool now declares its own `[workspace]` table, mirroring the server tool, so the bump script's lockfile refresh resolves it as an independent workspace instead of being claimed by the parent checkout's workspace across the worktree boundary. This is the same isolation the other excluded manifests already use.

User-facing changes in this candidate: the bundled server now speaks the v3 REST and WebSocket contract (breaking), the bundled CLI tool and the client-side Greeks calculator are removed (breaking), a C++ async historical-view use-after-free and two streaming-teardown deadlocks are fixed, TypeScript numeric inputs are validated at the boundary, and dependencies are refreshed with zero advisories. ThetaData's own served Greeks are unchanged.

Static gates pass: check_version_sync, check_docs_consistency, check_client_facing_vocab. The lockfile diffs are member-version-string bumps only, with no dependency changes.

Do not merge: the maintainer cuts the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
