### PR TITLE
docs: add a public roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ common `ThetaDataError` base.
 
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md) for where the project is headed. Up next: a [native Go SDK](https://github.com/userFRM/ThetaDataDx/issues/1019) and [`npx`-installable MCP](https://github.com/userFRM/ThetaDataDx/issues/1020).
+See [ROADMAP.md](ROADMAP.md) for where the project is headed. Up next: a [native Go SDK](https://github.com/userFRM/ThetaDataDx/issues/1019), a [self-updating server](https://github.com/userFRM/ThetaDataDx/issues/957), and [`npx`-installable MCP](https://github.com/userFRM/ThetaDataDx/issues/1020).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ common `ThetaDataError` base.
 - [Documentation site](https://userfrm.github.io/ThetaDataDx/): getting started, API reference, streaming, server, and MCP
 - [Changelog](CHANGELOG.md)
 
+## Roadmap
+
+See [ROADMAP.md](ROADMAP.md) for where the project is headed. Up next: a [native Go SDK](https://github.com/userFRM/ThetaDataDx/issues/1019) and [`npx`-installable MCP](https://github.com/userFRM/ThetaDataDx/issues/1020).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,20 @@
+# Roadmap
+
+This roadmap shows where ThetaDataDx is headed. It is intentionally undated: items move between horizons as priorities shift, and nothing here is a commitment. Each item links to a tracking issue where you can follow progress or weigh in.
+
+## Now
+
+Stabilizing v13 toward a stable `13.0.0` release. The release-candidate series is hardening the four SDKs, the bundled server, the MCP server, and the documentation ahead of the first stable cut.
+
+## Next
+
+- **Native Go SDK** ([#1019](https://github.com/userFRM/ThetaDataDx/issues/1019)). A first-class Go SDK written in pure Go, not a cgo wrapper. It will be a native peer of the other SDKs, held to the same machine-enforced cross-SDK parity guarantee, so Go keeps everything that makes it Go: static-binary cross-compilation, the goroutine scheduler under streaming load, and a toolchain-free `go get`.
+- **MCP over npm** ([#1020](https://github.com/userFRM/ThetaDataDx/issues/1020)). Run the MCP server with `npx -y thetadatadx-mcp`: no Rust toolchain, the one-line config every MCP client expects. `cargo install` stays for Rust users.
+
+## Recently shipped
+
+One identical surface across the Rust, Python, TypeScript, and C++ SDKs with machine-enforced cross-binding parity, a REST and WebSocket server, an MCP server, and a generated OpenAPI reference. See the [CHANGELOG](CHANGELOG.md) for the full history.
+
+---
+
+Have a request, or a different priority? [Open an issue](https://github.com/userFRM/ThetaDataDx/issues/new), or bring it up on the [ThetaData Discord](https://discord.thetadata.us/).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@ Stabilizing v13 toward a stable `13.0.0` release. The release-candidate series i
 ## Next
 
 - **Native Go SDK** ([#1019](https://github.com/userFRM/ThetaDataDx/issues/1019)). A first-class Go SDK written in pure Go, not a cgo wrapper. It will be a native peer of the other SDKs, held to the same machine-enforced cross-SDK parity guarantee, so Go keeps everything that makes it Go: static-binary cross-compilation, the goroutine scheduler under streaming load, and a toolchain-free `go get`.
+- **Self-updating server** ([#957](https://github.com/userFRM/ThetaDataDx/issues/957)). Push a tagged release and running servers pick it up, verify its signature, and swap themselves in, with staged rollout and a force-upgrade floor. Operators get urgent fixes without a manual re-download.
 - **MCP over npm** ([#1020](https://github.com/userFRM/ThetaDataDx/issues/1020)). Run the MCP server with `npx -y thetadatadx-mcp`: no Rust toolchain, the one-line config every MCP client expects. `cargo install` stays for Rust users.
 
 ## Recently shipped


### PR DESCRIPTION
Adds a public `ROADMAP.md` (Now / Next / Recently shipped, undated, GitHub now-next-later style) and links it from the README.

The two Next items are tracked in #1019 (native Go SDK, pure Go not cgo) and #1020 (MCP over npm). Nothing dated, nothing committed; each links to its tracking issue for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)