### PR TITLE
feat(mcp): distribute the mcp server as an npx-runnable npm package

### DIFF
--- a/.github/workflows/release-mcp-npm.yml
+++ b/.github/workflows/release-mcp-npm.yml
@@ -140,6 +140,34 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      # Refuse to publish unless the Release tag matches the version every
+      # package.json carries. A `release: published` fires for any tag, so
+      # without this an accidental or mis-tagged Release would publish the
+      # branch's current version (and pick its `next`/`latest` dist-tag from
+      # it). Assert (1) all six manifests — launcher + five platform — agree,
+      # then (2) the tag is exactly `v<version>` (the repo's tag convention).
+      # `RELEASE_TAG` comes via env, never interpolated into the script body.
+      - name: Preflight — tag matches package version
+        working-directory: tools/mcp/npm
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./thetadatadx-mcp/package.json').version")
+          for dir in thetadatadx-mcp linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
+            v=$(node -p "require('./${dir}/package.json').version")
+            if [ "$v" != "$version" ]; then
+              echo "::error::package version mismatch: ${dir}/package.json is ${v}, launcher is ${version} — all six manifests must agree"
+              exit 1
+            fi
+          done
+          if [ "$RELEASE_TAG" != "v${version}" ]; then
+            echo "::error::release tag ${RELEASE_TAG} does not match package version ${version} (expected tag v${version}) — refusing to publish"
+            exit 1
+          fi
+          echo "preflight ok: tag ${RELEASE_TAG} matches version ${version}"
+
       - name: Download all binary artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release-mcp-npm.yml
+++ b/.github/workflows/release-mcp-npm.yml
@@ -1,0 +1,210 @@
+name: Release MCP npm Package
+
+# Ships the MCP server (`tools/mcp`) to npm so `npx -y thetadatadx-mcp` runs
+# it with no Rust toolchain. The model mirrors esbuild / biome: a tiny JS
+# launcher package (`thetadatadx-mcp`) plus one prebuilt-binary package per
+# platform (`thetadatadx-mcp-<platform>`), wired as optionalDependencies so
+# npm installs only the host's binary.
+#
+# Each platform's binary is built on that platform's own native runner (no
+# cross-compilation from a single host), matching release-server.yml. On a
+# published GitHub Release the packages are published to npm; a manual
+# workflow_dispatch builds and uploads the binaries as workflow artifacts
+# only (no publish), so a release candidate can be smoke-tested without a
+# registry push.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-mcp-npm-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x64 — static musl so the one binary runs on any
+          # glibc/musl distribution; the platform package declares no
+          # `libc`, matching that portability.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            platform: linux-x64
+          # Linux arm64 — native arm runner, static musl for the same reason.
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            platform: linux-arm64
+          # macOS arm64 (Apple silicon) — the native target of the runner.
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            platform: darwin-arm64
+          # macOS x64 (Intel) — cross-target on the same Apple-silicon
+          # runner via `rustup target add`; both Apple targets share
+          # macos-latest.
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            platform: darwin-x64
+          # Windows x64 — MSVC toolchain, `.exe`.
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: win32-x64
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # The MCP crate declares its own `[workspace]`, so its build
+          # output lands under `tools/mcp/target`. Key the cache on the
+          # target triple so each matrix leg keeps a separate cache.
+          workspaces: tools/mcp
+          key: ${{ matrix.target }}
+
+      # `thetadatadx` builds its gRPC client from `proto/mdds.proto` via
+      # prost-build, which needs the protobuf compiler on every runner.
+      - uses: ./.github/actions/install-protoc
+
+      # musl is not a host target on the ubuntu runners. `musl-tools`
+      # provides the `musl-gcc` wrapper that ring / zstd's C build invokes
+      # when targeting the `*-unknown-linux-musl` triples.
+      - name: Install musl toolchain (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Add Rust target
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build release binary
+        shell: bash
+        # The musl C builds (ring, zstd) need an explicit compiler; cargo
+        # reads the target-scoped CC. Darwin/MSVC legs ignore the x64 var,
+        # and the arm64 leg sets its own.
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
+        run: cargo build --release --locked --manifest-path tools/mcp/Cargo.toml --target ${{ matrix.target }}
+
+      - name: Stage binary
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          bindir="tools/mcp/target/${{ matrix.target }}/release"
+          stage="$(mktemp -d)"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp "$bindir/thetadatadx-mcp.exe" "$stage/"
+          else
+            cp "$bindir/thetadatadx-mcp" "$stage/"
+          fi
+          echo "dir=$stage" >> "$GITHUB_OUTPUT"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-${{ matrix.platform }}
+          path: ${{ steps.stage.outputs.dir }}/thetadatadx-mcp*
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build
+    # Publish only on a real tag/release; workflow_dispatch builds the
+    # binaries (above) for testing but never pushes to the registry.
+    if: github.event_name == 'release'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: mcp-artifacts
+
+      # Drop each downloaded binary into its platform package. The artifact
+      # folder name encodes the platform; map it back to the Rust triple
+      # `populate.mjs` expects.
+      - name: Populate platform packages
+        working-directory: tools/mcp/npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          declare -A TRIPLE=(
+            [linux-x64]=x86_64-unknown-linux-musl
+            [linux-arm64]=aarch64-unknown-linux-musl
+            [darwin-x64]=x86_64-apple-darwin
+            [darwin-arm64]=aarch64-apple-darwin
+            [win32-x64]=x86_64-pc-windows-msvc
+          )
+          for platform in "${!TRIPLE[@]}"; do
+            dir="$GITHUB_WORKSPACE/mcp-artifacts/mcp-${platform}"
+            bin="$dir/thetadatadx-mcp"
+            [ "$platform" = "win32-x64" ] && bin="$dir/thetadatadx-mcp.exe"
+            node scripts/populate.mjs "${TRIPLE[$platform]}" "$bin"
+          done
+          ls -lR -- */thetadatadx-mcp* || true
+
+      # Publish the platform packages first, then the launcher — so a
+      # freshly installed launcher always finds its optionalDependency on
+      # the registry. Idempotent: skip a version already published. The
+      # dist-tag mirrors the TypeScript SDK — a hyphenated pre-release
+      # version (e.g. `13.0.0-rc.6`) goes to `next`, a final release to
+      # `latest`.
+      - name: Publish platform packages
+        working-directory: tools/mcp/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for dir in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
+            pkg_name=$(node -p "require('./${dir}/package.json').name")
+            pkg_version=$(node -p "require('./${dir}/package.json').version")
+            if npm view "${pkg_name}@${pkg_version}" version 2>/dev/null; then
+              echo "skip ${pkg_name}@${pkg_version} (already published)"
+            else
+              dist_tag=latest
+              case "$pkg_version" in *-*) dist_tag=next;; esac
+              npm publish "$dir" --access public --tag "$dist_tag"
+            fi
+          done
+
+      - name: Publish launcher package
+        working-directory: tools/mcp/npm/thetadatadx-mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkg_version=$(node -p "require('./package.json').version")
+          if npm view "thetadatadx-mcp@${pkg_version}" version 2>/dev/null; then
+            echo "skip thetadatadx-mcp@${pkg_version} (already published)"
+          else
+            dist_tag=latest
+            case "$pkg_version" in *-*) dist_tag=next;; esac
+            npm publish --provenance --access public --tag "$dist_tag"
+          fi

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ common `ThetaDataError` base.
 | [`thetadatadx-cpp`](thetadatadx-cpp/) | header + prebuilt library | C++ wrapper over the C ABI |
 | [`thetadatadx-ffi`](thetadatadx-ffi/) | release artifacts | C ABI for embedders |
 | [`tools/server`](tools/server/) | `thetadatadx-server` | Local HTTP / WebSocket server |
-| [`tools/mcp`](tools/mcp/) | `thetadatadx-mcp` | MCP server exposing every historical endpoint to AI clients |
+| [`tools/mcp`](tools/mcp/) | `thetadatadx-mcp` (npm) | MCP server exposing every historical endpoint to AI clients |
 | [`docs-site`](docs-site/) | — | Documentation site (GitHub Pages) |
 
 ## Documentation
@@ -297,7 +297,7 @@ common `ThetaDataError` base.
 
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md) for where the project is headed. Up next: a [native Go SDK](https://github.com/userFRM/ThetaDataDx/issues/1019), a [self-updating server](https://github.com/userFRM/ThetaDataDx/issues/957), and [`npx`-installable MCP](https://github.com/userFRM/ThetaDataDx/issues/1020).
+See [ROADMAP.md](ROADMAP.md) for where the project is headed. Up next: a [native Go SDK](https://github.com/userFRM/ThetaDataDx/issues/1019) and a [self-updating server](https://github.com/userFRM/ThetaDataDx/issues/957). The MCP server now runs straight from npm — `npx -y thetadatadx-mcp`.
 
 ## Contributing
 

--- a/docs-site/docs/mcp.md
+++ b/docs-site/docs/mcp.md
@@ -7,21 +7,32 @@ description: Give any Model Context Protocol client live access to every histori
 
 `thetadatadx-mcp` is a Model Context Protocol server over stdio: any MCP-capable client (Claude Desktop, Cursor, and others) gets a tool per historical endpoint, speaking JSON-RPC 2.0.
 
-## Install
-
-```bash
-cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx
-```
-
 ## Configure your client
 
-Most MCP clients read an `mcpServers` block from a project-local or user-level settings file; the shape is the same across clients (for example `.cursor/mcp.json` in Cursor):
+Most MCP clients read an `mcpServers` block from a project-local or user-level settings file; the shape is the same across clients (for example `.cursor/mcp.json` in Cursor). Point the client at `npx`, which downloads and runs the server on demand — no toolchain to install:
 
 ```json
 {
   "mcpServers": {
     "thetadata": {
-      "command": "thetadatadx-mcp",
+      "command": "npx",
+      "args": ["-y", "thetadatadx-mcp"],
+      "env": {
+        "THETADATA_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+`npx -y thetadatadx-mcp` fetches a prebuilt binary for your platform (Linux, macOS, and Windows on x64 and arm64) and runs it; nothing else to install. To authenticate with an email and password instead of an API key, swap the `env` block:
+
+```json
+{
+  "mcpServers": {
+    "thetadata": {
+      "command": "npx",
+      "args": ["-y", "thetadatadx-mcp"],
       "env": {
         "THETADATA_EMAIL": "you@example.com",
         "THETADATA_PASSWORD": "your-password"
@@ -31,22 +42,15 @@ Most MCP clients read an `mcpServers` block from a project-local or user-level s
 }
 ```
 
-To authenticate with an API key instead of email and password, set `THETADATA_API_KEY` in the `env` block (or pass `--api-key <KEY>` in `args`):
-
-```json
-{
-  "mcpServers": {
-    "thetadata": {
-      "command": "thetadatadx-mcp",
-      "env": {
-        "THETADATA_API_KEY": "your-api-key"
-      }
-    }
-  }
-}
-```
-
 The server resolves credentials in this order, highest first: the `--api-key` flag, then `THETADATA_API_KEY`, then `THETADATA_EMAIL` + `THETADATA_PASSWORD`, then a `--creds` file (email on line 1, password on line 2). The same names authenticate the SDK, the server, and every binding.
+
+### Rust users: build from source
+
+If you already have a Rust toolchain, install the binary directly and set `"command": "thetadatadx-mcp"` instead of the `npx` invocation above:
+
+```bash
+cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx
+```
 
 ::: warning
 Keep credentials in environment variables or a secrets manager — not in config files committed to version control.

--- a/scripts/ci/check_version_sync.py
+++ b/scripts/ci/check_version_sync.py
@@ -385,6 +385,27 @@ def main() -> int:
                 f"{package_json_version(platform_pkg)}, expected {canonical}"
             )
 
+    # The MCP server ships to npm as well (`npx -y thetadatadx-mcp`): a
+    # launcher package plus one prebuilt-binary package per platform, all
+    # under `tools/mcp/npm/`. They pin the canonical version exactly like
+    # the TypeScript packages and are bumped by `bump_version.py` in the
+    # same pass; scan every `package.json` (launcher + platforms) and the
+    # launcher's optionalDependencies so a missed bump trips this gate
+    # instead of shipping a launcher that depends on a stale binary
+    # package.
+    for mcp_pkg in (ROOT / "tools" / "mcp" / "npm").glob("*/package.json"):
+        if package_json_version(mcp_pkg) != canonical:
+            failures.append(
+                f"{mcp_pkg.relative_to(ROOT)} version is "
+                f"{package_json_version(mcp_pkg)}, expected {canonical}"
+            )
+        for name, pinned in package_json_optional_deps(mcp_pkg).items():
+            if pinned != canonical:
+                failures.append(
+                    f"{mcp_pkg.relative_to(ROOT)} optionalDependencies"
+                    f"['{name}'] is {pinned}, expected {canonical}"
+                )
+
     # Published Python wheel version. `thetadatadx-py/pyproject.toml` is
     # `dynamic = ["version"]` + maturin, so the wheel version is taken
     # from `thetadatadx-py/Cargo.toml` `[package].version` at build time, not

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -6,11 +6,12 @@ Usage:
 
 Reads the canonical version from ``thetadatadx-rs/Cargo.toml`` (only
 to print "from -> to" for context), then walks every file that pins a
-version of the published artifact and rewrites it. All four npm
-``package.json`` files, the six member Cargo.toml files (thetadatadx +
-ffi + tools/mcp + tools/server + thetadatadx-py +
-thetadatadx-ts), and the three ``optionalDependencies`` pins inside
-``thetadatadx-ts/package.json``. Cargo.lock files are refreshed via
+version of the published artifact and rewrites it. Every npm
+``package.json`` file (the TypeScript SDK launcher + its three platform
+packages, and the MCP server launcher + its five platform packages), the
+six member Cargo.toml files (thetadatadx + ffi + tools/mcp + tools/server
++ thetadatadx-py + thetadatadx-ts), and the ``optionalDependencies`` pins
+inside both ``package.json`` launchers. Cargo.lock files are refreshed via
 ``cargo update --workspace`` against every manifest that carries its own
 lockfile.
 
@@ -141,6 +142,22 @@ def main(argv: list[str]) -> int:
     print("  bumped thetadatadx-ts/package.json (+ optionalDependencies)")
 
     for platform_pkg in (ROOT / "thetadatadx-ts" / "npm").glob("*/package.json"):
+        bump_platform_package_json(platform_pkg, current, target)
+        print(f"  bumped {platform_pkg.relative_to(ROOT)}")
+
+    # The MCP server ships to npm too (`npx -y thetadatadx-mcp`): a launcher
+    # package with per-platform binary packages as optionalDependencies,
+    # mirroring the TypeScript SDK layout under `tools/mcp/npm/`.
+    bump_root_package_json(
+        ROOT / "tools" / "mcp" / "npm" / "thetadatadx-mcp" / "package.json",
+        current,
+        target,
+    )
+    print("  bumped tools/mcp/npm/thetadatadx-mcp/package.json (+ optionalDependencies)")
+
+    for platform_pkg in (ROOT / "tools" / "mcp" / "npm").glob("*/package.json"):
+        if platform_pkg.parent.name == "thetadatadx-mcp":
+            continue  # the launcher package, bumped above
         bump_platform_package_json(platform_pkg, current, target)
         print(f"  bumped {platform_pkg.relative_to(ROOT)}")
 

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -29,7 +29,7 @@ No install step is needed: point your MCP client at `npx -y thetadatadx-mcp` (se
 Rust users can install the binary directly instead:
 
 ```bash
-cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx
+git clone https://github.com/userFRM/ThetaDataDx && cargo install --path ThetaDataDx/tools/mcp
 ```
 
 Or build from source:
@@ -37,7 +37,7 @@ Or build from source:
 ```bash
 cd tools/mcp
 cargo build --release
-# Binary at ../../target/release/thetadatadx-mcp
+# Binary at tools/mcp/target/release/thetadatadx-mcp
 ```
 
 ## Configuration

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -24,6 +24,10 @@ The server authenticates **once** at startup, keeps the `Client` client alive, a
 
 ## Install
 
+No install step is needed: point your MCP client at `npx -y thetadatadx-mcp` (see [Configuration](#configuration)). `npx` downloads a prebuilt binary for your platform (Linux, macOS, and Windows on x64 and arm64) and runs it on demand.
+
+Rust users can install the binary directly instead:
+
 ```bash
 cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx
 ```
@@ -60,16 +64,16 @@ If no credentials are provided, the server starts in **offline mode**: only `pin
 
 ### Stdio MCP clients (config file)
 
-Most MCP clients read an `mcpServers` block from a project-local or user-level settings file. The shape is identical across clients; consult your client's docs for the exact file path.
+Most MCP clients read an `mcpServers` block from a project-local or user-level settings file. The shape is identical across clients; consult your client's docs for the exact file path. The `npx` command needs no prior install:
 
 ```json
 {
   "mcpServers": {
     "thetadata": {
-      "command": "thetadatadx-mcp",
+      "command": "npx",
+      "args": ["-y", "thetadatadx-mcp"],
       "env": {
-        "THETADATA_EMAIL": "you@example.com",
-        "THETADATA_PASSWORD": "your-password"
+        "THETADATA_API_KEY": "your-api-key"
       }
     }
   }
@@ -82,12 +86,14 @@ Or with a creds file:
 {
   "mcpServers": {
     "thetadata": {
-      "command": "thetadatadx-mcp",
-      "args": ["--creds", "/path/to/creds.txt"]
+      "command": "npx",
+      "args": ["-y", "thetadatadx-mcp", "--creds", "/path/to/creds.txt"]
     }
   }
 }
 ```
+
+If you installed the binary with `cargo install`, set `"command": "thetadatadx-mcp"` and drop the `npx` wrapper args.
 
 ### Cursor
 

--- a/tools/mcp/npm/.gitignore
+++ b/tools/mcp/npm/.gitignore
@@ -1,0 +1,4 @@
+# Binaries are dropped into each platform package at release time by
+# scripts/populate.mjs; only the package.json files are tracked.
+*/thetadatadx-mcp
+*/thetadatadx-mcp.exe

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "thetadatadx-mcp-darwin-arm64",
+  "version": "13.0.0-rc.6",
+  "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/userFRM/ThetaDataDx"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "thetadatadx-mcp",
+  "files": [
+    "thetadatadx-mcp"
+  ],
+  "engines": {
+    "node": ">= 18"
+  }
+}

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "thetadatadx-mcp-darwin-x64",
+  "version": "13.0.0-rc.6",
+  "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/userFRM/ThetaDataDx"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "thetadatadx-mcp",
+  "files": [
+    "thetadatadx-mcp"
+  ],
+  "engines": {
+    "node": ">= 18"
+  }
+}

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "thetadatadx-mcp-linux-arm64",
+  "version": "13.0.0-rc.6",
+  "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/userFRM/ThetaDataDx"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "thetadatadx-mcp",
+  "files": [
+    "thetadatadx-mcp"
+  ],
+  "engines": {
+    "node": ">= 18"
+  }
+}

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "thetadatadx-mcp-linux-x64",
+  "version": "13.0.0-rc.6",
+  "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/userFRM/ThetaDataDx"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "thetadatadx-mcp",
+  "files": [
+    "thetadatadx-mcp"
+  ],
+  "engines": {
+    "node": ">= 18"
+  }
+}

--- a/tools/mcp/npm/scripts/populate.mjs
+++ b/tools/mcp/npm/scripts/populate.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Drop a freshly built mcp binary into its platform package before publish.
+// The release workflow builds one binary per Rust target triple and calls
+// this once per triple; it copies the binary into the matching
+// `thetadatadx-mcp-<platform>` package and marks it executable.
+//
+//   node scripts/populate.mjs <rust-target-triple> <path-to-binary>
+//
+// Run from `tools/mcp/npm/` (or anywhere — paths resolve against this file).
+
+import { chmodSync, copyFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Rust target triple -> [platform package dir, binary name].
+const TARGETS = {
+  "x86_64-unknown-linux-musl": ["linux-x64", "thetadatadx-mcp"],
+  "aarch64-unknown-linux-musl": ["linux-arm64", "thetadatadx-mcp"],
+  "x86_64-apple-darwin": ["darwin-x64", "thetadatadx-mcp"],
+  "aarch64-apple-darwin": ["darwin-arm64", "thetadatadx-mcp"],
+  "x86_64-pc-windows-msvc": ["win32-x64", "thetadatadx-mcp.exe"],
+};
+
+const [, , triple, binary] = process.argv;
+if (!triple || !binary) {
+  console.error("usage: node scripts/populate.mjs <target-triple> <binary-path>");
+  process.exit(2);
+}
+
+const entry = TARGETS[triple];
+if (!entry) {
+  console.error(`unknown target triple: ${triple}`);
+  console.error(`known: ${Object.keys(TARGETS).join(", ")}`);
+  process.exit(2);
+}
+if (!existsSync(binary)) {
+  console.error(`binary not found: ${binary}`);
+  process.exit(2);
+}
+
+const [pkgDir, exe] = entry;
+const dest = join(dirname(fileURLToPath(import.meta.url)), "..", pkgDir, exe);
+copyFileSync(binary, dest);
+chmodSync(dest, 0o755);
+console.log(`populated ${pkgDir}/${exe} from ${binary}`);

--- a/tools/mcp/npm/thetadatadx-mcp/bin/cli.js
+++ b/tools/mcp/npm/thetadatadx-mcp/bin/cli.js
@@ -28,7 +28,7 @@ function binaryPath() {
       `thetadatadx-mcp does not ship a prebuilt binary for ${key}.\n` +
         `Supported: ${Object.keys(PACKAGES).join(", ")}.\n` +
         `Build from source instead:\n` +
-        `  cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx`,
+        `  git clone https://github.com/userFRM/ThetaDataDx && cargo install --path ThetaDataDx/tools/mcp`,
     );
   }
   const exe = process.platform === "win32" ? "thetadatadx-mcp.exe" : "thetadatadx-mcp";
@@ -44,7 +44,7 @@ function binaryPath() {
         `host does not match, or when optional dependencies are disabled\n` +
         `(e.g. --no-optional, --omit=optional, or a locked-down CI install).\n` +
         `Reinstall with optional dependencies enabled, or build from source:\n` +
-        `  cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx`,
+        `  git clone https://github.com/userFRM/ThetaDataDx && cargo install --path ThetaDataDx/tools/mcp`,
     );
   }
 }

--- a/tools/mcp/npm/thetadatadx-mcp/bin/cli.js
+++ b/tools/mcp/npm/thetadatadx-mcp/bin/cli.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Launcher for the thetadatadx-mcp server. The server is a native Rust
+// binary shipped as one optional dependency per platform (the
+// esbuild / biome model); this script resolves the binary for the host
+// platform and execs it, forwarding stdin/stdout (the MCP JSON-RPC
+// channel), stderr (logs), argv, and the environment (so THETADATA_API_KEY
+// and friends reach the server).
+
+const { spawnSync } = require("node:child_process");
+const { dirname, join } = require("node:path");
+
+// `${platform}-${arch}` -> the platform package that carries its binary.
+// Keys are Node's `process.platform`/`process.arch` values, so the lookup
+// needs no abi/libc guessing — the published set is exactly these.
+const PACKAGES = {
+  "linux-x64": "thetadatadx-mcp-linux-x64",
+  "linux-arm64": "thetadatadx-mcp-linux-arm64",
+  "darwin-x64": "thetadatadx-mcp-darwin-x64",
+  "darwin-arm64": "thetadatadx-mcp-darwin-arm64",
+  "win32-x64": "thetadatadx-mcp-win32-x64",
+};
+
+function binaryPath() {
+  const key = `${process.platform}-${process.arch}`;
+  const pkg = PACKAGES[key];
+  if (!pkg) {
+    throw new Error(
+      `thetadatadx-mcp does not ship a prebuilt binary for ${key}.\n` +
+        `Supported: ${Object.keys(PACKAGES).join(", ")}.\n` +
+        `Build from source instead:\n` +
+        `  cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx`,
+    );
+  }
+  const exe = process.platform === "win32" ? "thetadatadx-mcp.exe" : "thetadatadx-mcp";
+  try {
+    // Resolve the platform package's `package.json` (not the binary
+    // directly): an extensionless executable is not a resolvable module
+    // specifier, so anchor on the manifest and join the binary beside it.
+    return join(dirname(require.resolve(`${pkg}/package.json`)), exe);
+  } catch {
+    throw new Error(
+      `The ${pkg} package is not installed.\n` +
+        `It is an optional dependency for ${key} and npm skips it when the\n` +
+        `host does not match, or when optional dependencies are disabled\n` +
+        `(e.g. --no-optional, --omit=optional, or a locked-down CI install).\n` +
+        `Reinstall with optional dependencies enabled, or build from source:\n` +
+        `  cargo install thetadatadx-mcp --git https://github.com/userFRM/ThetaDataDx`,
+    );
+  }
+}
+
+const result = spawnSync(binaryPath(), process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  throw result.error;
+}
+// Re-raise the child's terminating signal as our own exit so a parent
+// supervisor sees the real cause; otherwise mirror the exit code.
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+process.exit(result.status ?? 1);

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "thetadatadx-mcp",
+  "version": "13.0.0-rc.6",
+  "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/userFRM/ThetaDataDx"
+  },
+  "bin": {
+    "thetadatadx-mcp": "bin/cli.js"
+  },
+  "files": [
+    "bin/cli.js"
+  ],
+  "optionalDependencies": {
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.6",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.6",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.6",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.6",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.6"
+  },
+  "engines": {
+    "node": ">= 18"
+  }
+}

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "thetadatadx-mcp-win32-x64",
+  "version": "13.0.0-rc.6",
+  "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/userFRM/ThetaDataDx"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "thetadatadx-mcp.exe",
+  "files": [
+    "thetadatadx-mcp.exe"
+  ],
+  "engines": {
+    "node": ">= 18"
+  }
+}


### PR DESCRIPTION
Ships the MCP server to npm so any MCP client can launch it with `npx -y thetadatadx-mcp` and no Rust toolchain (closes #1020).

## Layout

A JS launcher package `thetadatadx-mcp` plus one prebuilt-binary package per platform, the esbuild/biome model mirrored against the TypeScript SDK's per-platform layout:

- `tools/mcp/npm/thetadatadx-mcp/` — launcher: `bin/cli.js`, `bin` entry, the five platform packages as `optionalDependencies`.
- `tools/mcp/npm/{linux-x64,linux-arm64,darwin-x64,darwin-arm64,win32-x64}/` — each carries `os`/`cpu` so npm installs only the host's binary, with the binary dropped in at release time.

## Launcher

`bin/cli.js` detects `process.platform`+`process.arch`, resolves the matching platform package's binary (anchored on its `package.json`, since an extensionless executable is not a resolvable module specifier), and `spawnSync`s it with `stdio: "inherit"` so the MCP JSON-RPC channel, argv, and the environment (including `THETADATA_API_KEY`) all pass through. It propagates the child's exit code, re-raises a terminating signal, handles the `.exe` suffix on Windows, and prints an actionable error naming the platform and the `cargo install` fallback when a platform package is missing or optional dependencies were skipped.

## Release flow

`release-mcp-npm.yml` builds each binary on its own native runner (musl-static on Linux for one portable binary per arch), uploads them as artifacts, then on a published release populates each platform package via `scripts/populate.mjs` and publishes the platform packages and the launcher. The dist-tag mirrors the TypeScript SDK: a pre-release version goes to `next`, a final release to `latest`. A manual dispatch builds the binaries for smoke-testing without publishing.

## Version sync

The new `package.json` files are wired into `bump_version.py` (launcher + optionalDependencies + the five platform packages) and `check_version_sync.py` so they stay in lockstep with the workspace version, same as the TypeScript packages.

## Docs

`docs-site/docs/mcp.md` and both READMEs now lead with the npx client config and keep `cargo install` as the Rust-users path.

## Verification

- Offline stdio handshake through the launcher: `initialize` returns `protocolVersion 2025-11-25` and the server info; `tools/list` returns the offline tool set. Exit-code and SIGTERM propagation confirmed; the missing-package error path confirmed.
- `npm pack --dry-run`: the launcher packs `bin/cli.js` + `package.json`; a platform package packs `package.json` + the binary.
- Green: `actionlint`, `check_version_sync.py` (+ selftest), `check_client_facing_vocab.py`, `check_docs_consistency.py`, `generate_docs_site --check`, `cargo build`/`clippy` on the mcp crate.

No publish happens here; the workflow publishes on a published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)