### PR TITLE
docs: drop the removed local Greeks calculator from the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Py
 - **Complete coverage**: stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes, one client**: point-in-time history, real-time streaming, and bulk flat-file downloads.
 - **DataFrames built in**: every result chains straight to Polars, pandas, or Arrow over a zero-copy boundary.
-- **Greeks without a round-trip**: first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Greeks on demand**: first- through third-order Greeks and implied volatility, served straight from the option endpoints.
 - **The same surface in every language**: identical methods and identical typed errors, Python through Rust.
 - **No terminal to run**: a direct connection to ThetaData; nothing to install and babysit locally.
 
@@ -257,7 +257,7 @@ with client.streaming(on_event) as session:
 ## Endpoint coverage
 
 65 typed endpoints across stocks, options, indices, the market calendar, and
-interest rates, plus real-time streaming and a local Greeks calculator.
+interest rates, plus real-time streaming.
 
 | Category | Endpoints | Examples |
 |---|---|---|
@@ -281,7 +281,7 @@ common `ThetaDataError` base.
 
 | Path | Package | Purpose |
 |---|---|---|
-| [`thetadatadx-rs`](thetadatadx-rs/) | `thetadatadx` (crates.io) | The Rust SDK: tick types, Greeks, price math, and the network client in one crate |
+| [`thetadatadx-rs`](thetadatadx-rs/) | `thetadatadx` (crates.io) | The Rust SDK: tick types, decoders, and the network client in one crate |
 | [`thetadatadx-py`](thetadatadx-py/) | `thetadatadx` (PyPI) | Python package with DataFrame adapters |
 | [`thetadatadx-ts`](thetadatadx-ts/) | `thetadatadx` (npm) | TypeScript / Node.js package, prebuilt binaries |
 | [`thetadatadx-cpp`](thetadatadx-cpp/) | header + prebuilt library | C++ wrapper over the C ABI |

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -18,7 +18,7 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 - **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
-- **Greeks without a round-trip** — first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Greeks on demand** — first- through third-order Greeks and implied volatility, served straight from the option endpoints.
 - **Buffer or stream** — every history builder yields a `Vec<Tick>` on `.await`, or chunk-by-chunk via `.stream(handler)`.
 - **Typed errors** — one `Error` enum across every transport, plus a dedicated `StreamError` for the streaming path.
 - **DataFrames on demand** — opt into the `polars` / `arrow` features for a zero-copy conversion off any result.
@@ -184,10 +184,6 @@ let path = thetadatadx::flatfile_request(
     std::path::Path::new("/tmp/option-trade-quote"), FlatFileFormat::Csv,
 ).await?;
 ```
-
-## Greeks calculator
-
-A full Black-Scholes calculator — first- through third-order Greeks plus an implied-volatility solver — runs locally, no request required.
 
 ## DataFrames
 


### PR DESCRIPTION
The client-side Black-Scholes Greeks calculator was removed in #1016, but the READMEs still advertised it: the root and Rust READMEs claimed Greeks 'computed locally', listed 'a local Greeks calculator', carried a 'Greeks calculator' section, and named 'price math' in the crate description. Reframed to ThetaData-served Greeks, matching the TypeScript README. Greeks remain available through the option greeks endpoints; only the false local-computation claims are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)