### PR TITLE
docs: put the npx MCP install in the README + tidy the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ npm install thetadatadx        # TypeScript / Node.js
 cargo add thetadatadx          # Rust
 ```
 
+Point an AI client (Claude Desktop, Cursor, and others) at the MCP server, no install and no Rust toolchain:
+
+```json
+{ "command": "npx", "args": ["-y", "thetadatadx-mcp"], "env": { "THETADATA_API_KEY": "your_key" } }
+```
+
 C++ ships as a header plus a small implementation file over a prebuilt library (a CMake target wires it up). See the [C++ guide](thetadatadx-cpp/).
 
 ## Quick start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,6 @@ Stabilizing v13 toward a stable `13.0.0` release. The release-candidate series i
 
 - **Native Go SDK** ([#1019](https://github.com/userFRM/ThetaDataDx/issues/1019)). A first-class Go SDK written in pure Go, not a cgo wrapper. It will be a native peer of the other SDKs, held to the same machine-enforced cross-SDK parity guarantee, so Go keeps everything that makes it Go: static-binary cross-compilation, the goroutine scheduler under streaming load, and a toolchain-free `go get`.
 - **Self-updating server** ([#957](https://github.com/userFRM/ThetaDataDx/issues/957)). Push a tagged release and running servers pick it up, verify its signature, and swap themselves in, with staged rollout and a force-upgrade floor. Operators get urgent fixes without a manual re-download.
-- **MCP over npm** ([#1020](https://github.com/userFRM/ThetaDataDx/issues/1020)). Run the MCP server with `npx -y thetadatadx-mcp`: no Rust toolchain, the one-line config every MCP client expects. `cargo install` stays for Rust users.
 
 ## Recently shipped
 


### PR DESCRIPTION
The MCP server now ships as an npm package (#1023). This surfaces `npx -y thetadatadx-mcp` in the README's Install block so it's where users look, and removes the now-shipped MCP item from ROADMAP.md (it goes live on npm with the next release tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)