### PR TITLE
chore(release): prepare 13.0.0-rc.7

### DIFF
--- a/.github/release-notes/v13.0.0-rc.7.md
+++ b/.github/release-notes/v13.0.0-rc.7.md
@@ -1,0 +1,23 @@
+## ThetaDataDx 13.0.0-rc.7
+
+This release candidate ships the MCP server as an npm package you can run with `npx`, no Rust toolchain required, and corrects the streaming reference across the docs site. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.7/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- The MCP server is now distributed on npm and runs with `npx -y thetadatadx-mcp`, the one-line config every MCP client expects, with no Rust toolchain to install. `cargo install` stays for Rust users.
+- The streaming reference is corrected. There are now per-security-type market-value pages for stocks and options, the streamed-trade field set is narrowed to what the feed actually delivers (the extended fields are marked extended-format-only), a WebSocket-frame note clarifies the payload subset carried on the wire, and an open-interest availability banner records that open interest has no streaming frame while remaining a valid SDK event.
+- The READMEs drop the removed client-side Greeks calculator; the option Greeks are served straight from the option endpoints.
+- The npx MCP config is surfaced in the README install block, and the public roadmap is published.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.7"`
+- MCP: `npx -y thetadatadx-mcp`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. If you hit a snag with the npx MCP package or spot something off in the streaming docs, open an issue and we will sort it out. If you sent something in and you do not see your name, that is on us, not you, and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.7] - 2026-06-29
+
+### Added
+
+- **MCP server on npm:** the MCP server is now distributed as an npm package and runs with `npx -y thetadatadx-mcp`, the one-line config every MCP client expects, with no Rust toolchain required (#1023). `cargo install` stays for Rust users.
+
+### Documentation
+
+- The streaming reference is corrected: per-security-type market-value pages are added for stocks and options, the streamed-trade field set is narrowed to what the feed actually delivers (with the extended fields marked as extended-format-only), a WebSocket-frame note clarifies the payload subset carried on the wire, and an open-interest availability banner records that open interest has no streaming frame while remaining a valid SDK event (#1018).
+- The READMEs drop the removed client-side Greeks calculator; the option Greeks are served straight from the option endpoints (#1024).
+- The npx MCP config is surfaced in the README install block, and the public roadmap is published (#1025, #1021).
+
 ## [13.0.0-rc.6] - 2026-06-29
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.6"
+thetadatadx = "13.0.0-rc.7"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.6"
+thetadatadx = "13.0.0-rc.7"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.7] - 2026-06-29
+
+### Added
+
+- **MCP server on npm:** the MCP server is now distributed as an npm package and runs with `npx -y thetadatadx-mcp`, the one-line config every MCP client expects, with no Rust toolchain required (#1023). `cargo install` stays for Rust users.
+
+### Documentation
+
+- The streaming reference is corrected: per-security-type market-value pages are added for stocks and options, the streamed-trade field set is narrowed to what the feed actually delivers (with the extended fields marked as extended-format-only), a WebSocket-frame note clarifies the payload subset carried on the wire, and an open-interest availability banner records that open interest has no streaming frame while remaining a valid SDK event (#1018).
+- The READMEs drop the removed client-side Greeks calculator; the option Greeks are served straight from the option endpoints (#1024).
+- The npx MCP config is surfaced in the README install block, and the public roadmap is published (#1025, #1021).
+
 ## [13.0.0-rc.6] - 2026-06-29
 
 ### Breaking changes

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.6
+  version: 13.0.0-rc.7
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.6"
+thetadatadx = "13.0.0-rc.7"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.6", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.7", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.6",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.6",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.6"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.7",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.7",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.7"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.6",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.6",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.6",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.6",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.6"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.7",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.7",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.7",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.7",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.7"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.6",
+  "version": "13.0.0-rc.7",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.6"
+version = "13.0.0-rc.7"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Prepares the 13.0.0-rc.7 release candidate.

Bumps every Cargo manifest, npm package.json (the SDK platform packages and the six MCP npm packages), lockfile, and version pin from 13.0.0-rc.6 to 13.0.0-rc.7. Adds the rc.7 CHANGELOG entry and the release notes, and copies the changelog to the docs site byte-identical.

User-facing changes since rc.6: the MCP server is now distributed on npm and runs with npx -y thetadatadx-mcp (#1023), and the streaming reference is corrected with per-security-type market-value pages, a narrowed streamed-trade field set, a WebSocket-frame note, and an open-interest availability banner (#1018, #1024, #1025, #1021).

Static gates pass: check_version_sync, check_docs_consistency, check_client_facing_vocab. The lockfile diffs are member-version-string bumps only. The maintainer cuts the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)