### PR TITLE
fix(ci): stage MCP binary in a workspace-relative dir for Windows upload

### DIFF
--- a/.github/workflows/release-mcp-npm.yml
+++ b/.github/workflows/release-mcp-npm.yml
@@ -103,24 +103,26 @@ jobs:
         run: cargo build --release --locked --manifest-path tools/mcp/Cargo.toml --target ${{ matrix.target }}
 
       - name: Stage binary
-        id: stage
         shell: bash
+        # Stage into a workspace-relative dir, not `mktemp -d`: on the Windows
+        # runner `bash` is git-bash, whose `mktemp` returns an MSYS `/tmp/...`
+        # path that the upload-artifact action (native Windows) cannot resolve.
+        # A relative path resolves against the workspace for both.
         run: |
           set -euo pipefail
           bindir="tools/mcp/target/${{ matrix.target }}/release"
-          stage="$(mktemp -d)"
+          rm -rf stage && mkdir -p stage
           if [ "${{ runner.os }}" = "Windows" ]; then
-            cp "$bindir/thetadatadx-mcp.exe" "$stage/"
+            cp "$bindir/thetadatadx-mcp.exe" stage/
           else
-            cp "$bindir/thetadatadx-mcp" "$stage/"
+            cp "$bindir/thetadatadx-mcp" stage/
           fi
-          echo "dir=$stage" >> "$GITHUB_OUTPUT"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
           name: mcp-${{ matrix.platform }}
-          path: ${{ steps.stage.outputs.dir }}/thetadatadx-mcp*
+          path: stage/thetadatadx-mcp*
           if-no-files-found: error
 
   publish:


### PR DESCRIPTION
The win32-x64 leg of the maiden MCP publish (release-mcp-npm) failed at the artifact-upload step. The Stage step used `mktemp -d`, which on the Windows runner (git-bash) returns an MSYS `/tmp/...` path that `actions/upload-artifact` (native Windows) cannot resolve, so it found no binary, failed the build job, and skipped the publish job (`needs: build`). The other four legs (native Unix paths) succeeded.

Staged into a workspace-relative `stage/` dir instead, which both git-bash and the action resolve identically.

Validated: a `workflow_dispatch` build-only run (28377152705) on this branch built and uploaded all five platform legs green, including win32-x64; publish correctly skipped (dispatch never publishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)