### PR TITLE
chore(release): prepare 13.0.0-rc.8

### DIFF
--- a/.github/release-notes/v13.0.0-rc.8.md
+++ b/.github/release-notes/v13.0.0-rc.8.md
@@ -1,0 +1,21 @@
+## ThetaDataDx 13.0.0-rc.8
+
+This release candidate completes the full-trade streaming documentation and ships the MCP server on npm so you can run it with `npx`, no Rust toolchain required. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.8/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- The full-trade streaming pages now document the complete event delivery: for each traded contract the stream delivers a quote (BBO for stocks, NBBO for options), an OHLC bar, and the trade itself. Quote terminology is now correct per asset class.
+- The MCP server is available on npm and runs with `npx -y thetadatadx-mcp`, the one-line config every MCP client expects, with no Rust toolchain to install. `cargo install` stays for Rust users.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.8"`
+- MCP: `npx -y thetadatadx-mcp`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. If you hit a snag with the npx MCP package or spot something off in the streaming docs, open an issue and we will sort it out. If you sent something in and you do not see your name, that is on us, not you, and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.8] - 2026-06-29
+
+### Added
+
+- **MCP server on npm:** the `thetadatadx-mcp` server is available on npm and runs with `npx -y thetadatadx-mcp`, the one-line config every MCP client expects, with no Rust toolchain required. `cargo install` stays for Rust users.
+
+### Documentation
+
+- The full-trade streaming pages now document the complete event delivery: for each traded contract the stream delivers a quote (BBO for stocks, NBBO for options), an OHLC bar, and the trade itself, and the quote terminology is now correct per asset class (#1029).
+
 ## [13.0.0-rc.7] - 2026-06-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.7"
+thetadatadx = "13.0.0-rc.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.7"
+thetadatadx = "13.0.0-rc.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.8] - 2026-06-29
+
+### Added
+
+- **MCP server on npm:** the `thetadatadx-mcp` server is available on npm and runs with `npx -y thetadatadx-mcp`, the one-line config every MCP client expects, with no Rust toolchain required. `cargo install` stays for Rust users.
+
+### Documentation
+
+- The full-trade streaming pages now document the complete event delivery: for each traded contract the stream delivers a quote (BBO for stocks, NBBO for options), an OHLC bar, and the trade itself, and the quote terminology is now correct per asset class (#1029).
+
 ## [13.0.0-rc.7] - 2026-06-29
 
 ### Added

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.7
+  version: 13.0.0-rc.8
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.7"
+thetadatadx = "13.0.0-rc.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.7", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.8", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package-lock.json
+++ b/thetadatadx-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.5",
+  "version": "13.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "13.0.0-rc.5",
+      "version": "13.0.0-rc.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
@@ -18,9 +18,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "13.0.0-rc.5",
-        "thetadatadx-linux-x64-gnu": "13.0.0-rc.5",
-        "thetadatadx-win32-x64-msvc": "13.0.0-rc.5"
+        "thetadatadx-darwin-arm64": "13.0.0-rc.8",
+        "thetadatadx-linux-x64-gnu": "13.0.0-rc.8",
+        "thetadatadx-win32-x64-msvc": "13.0.0-rc.8"
       }
     },
     "node_modules/@emnapi/core": {

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.7",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.7",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.7"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.8",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.8",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.8"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.7",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.7",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.7",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.7",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.7"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.8",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.8",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.8",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.8",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.8"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.7",
+  "version": "13.0.0-rc.8",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.7"
+version = "13.0.0-rc.8"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Prepares the 13.0.0-rc.8 release candidate. Bumps every published manifest, Cargo.lock, and version-pinned doc from 13.0.0-rc.7 to 13.0.0-rc.8 via `scripts/release/bump_version.py`, and adds the rc.8 CHANGELOG entry, docs-site changelog entry, and `.github/release-notes/v13.0.0-rc.8.md`.

## Changes since rc.7

- **Documentation:** the full-trade streaming pages now document the complete event delivery for each traded contract (a quote — BBO for stocks, NBBO for options — an OHLC bar, and the trade itself), with quote terminology correct per asset class.
- **MCP:** the `thetadatadx-mcp` server is available on npm and runs with `npx -y thetadatadx-mcp`, no Rust toolchain required.

## Gates

`check_version_sync`, the docs-drift gate (`generate_docs_site --check`), `check_docs_consistency`, `check_client_facing_vocab`, `cargo build -p thetadatadx`, and `cargo fmt --check` all pass.

Do not merge or tag — the maintainer cuts the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)