### PR TITLE
docs(readme): scope full-trade event handling to the full-trade example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ typed event classes:
 
 ```python
 import time
-from thetadatadx import Contract, Ohlcvc, Quote, Trade
+from thetadatadx import Contract, MarketValue, Quote, Trade
 
 def on_event(event):
     match event:
@@ -108,12 +108,10 @@ def on_event(event):
                 f"bid_size={bs} ask_size={asz} bid_exchange={bx} "
                 f"ask_exchange={ax} ms_of_day={ms}"
             )
-        # The full-trade stream sends a quote and an OHLC bar before each
-        # trade, so the same callback also receives Ohlcvc bars.
-        case Ohlcvc(open=o, high=h, low=lo, close=cl, volume=v, contract=c):
+        case MarketValue(market_bid=mb, market_ask=ma, market_price=mp, ms_of_day=ms, contract=c):
             print(
-                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} bar "
-                f"o={o:.2f} h={h:.2f} l={lo:.2f} c={cl:.2f} volume={v}"
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} market_value "
+                f"bid={mb:.2f} ask={ma:.2f} price={mp:.2f} ms_of_day={ms}"
             )
 
 spy_call = Contract.option("SPY", expiration="20260619", strike="550", right="C")
@@ -243,10 +241,24 @@ instead of buffering it. See [Request sizing](https://userfrm.github.io/ThetaDat
 One connection, one authentication. Historical queries work immediately; the
 streaming transport connects on the first subscription. Subscribe specific
 contracts with the fluent `Contract` API, or take a whole-market feed: every
-option trade across the universe, no per-contract setup:
+option trade across the universe, no per-contract setup. The full-trade feed
+sends a quote and an OHLC bar before each trade, so add an `Ohlcvc` case to the
+callback to handle the bars:
 
 ```python
-with client.streaming(on_event) as session:
+from thetadatadx import Ohlcvc
+
+def on_full_trade(event):
+    match event:
+        case Ohlcvc(open=o, high=h, low=lo, close=cl, volume=v, contract=c):
+            print(
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} bar "
+                f"o={o:.2f} h={h:.2f} l={lo:.2f} c={cl:.2f} volume={v}"
+            )
+        case _:
+            on_event(event)   # reuse the quote/trade handling above
+
+with client.streaming(on_full_trade) as session:
     session.subscribe(SecType.OPTION.full_trades())
     time.sleep(60)   # the callback runs on the streaming thread; keep it fast
 ```

--- a/thetadatadx-cpp/README.md
+++ b/thetadatadx-cpp/README.md
@@ -141,17 +141,6 @@ int main() {
                           << " ms_of_day=" << event.quote.ms_of_day
                           << '\n';
                 break;
-            // The full-trade stream sends a quote and an OHLC bar before each
-            // trade, so the same callback also receives OHLCVC bars.
-            case THETADATADX_STREAM_OHLCVC:
-                std::cout << event.ohlcvc.contract.symbol
-                          << " bar open=" << event.ohlcvc.open
-                          << " high=" << event.ohlcvc.high
-                          << " low=" << event.ohlcvc.low
-                          << " close=" << event.ohlcvc.close
-                          << " volume=" << event.ohlcvc.volume
-                          << '\n';
-                break;
             default:
                 break;
         }
@@ -170,9 +159,26 @@ int main() {
 }
 ```
 
-Every subscription is the same value, so quotes, trades, and open interest across contracts mix freely. Or take a whole-market feed — every option trade across the universe — with no per-contract setup:
+Every subscription is the same value, so quotes, trades, and open interest across contracts mix freely. Or take a whole-market feed — every option trade across the universe — with no per-contract setup. The full-trade feed sends a quote and an OHLC bar before each trade, so add an `OHLCVC` case to the callback to handle the bars:
 
 ```cpp
+streaming.set_callback([](const thetadatadx::StreamEvent& event) {
+    switch (event.kind) {
+        case THETADATADX_STREAM_OHLCVC:
+            std::cout << event.ohlcvc.contract.symbol
+                      << " bar open=" << event.ohlcvc.open
+                      << " high=" << event.ohlcvc.high
+                      << " low=" << event.ohlcvc.low
+                      << " close=" << event.ohlcvc.close
+                      << " volume=" << event.ohlcvc.volume
+                      << '\n';
+            break;
+        // ...plus the quote/trade cases from above.
+        default:
+            break;
+    }
+});
+
 streaming.subscribe(thetadatadx::SecType::option().full_trades());   // the callback runs per event — keep it fast
 ```
 

--- a/thetadatadx-py/README.md
+++ b/thetadatadx-py/README.md
@@ -126,7 +126,7 @@ Real-time quotes and trades flow through the same client. Register a callback an
 
 ```python
 import time
-from thetadatadx import Contract, Ohlcvc, Quote, Trade
+from thetadatadx import Contract, Quote, Trade
 
 def on_event(event):
     match event:
@@ -140,13 +140,6 @@ def on_event(event):
                 f"{c.symbol} {c.expiration} {c.strike:g} {c.right} quote bid={b:.2f} ask={a:.2f} "
                 f"bid_size={bs} ask_size={asz} bid_exchange={bx} "
                 f"ask_exchange={ax} ms_of_day={ms}"
-            )
-        # The full-trade stream sends a quote and an OHLC bar before each
-        # trade, so the same callback also receives Ohlcvc bars.
-        case Ohlcvc(open=o, high=h, low=lo, close=cl, volume=v, contract=c):
-            print(
-                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} bar "
-                f"o={o:.2f} h={h:.2f} l={lo:.2f} c={cl:.2f} volume={v}"
             )
 
 spy_call = Contract.option("SPY", expiration="20260620", strike="550", right="C")
@@ -171,10 +164,22 @@ with client.streaming(on_event) as session:
 
 The option constructor is `Contract.option(symbol, *, expiration, strike, right)` — the leg parameters are keyword-only, so the call site always reads `expiration=…, strike=…, right=…` and never depends on argument order. Pair it with `Contract.stock(symbol)` for equities.
 
-Or take a whole-market feed — every option trade across the universe, no per-contract setup:
+Or take a whole-market feed — every option trade across the universe, no per-contract setup. The full-trade feed sends a quote and an OHLC bar before each trade, so add an `Ohlcvc` case to the callback to handle the bars:
 
 ```python
-with client.streaming(on_event) as session:
+from thetadatadx import Ohlcvc
+
+def on_full_trade(event):
+    match event:
+        case Ohlcvc(open=o, high=h, low=lo, close=cl, volume=v, contract=c):
+            print(
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} bar "
+                f"o={o:.2f} h={h:.2f} l={lo:.2f} c={cl:.2f} volume={v}"
+            )
+        case _:
+            on_event(event)   # reuse the quote/trade handling above
+
+with client.streaming(on_full_trade) as session:
     session.subscribe(SecType.OPTION.full_trades())
     time.sleep(60)   # the callback runs on the streaming thread — keep it fast
 ```

--- a/thetadatadx-ts/README.md
+++ b/thetadatadx-ts/README.md
@@ -102,14 +102,6 @@ await client.stream.startStreaming((event) => {
       `bid_size=${bidSize} ask_size=${askSize} bid_exchange=${bidExchange} ` +
       `ask_exchange=${askExchange} ms_of_day=${msOfDay}`,
     );
-  } else if (event.kind === 'ohlcvc' && event.ohlcvc) {
-    // The full-trade stream sends a quote and an OHLC bar before each trade,
-    // so the same callback also receives ohlcvc bars.
-    const { contract, open, high, low, close, volume } = event.ohlcvc;
-    console.log(
-      `${contract.symbol} ${contract.expiration} ${contract.strike} ${contract.right} bar ` +
-      `o=${open} h=${high} l=${low} c=${close} volume=${volume}`,
-    );
   }
 });
 
@@ -132,10 +124,21 @@ client.stream.subscribe(stock.quote());
 client.stream.subscribeMany([option.quote(), option.trade(), option.openInterest()]);
 ```
 
-Or take a whole-market feed — every option trade across the universe, no per-contract setup:
+Or take a whole-market feed — every option trade across the universe, no per-contract setup. The full-trade feed sends a quote and an OHLC bar before each trade, so add an `ohlcvc` branch to the callback to handle the bars:
 
 ```typescript
 import { SecType } from 'thetadatadx';
+
+await client.stream.startStreaming((event) => {
+  if (event.kind === 'ohlcvc' && event.ohlcvc) {
+    const { contract, open, high, low, close, volume } = event.ohlcvc;
+    console.log(
+      `${contract.symbol} ${contract.expiration} ${contract.strike} ${contract.right} bar ` +
+      `o=${open} h=${high} l=${low} c=${close} volume=${volume}`,
+    );
+  }
+  // ...plus the quote/trade branches from above.
+});
 
 client.stream.subscribe(SecType.option().fullTrades());   // the callback runs per event — keep it fast
 ```


### PR DESCRIPTION
## Problem

The quick-start streaming snippets in the READMEs paired a per-contract subscribe (`subscribe_many([... .quote(), .trade(), .market_value()])` or the per-language equivalent) with a callback that carried an `Ohlcvc` case and a comment claiming "the full-trade stream sends a quote and an OHLC bar before each trade." A per-contract subscribe to quote/trade/market-value does not deliver OHLC bars, so the note and the case were misplaced in those examples.

## Solution

The quick-start callbacks now match exactly what each example subscribes: Quote, Trade, and (where `market_value()` is subscribed) MarketValue. The `Ohlcvc` handling and the quote-plus-OHLC-before-trade note now live only with the full-trades feed, which is the subscription that actually delivers a quote and an OHLC bar before each trade. The Rust example already subscribes `full_trades()` in the same block as its callback, so its `Ohlcvc` case stays as-is.

## Impact

Docs only, no code changes. README streaming examples are now internally consistent: each callback handles precisely the event kinds its subscription produces, and the full-trade behavior is documented where it applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
