### PR TITLE
feat(fpss): re-export the decode/wire internals behind __internal

### DIFF
--- a/thetadatadx-rs/src/fpss/connection.rs
+++ b/thetadatadx-rs/src/fpss/connection.rs
@@ -46,7 +46,7 @@ pub type FpssStream = StreamOwned<ClientConnection, TcpStream>;
 /// Mirrors the three `StreamingConfig` keepalive knobs; bundled so the
 /// connect path takes one argument instead of three loose integers.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct TcpKeepaliveSpec {
+pub struct TcpKeepaliveSpec {
     /// Idle time before the first probe.
     pub idle: Duration,
     /// Interval between unanswered probes.
@@ -229,7 +229,7 @@ pub(crate) fn order_hosts(
 /// # Errors
 ///
 /// Returns an error on network, authentication, or parsing failure.
-pub(crate) fn connect_to_servers(
+pub fn connect_to_servers(
     servers: &[(&str, u16)],
     connect_timeout: Duration,
     read_timeout: Duration,

--- a/thetadatadx-rs/src/fpss/delta.rs
+++ b/thetadatadx-rs/src/fpss/delta.rs
@@ -111,7 +111,7 @@ impl DeltaState {
     /// Note: `last_stop` is intentionally NOT cleared here because STOP
     /// itself calls `clear()`, and the timestamp must survive to suppress
     /// stale-tick warnings for 5 seconds after the STOP signal.
-    pub(super) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.prev.clear();
         self.ohlcvc.clear();
         self.last_was_date = false;

--- a/thetadatadx-rs/src/fpss/framing.rs
+++ b/thetadatadx-rs/src/fpss/framing.rs
@@ -54,7 +54,7 @@ pub(crate) const ERROR_IO_PENDING: i32 = 997;
 ///   overlapped I/O layer. Maps to `ErrorKind::Uncategorized` in `std`,
 ///   so a `kind()` match alone misses it.
 #[must_use]
-pub(crate) fn is_transient_read(io_err: &std::io::Error) -> bool {
+pub fn is_transient_read(io_err: &std::io::Error) -> bool {
     matches!(
         io_err.kind(),
         std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut

--- a/thetadatadx-rs/src/fpss/io_loop/login.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/login.rs
@@ -19,7 +19,7 @@ use super::super::framing::{is_drain_yield, read_frame_into_with_stall_timeout, 
 use super::super::protocol::parse_disconnect_reason;
 
 /// Outcome of a single login handshake.
-pub(in crate::fpss) enum LoginResult {
+pub enum LoginResult {
     Success(String),
     Disconnected(RemoveReason),
 }
@@ -60,7 +60,7 @@ fn handshake_deadline(read_timeout: Duration) -> Instant {
 /// post-login `decode_frame` dispatch uses — a typed control frame that
 /// precedes `METADATA` would otherwise be lost, since the handshake loop
 /// consumes it before the main dispatch can turn it into a typed event.
-pub(in crate::fpss) fn wait_for_login(
+pub fn wait_for_login(
     stream: &mut connection::FpssStream,
     pending_control: &mut Vec<StreamControl>,
     read_timeout: Duration,

--- a/thetadatadx-rs/src/fpss/io_loop/mod.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/mod.rs
@@ -18,7 +18,10 @@
 mod login;
 mod ping;
 
-pub(in crate::fpss) use login::{wait_for_login, LoginResult};
+// Re-exported (`pub`) so the `__internal` fpss surface (`fpss::internals`) can
+// hand the login handshake to a downstream consumer that owns the read loop;
+// crate-internal callers reach the same items through this import.
+pub use login::{wait_for_login, LoginResult};
 pub(in crate::fpss) use ping::ping_loop;
 
 use std::collections::HashMap;

--- a/thetadatadx-rs/src/fpss/io_loop/mod.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/mod.rs
@@ -18,10 +18,14 @@
 mod login;
 mod ping;
 
-// Re-exported (`pub`) so the `__internal` fpss surface (`fpss::internals`) can
-// hand the login handshake to a downstream consumer that owns the read loop;
-// crate-internal callers reach the same items through this import.
+// Re-exported so the `__internal` fpss surface (`fpss::internals`) can hand the
+// login handshake to a downstream consumer that owns the read loop. `pub` only
+// under the feature; otherwise crate-internal, matching the convention used by
+// the crate's other `__internal`-gated surfaces.
+#[cfg(feature = "__internal")]
 pub use login::{wait_for_login, LoginResult};
+#[cfg(not(feature = "__internal"))]
+pub(in crate::fpss) use login::{wait_for_login, LoginResult};
 pub(in crate::fpss) use ping::ping_loop;
 
 use std::collections::HashMap;

--- a/thetadatadx-rs/src/fpss/mod.rs
+++ b/thetadatadx-rs/src/fpss/mod.rs
@@ -111,8 +111,8 @@ pub mod internals {
     pub use super::delta::DeltaState;
     pub use super::events::FpssEventInternal;
     pub use super::framing::{
-        is_drain_yield, is_transient_read, read_frame_into_with_stall_timeout,
-        write_raw_frame, write_raw_frame_no_flush, FrameReadState, MAX_PAYLOAD_LEN,
+        is_drain_yield, is_transient_read, read_frame_into_with_stall_timeout, write_raw_frame,
+        write_raw_frame_no_flush, FrameReadState, MAX_PAYLOAD_LEN,
     };
     pub use super::io_loop::{wait_for_login, LoginResult};
     pub use super::protocol::wire::{

--- a/thetadatadx-rs/src/fpss/mod.rs
+++ b/thetadatadx-rs/src/fpss/mod.rs
@@ -104,6 +104,7 @@ pub mod __test_internals {
 /// bump, and absent unless `__internal` is enabled, so `cargo-semver-checks`
 /// (default features) never sees it.
 #[cfg(feature = "__internal")]
+#[doc(hidden)]
 pub mod internals {
     pub use super::connection::{connect_to_servers, FpssStream, TcpKeepaliveSpec};
     pub use super::decode::decode_frame;

--- a/thetadatadx-rs/src/fpss/mod.rs
+++ b/thetadatadx-rs/src/fpss/mod.rs
@@ -97,6 +97,30 @@ pub mod __test_internals {
     pub use disruptor::Polling; // VOCAB-OK: internal crate name, not user-facing
 }
 
+/// Crate-private FPSS decode / wire / framing / login / connection surface,
+/// exposed behind `__internal` for a downstream consumer that drives the
+/// decode into its own ingest ring (no Disruptor, no second consumer thread).
+/// NOT part of the supported public API: subject to change without a SemVer
+/// bump, and absent unless `__internal` is enabled, so `cargo-semver-checks`
+/// (default features) never sees it.
+#[cfg(feature = "__internal")]
+pub mod internals {
+    pub use super::connection::{connect_to_servers, FpssStream, TcpKeepaliveSpec};
+    pub use super::decode::decode_frame;
+    pub use super::delta::DeltaState;
+    pub use super::events::FpssEventInternal;
+    pub use super::framing::{
+        is_drain_yield, is_transient_read, read_frame_into_with_stall_timeout,
+        write_raw_frame, write_raw_frame_no_flush, FrameReadState, MAX_PAYLOAD_LEN,
+    };
+    pub use super::io_loop::{wait_for_login, LoginResult};
+    pub use super::protocol::wire::{
+        build_credentials_payload, build_full_type_subscribe_payload, build_ping_payload,
+        build_stop_payload, build_subscribe_payload, parse_contract_message,
+        parse_disconnect_reason, parse_req_response,
+    };
+}
+
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc as std_mpsc;


### PR DESCRIPTION
## What
Adds an `fpss::internals` module, gated on the existing `__internal` feature, re-exporting the crate-private FPSS framing, connection, login, decode, and wire surface. A downstream consumer that drives the frame decode into its own ingest ring can depend on these directly instead of vendoring a copy, so upstream fixes reach it by bumping the dependency rather than cherry-picking.

## Surface
What a consumer needs when it owns the read loop: the incremental frame reader and raw-frame writers, the TLS connect and its keepalive spec, the login handshake (`wait_for_login` / `LoginResult`), `decode_frame` with its `DeltaState` and `FpssEventInternal` output, and the wire payload builders and parsers.

## Not public API
The module exists only under `__internal`, the items stay in private or crate-private modules, and the default-feature public API is unchanged: the few items widened to `pub` are capped by their enclosing modules, so nothing new is reachable without the feature. `cargo-semver-checks` runs with default features and never sees it.

## Verification
Builds and clippy clean with and without `__internal`, fmt and rustdoc clean, fpss unit tests green (291 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)