### PR TITLE
refactor(fpss): drop the transitively-reachable parsers from the __internal surface

### DIFF
--- a/thetadatadx-rs/src/fpss/mod.rs
+++ b/thetadatadx-rs/src/fpss/mod.rs
@@ -117,8 +117,7 @@ pub mod internals {
     pub use super::io_loop::{wait_for_login, LoginResult};
     pub use super::protocol::wire::{
         build_credentials_payload, build_full_type_subscribe_payload, build_ping_payload,
-        build_stop_payload, build_subscribe_payload, parse_contract_message,
-        parse_disconnect_reason, parse_req_response,
+        build_stop_payload, build_subscribe_payload,
     };
 }
 


### PR DESCRIPTION
## What
Removes `parse_contract_message`, `parse_req_response`, and `parse_disconnect_reason` from the `fpss::internals` re-export (follows #1038).

They run inside `decode_frame` (the Contract / ReqResponse / Disconnected arms) and `wait_for_login`, both already exposed, so a consumer that owns the read loop reaches their results through the `decode_frame` events and `LoginResult` rather than the standalone parsers. The internal surface is now the items a consumer actually names, none unused.

The parsers stay `pub` in their module (still used internally); only the re-export is dropped. Builds clean with and without `__internal`, default-feature public API unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)