### PR TITLE
chore(release): prepare 13.0.0-rc.10

### DIFF
--- a/.github/release-notes/v13.0.0-rc.10.md
+++ b/.github/release-notes/v13.0.0-rc.10.md
@@ -1,0 +1,21 @@
+## ThetaDataDx 13.0.0-rc.10
+
+This release candidate fixes a post-reconnect tick desync in the FPSS stream and ships a new interactive request builder across the API reference docs. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.10/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- **Reconnect fix:** the FPSS delta-decode state now resets on reconnect, so the first ticks after a reconnect decode against a fresh baseline. If you streamed across a reconnect, this removes a class of post-reconnect price and size desync.
+- **Interactive API reference:** every reference endpoint page now renders a live request builder. Pick your language, toggle the client and auth method, edit any parameter, and the example code and sample response update as you go.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.10"`
+- MCP: `npx -y thetadatadx-mcp`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. If you hit a snag, open an issue and we will sort it out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.10] - 2026-06-30
+
+### Added
+
+- An internal-only `__internal` cargo feature re-exports the FPSS decode, wire, framing, and login surface as `fpss::internals`, for a downstream consumer that drives the decode into its own ingest loop. It is not part of the public API and carries no SemVer guarantee (#1038, #1039).
+
+### Fixed
+
+- **Post-reconnect tick desync:** the FPSS delta-decode state is now reset on reconnect, so the first ticks after a reconnect decode against a fresh baseline instead of a stale one (#1036).
+
+### Documentation
+
+- Every API reference page now renders an interactive request builder in place of the static language tabs. Pick a language, toggle the client and auth method, edit any parameter, and the example code and sample response regenerate live (#1037).
+- Scoped the full-trade event-handling note to the full-trade example in the README (#1034).
+
 ## [13.0.0-rc.9] - 2026-06-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.9"
+thetadatadx = "13.0.0-rc.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.9"
+thetadatadx = "13.0.0-rc.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.10] - 2026-06-30
+
+### Added
+
+- An internal-only `__internal` cargo feature re-exports the FPSS decode, wire, framing, and login surface as `fpss::internals`, for a downstream consumer that drives the decode into its own ingest loop. It is not part of the public API and carries no SemVer guarantee (#1038, #1039).
+
+### Fixed
+
+- **Post-reconnect tick desync:** the FPSS delta-decode state is now reset on reconnect, so the first ticks after a reconnect decode against a fresh baseline instead of a stale one (#1036).
+
+### Documentation
+
+- Every API reference page now renders an interactive request builder in place of the static language tabs. Pick a language, toggle the client and auth method, edit any parameter, and the example code and sample response regenerate live (#1037).
+- Scoped the full-trade event-handling note to the full-trade example in the README (#1034).
+
 ## [13.0.0-rc.9] - 2026-06-29
 
 ### Added

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.9
+  version: 13.0.0-rc.10
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.9"
+thetadatadx = "13.0.0-rc.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.9", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.10", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package-lock.json
+++ b/thetadatadx-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "13.0.0-rc.9",
+      "version": "13.0.0-rc.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
@@ -18,9 +18,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "13.0.0-rc.9",
-        "thetadatadx-linux-x64-gnu": "13.0.0-rc.9",
-        "thetadatadx-win32-x64-msvc": "13.0.0-rc.9"
+        "thetadatadx-darwin-arm64": "13.0.0-rc.10",
+        "thetadatadx-linux-x64-gnu": "13.0.0-rc.10",
+        "thetadatadx-win32-x64-msvc": "13.0.0-rc.10"
       }
     },
     "node_modules/@emnapi/core": {

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.9",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.9",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.9"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.10",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.10",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.10"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.9",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.9",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.9",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.9",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.9"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.10",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.10",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.10",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.10",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.10"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.9",
+  "version": "13.0.0-rc.10",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.9"
+version = "13.0.0-rc.10"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Bumps every version pin to 13.0.0-rc.10 in lockstep (via `scripts/release/bump_version.py` plus the prose/doc files the tool does not own) and adds the changelog entry + release notes.

Ships since rc.9:
- Post-reconnect FPSS delta-decode reset (#1036)
- Interactive request builder across the API reference docs (#1037)
- Internal-only fpss decode/wire surface behind `__internal` (#1038, #1039)

`check_version_sync.py`: ok. The live release smoke (`validate_release.sh`) is run separately with credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)