### PR TITLE
refactor(fpss): remove the mid-frame drain-yield / frame-deadline machinery

### DIFF
--- a/thetadatadx-rs/src/fpss/framing.rs
+++ b/thetadatadx-rs/src/fpss/framing.rs
@@ -66,149 +66,34 @@ pub fn is_transient_read(io_err: &std::io::Error) -> bool {
 /// The framing length field is a single byte, capping the payload at 255.
 pub const MAX_PAYLOAD_LEN: usize = 255;
 
-/// Wall-clock cap on the mid-frame retry budget.
+/// Read the 2-byte FPSS header under a per-stall no-progress timeout.
 ///
-/// The I/O loop drains outbound commands (ping heartbeats, subscribe /
-/// unsubscribe writes, shutdown) between `read_frame_into` returns. The
-/// 50 ms blocking-read timeout on the TLS socket is the primary drain
-/// cadence. A partial-frame arrival used to loop internally for up to
-/// `READ_TIMEOUT_MS` (10 s) — and indefinitely when bytes kept
-/// trickling in before each per-stall deadline — which stalled the
-/// command drain for seconds at a time.
-///
-/// This cap bounds the total wall-clock time the mid-frame reader will
-/// spend retrying before it yields control back to the I/O loop via
-/// `StreamErrorKind::ProtocolError` with a `DRAIN_YIELD_MARKER` substring.
-/// At 200 ms it is 4× the 50 ms drain cadence, generous enough for
-/// normal TCP gaps yet tight enough that a pathological trickler cannot
-/// block heartbeats past the 2 s ping grace.
-pub const MID_FRAME_DRAIN_WINDOW_MS: u64 = 200;
-
-/// Marker substring the I/O loop matches to recognise a drain-yield
-/// error. The full error is a regular `ProtocolError` so it fits the
-/// existing error taxonomy; the substring lets the loop pattern-match
-/// without plumbing a new enum variant through every downstream
-/// consumer (FFI / Python bindings / SDK surfaces).
-pub(crate) const DRAIN_YIELD_MARKER: &str = "drain-yield: bounded retry budget exceeded";
-
-/// Per-frame read resumption state.
-///
-/// Threaded through `read_frame_into` so the I/O loop can yield to
-/// drain outbound commands mid-frame and then re-enter the reader
-/// without losing the bytes already delivered by the TLS socket. Each
-/// call to `read_frame_into` reads zero or more bytes, updates the
-/// state in place, and either returns a fully decoded frame
-/// (`Ok(Some(...))`) or yields (`Err(ProtocolError)` carrying the
-/// `DRAIN_YIELD_MARKER` substring).
-///
-/// The state is sized with the wire layout: 2 header bytes then up to
-/// `MAX_PAYLOAD_LEN` payload bytes. No heap allocations on the hot
-/// path — the embedded `header_buf` is a fixed `[u8; 2]` and the
-/// payload bytes live in the caller-owned `Vec<u8>`.
-#[derive(Debug, Default, Clone)]
-pub struct FrameReadState {
-    /// Bytes read so far into the 2-byte header. 0, 1, or 2.
-    header_read: u8,
-    /// Decoded header bytes. Meaningful only once `header_read == 2`.
-    header_buf: [u8; 2],
-    /// `true` once the header is complete and we're reading payload.
-    payload_phase: bool,
-    /// Bytes read so far into the payload. 0..=payload_len.
-    payload_read: usize,
-    /// Expected payload length. Meaningful only during `payload_phase`.
-    payload_len: usize,
-    /// Hard wall-clock deadline for the in-progress frame, armed when
-    /// the first byte of the frame is read and carried across every
-    /// resumed `read_frame_into*` / drain-yield re-entry. `None` until
-    /// the first byte lands; cleared (with the rest of the state) when
-    /// the frame completes.
-    ///
-    /// The per-stall and per-call drain budgets both re-arm on progress
-    /// (stall) or per invocation (drain), so neither bounds the *total*
-    /// time a single frame may occupy: a peer trickling one byte per
-    /// resume keeps both clocks fresh forever. This deadline is the one
-    /// budget that accumulates across resumptions, so a partial frame
-    /// can never be held past the configured cap — once it expires the
-    /// reader fails fatally and the I/O loop's reconnect/watchdog fires.
-    frame_deadline: Option<Instant>,
-}
-
-impl FrameReadState {
-    /// Build a fresh resumption state for the start of a new frame.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-/// Read the 2-byte FPSS header with configurable per-stall timeout
-/// and drain-yield budget.
-///
-/// Byte-for-byte match with the JVM terminal's framed read under a
-/// 10_000 ms per-stall socket timeout; a `drain_budget` yield on top.
-/// Contract:
+/// Byte-for-byte match with the terminal's framed read under a per-stall
+/// socket timeout. Contract:
 /// - EOF before any byte → `Ok(None)` (graceful server close).
 /// - Pre-header `WouldBlock` / `TimedOut` (n == 0) → propagate as
 ///   `Error::Io` so `io_loop::is_read_timeout` drains pings +
 ///   command queue.
-/// - Mid-header `WouldBlock` / `TimedOut` (n > 0) → retry. The
-///   stall deadline is **re-armed on every successful byte**,
-///   matching the JVM terminal's per-`read()` socket-timeout
-///   semantics. Fatal
-///   if `stall_timeout` elapses without any forward progress.
-/// - Mid-header retries exceeding `drain_budget` of aggregate
-///   wall-clock time → return a `ProtocolError` carrying the
-///   [`DRAIN_YIELD_MARKER`] so the I/O loop recognizes the yield,
-///   drains outbound commands, and re-enters the reader. The
-///   partial header bytes are preserved on `state` so the next
-///   call resumes from byte `state.header_read` without desync.
-/// - The in-progress frame exceeding `frame_cap` of total wall-clock
-///   time (measured from the first byte of the frame, persisted on
-///   `state.frame_deadline` so it accumulates across resumed calls) →
-///   fatal `ProtocolError`. The per-stall and drain budgets both
-///   re-arm on progress / per call, so only this cap stops a peer that
-///   trickles one byte per resume from holding a single header forever.
+/// - Mid-header `WouldBlock` / `TimedOut` (n > 0) → retry. The stall
+///   deadline is **re-armed on every successful byte**, matching the
+///   terminal's per-`read()` socket-timeout semantics. Fatal only if
+///   `stall_timeout` elapses without any forward progress.
 ///
 /// Earlier revisions treated the first mid-header `WouldBlock` as
-/// fatal desync. Captured raw-byte dumps on dev + prod showed the
-/// bytes were valid frames that arrived 50-76 ms after the first
-/// `WouldBlock`; aggressive escalation caused a reconnect storm
-/// whose downstream effects accounted for the spurious "unknown
-/// message code" reports.
+/// fatal desync. Captured raw-byte dumps showed the bytes were valid
+/// frames that arrived 50-76 ms after the first `WouldBlock`;
+/// aggressive escalation caused a reconnect storm whose downstream
+/// effects accounted for the spurious "unknown message code" reports.
 fn read_header_with_timeout<R: Read>(
     reader: &mut R,
-    state: &mut FrameReadState,
     stall_timeout: Duration,
-    drain_budget: Duration,
-    frame_cap: Duration,
 ) -> Result<Option<[u8; 2]>, crate::error::Error> {
+    let mut header_buf = [0u8; 2];
+    let mut header_read = 0usize;
     let mut stall_deadline: Option<Instant> = None;
-    // Arm the drain budget the moment ANY header byte is in flight —
-    // whether it was delivered by a prior call (`state.header_read > 0`
-    // on entry) or by the first successful read inside this call. A
-    // fresh invocation with zero bytes in flight keeps the pre-header
-    // WouldBlock semantics unchanged (the caller drains pings + commands
-    // on `Error::Io`); but once the first byte lands, a subsequent
-    // mid-header stall must be bounded by the yield cap exactly like the
-    // mid-payload path, so it cannot block the command drain for the
-    // full `stall_timeout`.
-    let mut drain_deadline: Option<Instant> = if state.header_read > 0 {
-        Some(Instant::now() + drain_budget)
-    } else {
-        None
-    };
-    // Arm the per-frame hard cap if a prior call already banked header
-    // bytes for this frame; otherwise it arms below when the first byte
-    // of the frame lands. Persisted on `state` so it survives both
-    // drain-yields and the header→payload phase transition.
-    if state.header_read > 0 {
-        state
-            .frame_deadline
-            .get_or_insert_with(|| Instant::now() + frame_cap);
-    }
     loop {
-        let n = state.header_read as usize;
-        match reader.read(&mut state.header_buf[n..]) {
+        let n = header_read;
+        match reader.read(&mut header_buf[n..]) {
             Ok(0) if n == 0 => return Ok(None),
             Ok(0) => {
                 return Err(crate::error::Error::Stream {
@@ -219,20 +104,10 @@ fn read_header_with_timeout<R: Read>(
             Ok(read) => {
                 // Forward progress — re-arm the stall clock for the next gap.
                 stall_deadline = None;
-                let new_n = n + read;
-                state.header_read = u8::try_from(new_n).unwrap_or(2);
-                if new_n >= 2 {
-                    return Ok(Some(state.header_buf));
+                header_read = n + read;
+                if header_read >= 2 {
+                    return Ok(Some(header_buf));
                 }
-                // First header byte just landed inside this call: arm the
-                // drain budget so a stall on the second byte yields at the
-                // cap rather than blocking for the full `stall_timeout`,
-                // and arm the per-frame hard cap from the same instant so
-                // the whole frame is bounded against a trickler.
-                drain_deadline.get_or_insert_with(|| Instant::now() + drain_budget);
-                state
-                    .frame_deadline
-                    .get_or_insert_with(|| Instant::now() + frame_cap);
             }
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof && n == 0 => return Ok(None),
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
@@ -242,42 +117,17 @@ fn read_header_with_timeout<R: Read>(
                 })
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) if n > 0 && is_transient_read(&e) => {
-                // Drain-yield: the aggregate wall-clock cap exists so
-                // the command drain cannot be starved by a trickling
-                // sender. The partial header bytes are preserved on
-                // `state` so the next call resumes at byte
-                // `state.header_read`.
+            Err(e) if n == 0 && is_transient_read(&e) => {
+                // Pre-header transient: no bytes in flight. Surface as
+                // `Error::Io` so the I/O loop drains pings + commands and
+                // re-enters, exactly as the terminal's read-slice does.
+                return Err(e.into());
+            }
+            Err(e) if is_transient_read(&e) => {
+                // Mid-header transient with bytes already in flight. Retry
+                // under the stall clock, re-armed on every byte of forward
+                // progress; only `stall_timeout` of total silence is fatal.
                 let now = Instant::now();
-                // Per-frame hard cap first: unlike the drain-yield (which
-                // is recoverable and re-armed per call) an exhausted frame
-                // deadline is fatal, so the I/O loop's reconnect/watchdog
-                // tears down a peer that has trickled a single header past
-                // the cap instead of resuming it forever.
-                if let Some(fd) = state.frame_deadline {
-                    if now >= fd {
-                        return Err(crate::error::Error::Stream {
-                            kind: crate::error::StreamErrorKind::ProtocolError,
-                            message: format!(
-                                "mid-header frame deadline exceeded after {n} of 2 byte(s) \
-                                 (per-frame cap {} ms): {e}",
-                                frame_cap.as_millis()
-                            ),
-                        });
-                    }
-                }
-                if let Some(db) = drain_deadline {
-                    if now >= db {
-                        return Err(crate::error::Error::Stream {
-                            kind: crate::error::StreamErrorKind::ProtocolError,
-                            message: format!(
-                                "{DRAIN_YIELD_MARKER}: mid-header after {n} of 2 byte(s) \
-                                 (budget {} ms): {e}",
-                                drain_budget.as_millis()
-                            ),
-                        });
-                    }
-                }
                 let deadline = *stall_deadline.get_or_insert(now + stall_timeout);
                 if now >= deadline {
                     return Err(crate::error::Error::Stream {
@@ -295,61 +145,31 @@ fn read_header_with_timeout<R: Read>(
     }
 }
 
-/// Read exactly `buf.len()` bytes of payload with configurable
-/// per-stall timeout and drain-yield budget.
+/// Read exactly `buf.len()` bytes of payload under a per-stall
+/// no-progress timeout.
 ///
-/// Matches the JVM terminal's read-N-bytes under a 10_000 ms per-stall
-/// socket timeout: every `WouldBlock` /
-/// `TimedOut` re-arms a fresh `stall_timeout` deadline from the last
-/// successful byte of progress, not from function entry. A stream
-/// that dribbles data in slowly but steadily is fine; only
-/// `stall_timeout` of total silence fails.
+/// Matches the terminal's read-N-bytes under a per-stall socket timeout:
+/// every `WouldBlock` / `TimedOut` re-arms a fresh `stall_timeout`
+/// deadline from the last successful byte of progress, not from function
+/// entry. A stream that dribbles data in slowly but steadily is fine;
+/// only `stall_timeout` of total silence fails.
 ///
-/// `drain_budget` is the aggregate wall-clock cap that bounds the
-/// total time this function can spend retrying before yielding
-/// control to the I/O loop. On yield the function returns a
-/// `ProtocolError` carrying [`DRAIN_YIELD_MARKER`] and updates
-/// `state.payload_read` so the next call resumes from the exact byte
-/// offset. Without this budget, a pathological sender dribbling one
-/// byte every `stall_timeout - 1 ms` could block the command drain
-/// for up to `stall_timeout * payload_len / byte` seconds -- the
-/// ping / subscribe / shutdown queue would stall behind it.
-///
-/// `frame_cap` is the per-frame hard cap (persisted on
-/// `state.frame_deadline`). Unlike `drain_budget` it accumulates across
-/// resumed calls and across the header→payload phase transition, so a
-/// peer trickling one byte per resume — which keeps both the per-stall
-/// and per-call drain clocks fresh — is still cut off once the whole
-/// frame exceeds the cap. Exhausting it is fatal (not a drain-yield) so
-/// the I/O loop's reconnect/watchdog fires instead of resuming forever.
-///
-/// Earlier revisions treated the first `WouldBlock` as a fatal
-/// desync. Raw-byte tap captures on dev + prod showed every
-/// "corruption" event was a valid frame that finished arriving
-/// 50-76 ms after the first `WouldBlock`. The JVM terminal tolerates
-/// that gap silently; so do we now, bounded by the drain-yield budget.
+/// Earlier revisions treated the first `WouldBlock` as a fatal desync.
+/// Raw-byte tap captures showed every "corruption" event was a valid
+/// frame that finished arriving 50-76 ms after the first `WouldBlock`.
+/// The terminal tolerates that gap silently; so do we now.
 ///
 /// `Interrupted` is retried (POSIX signal wakeups are benign).
 /// `EOF` and going `stall_timeout` without progress are still fatal.
 fn read_exact_payload_with_timeout<R: Read>(
     reader: &mut R,
     buf: &mut [u8],
-    state: &mut FrameReadState,
     stall_timeout: Duration,
-    drain_budget: Duration,
-    frame_cap: Duration,
 ) -> Result<(), crate::error::Error> {
+    let mut payload_read = 0usize;
     let mut stall_deadline: Option<Instant> = None;
-    let drain_deadline: Instant = Instant::now() + drain_budget;
-    // Continue (or, for a zero-byte-header frame that somehow reaches
-    // here, arm) the per-frame hard cap. In the normal flow the header
-    // phase already armed it on the first byte, so this preserves the
-    // elapsed header time rather than resetting the budget.
-    let frame_deadline: Instant = *state
-        .frame_deadline
-        .get_or_insert_with(|| Instant::now() + frame_cap);
-    while state.payload_read < buf.len() {
-        let n = state.payload_read;
+    while payload_read < buf.len() {
+        let n = payload_read;
         match reader.read(&mut buf[n..]) {
             Ok(0) => {
                 return Err(crate::error::Error::Stream {
@@ -360,43 +180,14 @@ fn read_exact_payload_with_timeout<R: Read>(
             Ok(k) => {
                 // Forward progress — re-arm the stall clock for the next gap.
                 stall_deadline = None;
-                state.payload_read = n + k;
+                payload_read = n + k;
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(e) if is_transient_read(&e) => {
-                // Drain-yield: the aggregate wall-clock cap exists so
-                // the command drain cannot be starved by a trickling
-                // sender. The partial payload bytes are preserved
-                // on `state.payload_read` so the next call resumes
-                // from the exact byte offset.
+                // Retry under the stall clock, re-armed on every byte of
+                // forward progress; only `stall_timeout` of total silence
+                // is fatal — the terminal's per-`read()` socket-timeout.
                 let now = Instant::now();
-                // Per-frame hard cap first: an exhausted frame deadline is
-                // fatal (the drain-yield is recoverable and re-armed per
-                // call), so a peer trickling one byte per resume is torn
-                // down by the I/O loop's reconnect/watchdog once the whole
-                // frame exceeds the cap instead of resuming forever.
-                if now >= frame_deadline {
-                    return Err(crate::error::Error::Stream {
-                        kind: crate::error::StreamErrorKind::ProtocolError,
-                        message: format!(
-                            "mid-payload frame deadline exceeded after {n} of {} byte(s) \
-                             (per-frame cap {} ms): {e}",
-                            buf.len(),
-                            frame_cap.as_millis()
-                        ),
-                    });
-                }
-                if now >= drain_deadline {
-                    return Err(crate::error::Error::Stream {
-                        kind: crate::error::StreamErrorKind::ProtocolError,
-                        message: format!(
-                            "{DRAIN_YIELD_MARKER}: mid-payload after {n} of {} byte(s) \
-                             (budget {} ms): {e}",
-                            buf.len(),
-                            drain_budget.as_millis()
-                        ),
-                    });
-                }
                 let deadline = *stall_deadline.get_or_insert(now + stall_timeout);
                 if now >= deadline {
                     return Err(crate::error::Error::Stream {
@@ -435,13 +226,13 @@ pub(crate) fn is_binary_payload(payload: &[u8]) -> bool {
 /// calls with similarly-sized frames hit zero allocator calls after the
 /// first frame.
 ///
-/// # Resumable reads
+/// # Single-call frame read
 ///
-/// The `state` argument carries partial-frame progress across calls.
-/// On a drain-yield error the state is updated to record the exact
-/// byte offset in the header or payload, so the next call resumes
-/// without desync. When a full frame is returned, the state is
-/// reset to idle for the next frame.
+/// Each call reads one complete frame (header + payload) before
+/// returning, bounded solely by the per-stall no-progress timeout — the
+/// same bound the terminal's read loop applies. There is no mid-frame
+/// resumption: a frame whose bytes span multiple read slices simply
+/// blocks here until it completes or the stall timeout fires.
 ///
 /// # Unknown message codes
 ///
@@ -459,12 +250,11 @@ pub(crate) fn is_binary_payload(payload: &[u8]) -> bool {
 pub fn read_frame_into<R: Read>(
     reader: &mut R,
     buf: &mut Vec<u8>,
-    state: &mut FrameReadState,
 ) -> Result<Option<(StreamMsgType, usize)>, crate::error::Error> {
-    read_frame_into_with_stall_timeout(reader, buf, state, Duration::from_millis(READ_TIMEOUT_MS))
+    read_frame_into_with_stall_timeout(reader, buf, Duration::from_millis(READ_TIMEOUT_MS))
 }
 
-/// Takes the per-stall mid-frame timeout from the caller instead of the
+/// Takes the per-stall read timeout from the caller instead of the
 /// parity-reference `READ_TIMEOUT_MS` default. The I/O loop threads the
 /// user-supplied [`crate::config::StreamingConfig::timeout_ms`] through this
 /// entry point so the public knob actually controls the framing stall budget.
@@ -475,70 +265,26 @@ pub fn read_frame_into<R: Read>(
 pub fn read_frame_into_with_stall_timeout<R: Read>(
     reader: &mut R,
     buf: &mut Vec<u8>,
-    state: &mut FrameReadState,
     stall_timeout: Duration,
 ) -> Result<Option<(StreamMsgType, usize)>, crate::error::Error> {
     loop {
-        // Header phase: read bytes into `state.header_buf` until we
-        // have both. A drain-yield here preserves partial progress
-        // via `state.header_read`.
-        if !state.payload_phase {
-            // The per-frame hard cap is tied to `stall_timeout`: a single FPSS
-            // frame (≤ 257 bytes on the wire) never legitimately takes longer
-            // than the read deadline to fully arrive, so the same budget that
-            // bounds one stall also bounds the whole frame against a trickler.
-            let header = read_header_with_timeout(
-                reader,
-                state,
-                stall_timeout,
-                Duration::from_millis(MID_FRAME_DRAIN_WINDOW_MS),
-                stall_timeout,
-            )?;
-            let Some(header) = header else {
-                // Clean EOF before any byte of this frame — reset the
-                // state to idle so the next caller-driven frame starts
-                // fresh if the stream reopens (reconnect path).
-                *state = FrameReadState::new();
-                return Ok(None);
-            };
+        // Header phase: read both header bytes, bounded by the per-stall
+        // no-progress timeout.
+        let Some(header) = read_header_with_timeout(reader, stall_timeout)? else {
+            // Clean EOF before any byte of this frame.
+            return Ok(None);
+        };
 
-            let payload_len = header[0] as usize;
-            state.payload_len = payload_len;
-            state.payload_phase = true;
-            state.payload_read = 0;
+        let payload_len = header[0] as usize;
+        let code_byte = header[1];
 
-            // Always consume the payload to keep the stream aligned.
-            // The `buf.clear()` + `buf.resize()` is done here, at
-            // header completion, so we only allocate once per frame.
-            buf.clear();
-            buf.resize(payload_len, 0);
-        }
-
-        // Payload phase: read bytes until `payload_len` are in buf.
-        // A drain-yield here preserves `state.payload_read`.
-        let payload_len = state.payload_len;
-        let code_byte = state.header_buf[1];
+        // Always consume the payload to keep the stream aligned. The
+        // `buf.clear()` + `buf.resize()` allocates at most once per frame.
+        buf.clear();
+        buf.resize(payload_len, 0);
         if payload_len > 0 {
-            // Per-frame hard cap tied to `stall_timeout`; see the header phase
-            // above. The deadline persisted on `state` already carries the
-            // header-phase elapsed time, so the payload phase continues the
-            // same per-frame budget rather than restarting it.
-            read_exact_payload_with_timeout(
-                reader,
-                &mut buf[..payload_len],
-                state,
-                stall_timeout,
-                Duration::from_millis(MID_FRAME_DRAIN_WINDOW_MS),
-                stall_timeout,
-            )?;
+            read_exact_payload_with_timeout(reader, &mut buf[..payload_len], stall_timeout)?;
         }
-
-        // Frame complete — decide how to return based on the code.
-        // `state` is reset AFTER the code classification so a
-        // drain-yield above (pre-classification) would have carried
-        // the partial state through unchanged.
-        let reset_state = FrameReadState::new();
-        *state = reset_state;
 
         if let Some(code) = StreamMsgType::from_code(code_byte) {
             return Ok(Some((code, payload_len)));
@@ -553,20 +299,6 @@ pub fn read_frame_into_with_stall_timeout<R: Read>(
             "skipping unknown FPSS message code"
         );
     }
-}
-
-/// `true` if an error is a drain-yield from a mid-frame reader. The
-/// I/O loop catches this in the read branch, drains outbound commands,
-/// and re-enters `read_frame_into` with the same `FrameReadState` so
-/// the partial frame resumes byte-for-byte.
-pub fn is_drain_yield(err: &crate::error::Error) -> bool {
-    matches!(
-        err,
-        crate::error::Error::Stream {
-            kind: crate::error::StreamErrorKind::ProtocolError,
-            message,
-        } if message.contains(DRAIN_YIELD_MARKER)
-    )
 }
 
 /// Write a frame from raw parts without constructing a `Frame` struct.
@@ -644,8 +376,9 @@ mod tests {
         buf
     }
 
-    /// Reader that always returns `WouldBlock` (or a caller-chosen kind).
-    /// Models a stream where the header arrived but the payload never does.
+    /// Reader that returns a fixed prefix then always `WouldBlock` (or a
+    /// caller-chosen kind). Models a stream where some bytes arrived but
+    /// the rest of the frame never does.
     struct AlwaysStalledAfter {
         prefix: Vec<u8>,
         pos: usize,
@@ -666,9 +399,9 @@ mod tests {
         }
     }
 
-    /// A prolonged mid-payload stall (no progress past the short stall
-    /// deadline) must escalate to a fatal `ProtocolError`. The reader
-    /// never delivers the remaining payload bytes.
+    /// A prolonged mid-payload stall (no progress past the stall deadline)
+    /// must escalate to a fatal `ProtocolError`. The reader never delivers
+    /// the remaining payload bytes.
     #[test]
     fn mid_payload_stall_past_deadline_escalates_to_fatal() {
         // LEN=4, CODE=PING; 2 of 4 payload bytes arrive; then infinite stall.
@@ -677,27 +410,15 @@ mod tests {
             pos: 0,
             err_kind: std::io::ErrorKind::WouldBlock,
         };
-        // Consume the header via the public entry point, then the payload
-        // path (timeout-configurable variant) must bail after 20 ms of
-        // no-progress. Build a minimal 2-byte buffer matching payload size.
+        // Consume the header via read_exact, then the payload reader must
+        // bail after 20 ms of no progress.
         let mut header = [0u8; 2];
         std::io::Read::read_exact(&mut reader, &mut header).unwrap();
         assert_eq!(header, [0x04, StreamMsgType::Ping as u8]);
         let mut payload = [0u8; 4];
-        let mut state = FrameReadState::new();
-        // First two payload bytes land; next reads stall forever. Use a
-        // generous drain budget (1 s) and per-frame cap (60 s) so the
-        // stall-deadline escalation fires first -- this test asserts the
-        // per-stall failure path.
-        let err = read_exact_payload_with_timeout(
-            &mut reader,
-            &mut payload,
-            &mut state,
-            Duration::from_millis(20),
-            Duration::from_secs(1),
-            Duration::from_secs(60),
-        )
-        .unwrap_err();
+        let err =
+            read_exact_payload_with_timeout(&mut reader, &mut payload, Duration::from_millis(20))
+                .unwrap_err();
         match err {
             crate::error::Error::Stream { kind, message } => {
                 assert_eq!(kind, crate::error::StreamErrorKind::ProtocolError);
@@ -711,23 +432,10 @@ mod tests {
         }
     }
 
-    /// A slow-trickling stream whose gaps are each well under the deadline
-    /// but whose aggregate duration exceeds it must still succeed. Proves
-    /// the deadline re-arms on every successful byte (the JVM terminal's
-    /// per-read socket-timeout semantics) rather than running from function
-    /// entry.
-    /// Delivers one byte per `Ok`, with each byte preceded by a single
-    /// `WouldBlock` that sleeps for `sleep_per_stall` wall-clock time.
-    /// Used to verify the stall-deadline actually resets on progress —
-    /// cumulative sleep exceeds the configured deadline, but each
-    /// individual gap is under it. If the deadline did not reset, the
-    /// second gap would trip it.
-    ///
-    /// The per-stall sleep is kept far below the per-stall deadline so CPU
-    /// contention (a 5 ms sleep ballooning under load) cannot stretch a
-    /// single gap across the deadline and trip a spurious fatal; the
-    /// non-vacuousness instead comes from the *number* of gaps, whose real
-    /// cumulative sleep is guaranteed to exceed the deadline.
+    /// Delivers one byte per `Ok`, each preceded by a single `WouldBlock`
+    /// that sleeps for `sleep_per_stall`. Verifies the stall deadline
+    /// resets on progress: cumulative sleep exceeds the deadline, but each
+    /// individual gap is under it, so only reset-on-progress lets it pass.
     struct SleepingTrickle {
         remaining: Vec<u8>,
         sleep_per_stall: Duration,
@@ -753,22 +461,15 @@ mod tests {
         }
     }
 
-    /// Many small gaps under a generous per-stall deadline:
+    /// Many small gaps under a generous per-stall deadline must succeed:
     /// - `PAYLOAD_LEN` bytes, one `WouldBlock` gap before each.
     /// - Per-stall sleep `GAP_MS` (5 ms) is 40× below the per-stall
     ///   deadline `STALL_MS` (200 ms), so even a heavily load-stretched
-    ///   gap stays well under the deadline — no spurious "without
-    ///   progress" fatal.
+    ///   gap stays well under the deadline.
     /// - Cumulative real sleep `PAYLOAD_LEN × GAP_MS` (80 × 5 ms = 400 ms)
-    ///   structurally exceeds the per-stall deadline, so the success is
-    ///   not vacuous: a fixed deadline armed from function entry (the
-    ///   prior, broken style) would fire once cumulative sleep crossed
-    ///   `STALL_MS`. Only the reset-on-progress semantics let it complete.
-    ///
-    /// Behavioral assertions preserved: the read succeeds (no byte loss,
-    /// payload arrives in order) under reset-on-progress, and the
-    /// lower-bound wall-time check stays non-vacuous because it is backed
-    /// by `PAYLOAD_LEN` real sleeps that sum past the deadline.
+    ///   structurally exceeds the per-stall deadline, so a fixed deadline
+    ///   armed from function entry (the broken style) would fire; only
+    ///   reset-on-progress lets the read complete.
     #[test]
     fn mid_payload_progress_resets_deadline() {
         const PAYLOAD_LEN: usize = 80;
@@ -784,21 +485,9 @@ mod tests {
             stalled_since_last_byte: false,
         };
         let mut payload = vec![0u8; PAYLOAD_LEN];
-        let mut state = FrameReadState::new();
         let started = Instant::now();
-        // Drain budget and per-frame cap far above the aggregate wall
-        // time so this test pins the per-stall reset semantics
-        // independently of both the drain-yield and per-frame-cap paths
-        // (generous upper bounds, not tight ones).
-        read_exact_payload_with_timeout(
-            &mut reader,
-            &mut payload,
-            &mut state,
-            Duration::from_millis(STALL_MS),
-            Duration::from_secs(5),
-            Duration::from_secs(60),
-        )
-        .unwrap();
+        read_exact_payload_with_timeout(&mut reader, &mut payload, Duration::from_millis(STALL_MS))
+            .unwrap();
         let elapsed = started.elapsed();
         let expected: Vec<u8> = (0..u8::try_from(PAYLOAD_LEN).unwrap()).collect();
         assert_eq!(payload, expected, "every byte must land in order");
@@ -821,18 +510,9 @@ mod tests {
         let mut header = [0u8; 2];
         std::io::Read::read_exact(&mut reader, &mut header).unwrap();
         let mut payload = [0u8; 3];
-        let mut state = FrameReadState::new();
-        // Drain budget (1 s) and per-frame cap (60 s) are generous so the
-        // stall-deadline wins.
-        let err = read_exact_payload_with_timeout(
-            &mut reader,
-            &mut payload,
-            &mut state,
-            Duration::from_millis(20),
-            Duration::from_secs(1),
-            Duration::from_secs(60),
-        )
-        .unwrap_err();
+        let err =
+            read_exact_payload_with_timeout(&mut reader, &mut payload, Duration::from_millis(20))
+                .unwrap_err();
         match err {
             crate::error::Error::Stream { kind, message } => {
                 assert_eq!(kind, crate::error::StreamErrorKind::ProtocolError);
@@ -842,7 +522,9 @@ mod tests {
         }
     }
 
-    /// Same three-property set but for the header path.
+    /// Same stall-escalation property for the header path: the first
+    /// header byte arrives, then the reader stalls without progress past
+    /// the deadline, and the header read must fail fatally.
     #[test]
     fn mid_header_stall_past_deadline_escalates_to_fatal() {
         let mut reader = AlwaysStalledAfter {
@@ -850,17 +532,7 @@ mod tests {
             pos: 0,
             err_kind: std::io::ErrorKind::WouldBlock,
         };
-        let mut state = FrameReadState::new();
-        // Drain budget (1 s) and per-frame cap (60 s) generous so the
-        // per-stall deadline trips first.
-        let err = read_header_with_timeout(
-            &mut reader,
-            &mut state,
-            Duration::from_millis(20),
-            Duration::from_secs(1),
-            Duration::from_secs(60),
-        )
-        .unwrap_err();
+        let err = read_header_with_timeout(&mut reader, Duration::from_millis(20)).unwrap_err();
         match err {
             crate::error::Error::Stream { kind, message } => {
                 assert_eq!(kind, crate::error::StreamErrorKind::ProtocolError);
@@ -874,666 +546,24 @@ mod tests {
         }
     }
 
-    /// Finding #2: a peer that delivers the FIRST header byte and then
-    /// stalls must be cut off at the drain-yield cap, NOT held for the
-    /// full per-stall `stall_timeout`. The drain budget is armed on the
-    /// first successful header byte read inside the call, so a mid-header
-    /// stall is bounded exactly like the mid-payload path; otherwise the
-    /// reader could block the command drain (heartbeats, subscribes) for
-    /// the whole `stall_timeout`.
-    ///
-    /// The deciding signature: with `drain_budget` (40 ms) far below
-    /// `stall_timeout` (5 s), the error must carry [`DRAIN_YIELD_MARKER`]
-    /// and return well inside the stall timeout. Before the fix the first
-    /// byte left `drain_deadline` un-armed, so this call fell through to
-    /// the per-stall path and the test would block for ~5 s before a
-    /// "without progress" fatal.
+    /// A pre-header transient (zero bytes in flight) must surface as
+    /// `Error::Io`, not a fatal `ProtocolError`: the I/O loop treats this
+    /// as a benign drain-cadence tick and drains pings + commands. This is
+    /// the boundary that keeps the command drain alive between frames.
     #[test]
-    fn mid_header_first_byte_then_stall_yields_at_cap() {
+    fn pre_header_would_block_surfaces_as_io_error() {
         let mut reader = AlwaysStalledAfter {
-            // One header byte (LEN=5), then an unbroken stall.
-            prefix: vec![0x05],
+            prefix: Vec::new(),
             pos: 0,
             err_kind: std::io::ErrorKind::WouldBlock,
         };
-        let mut state = FrameReadState::new();
-        let started = Instant::now();
-        let err = read_header_with_timeout(
-            &mut reader,
-            &mut state,
-            // Generous per-stall timeout: if the drain budget were not
-            // armed on the first byte, the call would block this long.
-            Duration::from_secs(5),
-            // Tight drain budget — the cap that must fire instead.
-            Duration::from_millis(40),
-            // Generous per-frame cap so the drain-yield fires first.
-            Duration::from_secs(60),
-        )
-        .unwrap_err();
-        let elapsed = started.elapsed();
-
-        match &err {
-            crate::error::Error::Stream { kind, message } => {
-                assert_eq!(*kind, crate::error::StreamErrorKind::ProtocolError);
-                assert!(
-                    message.contains(DRAIN_YIELD_MARKER),
-                    "first-byte-then-stall must yield at the drain cap, got: {message}"
-                );
-                assert!(
-                    message.contains("mid-header"),
-                    "expected mid-header context, got: {message}"
-                );
+        let err = read_header_with_timeout(&mut reader, Duration::from_millis(20)).unwrap_err();
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert!(is_transient_read(&io_err), "must be a transient read");
             }
-            other => panic!("expected mid-header drain-yield, got {other:?}"),
+            other => panic!("pre-header WouldBlock must be Error::Io, got {other:?}"),
         }
-        assert!(
-            is_drain_yield(&err),
-            "is_drain_yield must match the produced error"
-        );
-        // Must return at the cap, nowhere near the 5 s stall timeout.
-        assert!(
-            elapsed < Duration::from_secs(1),
-            "drain-yield must fire at the ~40 ms cap, not the 5 s stall timeout; \
-             elapsed = {elapsed:?}"
-        );
-        // The single delivered byte must be preserved for resumption.
-        assert_eq!(
-            state.header_read, 1,
-            "the first header byte must be retained on state for the next call"
-        );
-    }
-
-    /// Reader that delivers the first header byte IMMEDIATELY (no
-    /// pre-stall), then emits sleeping `WouldBlock` errors before the
-    /// second byte. Models the exact mid-header stall finding #2 bounds:
-    /// the first byte lands inside the call (arming the drain budget),
-    /// and the gap before the second byte must be cut off at the cap.
-    struct FirstByteThenSleepingStall {
-        byte_one: Option<u8>,
-        byte_two: Option<u8>,
-        sleep_per_stall: Duration,
-        stalls_before_byte_two: usize,
-    }
-
-    impl std::io::Read for FirstByteThenSleepingStall {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            if let Some(b) = self.byte_one.take() {
-                buf[0] = b;
-                return Ok(1);
-            }
-            if self.stalls_before_byte_two > 0 {
-                self.stalls_before_byte_two -= 1;
-                std::thread::sleep(self.sleep_per_stall);
-                return Err(std::io::Error::new(std::io::ErrorKind::WouldBlock, "gap"));
-            }
-            if let Some(b) = self.byte_two.take() {
-                buf[0] = b;
-                return Ok(1);
-            }
-            Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "exhausted",
-            ))
-        }
-    }
-
-    /// Finding #2: after the first-byte drain-yield, the next call with
-    /// the SAME state resumes at byte 1 and completes the header once the
-    /// peer delivers the second byte. No byte is lost or re-read — the
-    /// invariant that makes the mid-header yield safe for command-drain
-    /// re-entry.
-    #[test]
-    fn mid_header_drain_yield_resumes_without_byte_loss() {
-        let mut reader = FirstByteThenSleepingStall {
-            byte_one: Some(0x01),
-            byte_two: Some(StreamMsgType::Ping as u8),
-            sleep_per_stall: Duration::from_millis(25),
-            // Enough sleeping stalls (25 ms each) to overrun the 10 ms
-            // budget on the first call.
-            stalls_before_byte_two: 10,
-        };
-        let mut state = FrameReadState::new();
-
-        // First call: byte 1 lands immediately and arms the 10 ms budget;
-        // the first 25 ms stall then trips the cap, so the call yields
-        // with exactly one byte banked. The per-frame cap (60 s) is far
-        // above the test's runtime so the drain-yield fires first.
-        let err = read_header_with_timeout(
-            &mut reader,
-            &mut state,
-            Duration::from_secs(5),
-            Duration::from_millis(10),
-            Duration::from_secs(60),
-        )
-        .unwrap_err();
-        assert!(is_drain_yield(&err), "first call must drain-yield");
-        assert_eq!(state.header_read, 1, "one byte banked across the yield");
-
-        // Drain the remaining inter-byte stalls so byte 2 is reachable,
-        // then the second call completes the header from the preserved
-        // offset with a generous budget. No byte is re-read. The per-frame
-        // deadline carried on `state` from the first call is far from
-        // expiry, so it does not preempt completion.
-        reader.stalls_before_byte_two = 0;
-        let header = read_header_with_timeout(
-            &mut reader,
-            &mut state,
-            Duration::from_secs(5),
-            Duration::from_secs(1),
-            Duration::from_secs(60),
-        )
-        .expect("second call completes the header")
-        .expect("a full 2-byte header");
-        assert_eq!(
-            header,
-            [0x01, StreamMsgType::Ping as u8],
-            "both header bytes must be present and in order after resumption"
-        );
-    }
-
-    // -- Finding #3 coverage: drain-yield + bounded retry budget -----------
-    //
-    // The mid-frame reader must not block the command drain for more than
-    // a small multiple of the 50 ms command-drain cadence. Previously a
-    // trickling sender could loop internally for up to 10 s (the full
-    // READ_TIMEOUT_MS) because the per-stall deadline reset on every
-    // successful byte. Now the aggregate drain-yield budget caps the total
-    // wall time in the reader; exceeding it returns a
-    // `ProtocolError` tagged with `DRAIN_YIELD_MARKER` so the I/O loop
-    // drains commands and re-enters with the preserved `FrameReadState`.
-
-    /// Bytes-at-a-time producer: delivers ONE byte, then WouldBlock
-    /// forever, then one more byte, etc. Each WouldBlock sleeps for
-    /// `sleep_per_stall` so the test can measure wall-clock behaviour
-    /// deterministically.
-    struct OneByteAtATime {
-        remaining: Vec<u8>,
-        sleep_per_stall: Duration,
-        stalled_since_last_byte: bool,
-    }
-
-    impl std::io::Read for OneByteAtATime {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            if self.remaining.is_empty() {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::WouldBlock,
-                    "exhausted; idle stall",
-                ));
-            }
-            if !self.stalled_since_last_byte {
-                self.stalled_since_last_byte = true;
-                std::thread::sleep(self.sleep_per_stall);
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::WouldBlock,
-                    "pre-byte stall",
-                ));
-            }
-            buf[0] = self.remaining.remove(0);
-            self.stalled_since_last_byte = false;
-            Ok(1)
-        }
-    }
-
-    /// Finding #3: a bytes-at-a-time producer with a small stall per byte
-    /// must NOT keep the mid-payload reader occupied past the drain-yield
-    /// budget. The reader must yield before consuming the whole payload,
-    /// preserving partial state. This is the exact scenario the command
-    /// drain needs to service heartbeats.
-    ///
-    /// Load-robust parameter choice (no tight wall-clock margins):
-    /// - Per-stall sleep `GAP_MS` (3 ms) is three orders of magnitude
-    ///   below the per-stall deadline (30 s), so the per-stall "without
-    ///   progress" path can never preempt the drain-yield even when a
-    ///   sleep balloons under CPU contention. Only the drain-yield path
-    ///   can fire — which is the property under test.
-    /// - The drain budget (150 ms) is ~50× a single gap, so at least one
-    ///   byte is guaranteed to land before the budget trips (no spurious
-    ///   `payload_read == 0`), yet far below the aggregate
-    ///   `PAYLOAD_LEN × GAP_MS` (200 × 3 ms = 600 ms), so the yield is
-    ///   guaranteed to happen strictly before the full payload arrives.
-    ///
-    /// Behavioral assertions preserved: the error is a drain-yield
-    /// (`DRAIN_YIELD_MARKER`, mid-payload context), `is_drain_yield`
-    /// agrees, and partial progress is banked (`0 < payload_read <
-    /// PAYLOAD_LEN`). The wall-time bound stays only as a generous
-    /// "didn't hang" backstop; the before-completion property is pinned
-    /// deterministically by the `payload_read < PAYLOAD_LEN` count check.
-    #[test]
-    fn mid_payload_bytes_at_a_time_yields_before_full_payload() {
-        const PAYLOAD_LEN: usize = 200;
-        const GAP_MS: u64 = 3;
-        const BUDGET_MS: u64 = 150;
-        // Budget must sit between one gap (so a byte lands) and the
-        // aggregate (so the yield precedes completion).
-        const _: () = assert!(BUDGET_MS > GAP_MS);
-        const _: () = assert!(BUDGET_MS < PAYLOAD_LEN as u64 * GAP_MS);
-
-        // Byte values are irrelevant here (the test asserts counts, not
-        // contents); fill with a wrapping pattern so any PAYLOAD_LEN is
-        // valid without an overflow on the `u8` range.
-        let mut reader = OneByteAtATime {
-            remaining: (0..PAYLOAD_LEN).map(|i| (i % 256) as u8).collect(),
-            sleep_per_stall: Duration::from_millis(GAP_MS),
-            stalled_since_last_byte: false,
-        };
-        let mut payload = vec![0u8; PAYLOAD_LEN];
-        let mut state = FrameReadState::new();
-        let started = Instant::now();
-        // Per-stall deadline (30 s) and per-frame cap (120 s) are enormous
-        // so neither can preempt the drain-yield; the drain budget is what
-        // must fire.
-        let err = read_exact_payload_with_timeout(
-            &mut reader,
-            &mut payload,
-            &mut state,
-            Duration::from_secs(30),
-            Duration::from_millis(BUDGET_MS),
-            Duration::from_secs(120),
-        )
-        .unwrap_err();
-        let elapsed = started.elapsed();
-
-        // The error must be a drain-yield, not a per-stall fatal.
-        match &err {
-            crate::error::Error::Stream { kind, message } => {
-                assert_eq!(*kind, crate::error::StreamErrorKind::ProtocolError);
-                assert!(
-                    message.contains(DRAIN_YIELD_MARKER),
-                    "expected drain-yield marker, got: {message}"
-                );
-                assert!(
-                    message.contains("mid-payload"),
-                    "expected mid-payload context, got: {message}"
-                );
-            }
-            other => panic!("expected drain-yield Fpss error, got {other:?}"),
-        }
-        assert!(
-            is_drain_yield(&err),
-            "is_drain_yield helper must match the produced error"
-        );
-
-        // Generous "didn't hang" backstop only — the meaningful
-        // before-completion property is the deterministic count check
-        // below, not a tight wall-clock margin.
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "drain-yield must fire well before the per-stall deadline; \
-             elapsed = {elapsed:?}"
-        );
-
-        // Partial progress must be preserved: at least SOME bytes
-        // should have landed (the budget is far above a single gap), and
-        // strictly less than the full payload (the yield MUST happen
-        // before completion — pinned deterministically by the budget
-        // sitting below the aggregate sleep).
-        assert!(
-            state.payload_read > 0,
-            "partial payload bytes must have landed before the yield"
-        );
-        assert!(
-            state.payload_read < PAYLOAD_LEN,
-            "yield must happen BEFORE the full payload arrives; got \
-             {} of {}",
-            state.payload_read,
-            PAYLOAD_LEN
-        );
-    }
-
-    /// Finding #3: after a drain-yield, the next call to
-    /// `read_exact_payload_with_timeout` with the SAME state must
-    /// resume from the exact byte offset. No bytes are lost, none
-    /// are re-read. This is the invariant that makes the yield
-    /// safe for the command-drain re-entry pattern.
-    ///
-    /// Load-robust parameters (same shape as the yield-before-completion
-    /// test): tiny per-stall sleep under an enormous per-stall deadline so
-    /// the per-stall path can never preempt the drain-yield, and a drain
-    /// budget that sits comfortably between a single gap (so byte 1 lands)
-    /// and the aggregate sleep (so the first call yields mid-payload).
-    #[test]
-    fn drain_yield_preserves_payload_read_for_resumption() {
-        const PAYLOAD_LEN: usize = 40;
-        const GAP_MS: u64 = 5;
-        const BUDGET_MS: u64 = 60;
-        const _: () = assert!(BUDGET_MS > GAP_MS);
-        const _: () = assert!(BUDGET_MS < PAYLOAD_LEN as u64 * GAP_MS);
-
-        // Deterministic, distinct-ish byte pattern so the final equality
-        // check proves both no-loss AND correct ordering.
-        let expected: Vec<u8> = (0..PAYLOAD_LEN)
-            .map(|i| (i.wrapping_mul(7) % 256) as u8)
-            .collect();
-        let mut reader = OneByteAtATime {
-            remaining: expected.clone(),
-            sleep_per_stall: Duration::from_millis(GAP_MS),
-            stalled_since_last_byte: false,
-        };
-        let mut payload = vec![0u8; PAYLOAD_LEN];
-        let mut state = FrameReadState::new();
-
-        // First call: per-stall deadline 30 s (never trips), drain budget
-        // 60 ms -> yields after a handful of bytes, never the whole
-        // payload (aggregate sleep is PAYLOAD_LEN × GAP_MS = 200 ms). The
-        // per-frame cap (120 s) is far above the aggregate so it never
-        // preempts the drain-yield this test pins.
-        let err = read_exact_payload_with_timeout(
-            &mut reader,
-            &mut payload,
-            &mut state,
-            Duration::from_secs(30),
-            Duration::from_millis(BUDGET_MS),
-            Duration::from_secs(120),
-        )
-        .unwrap_err();
-        assert!(is_drain_yield(&err), "first call must drain-yield");
-        let first_read = state.payload_read;
-        assert!(
-            first_read > 0 && first_read < PAYLOAD_LEN,
-            "first call must land some but not all bytes; got {first_read}"
-        );
-
-        // Second call: finish the payload with a generous budget. The
-        // state carries the first-call progress (including the per-frame
-        // deadline) so no bytes are re-read and the deadline does not
-        // preempt completion.
-        read_exact_payload_with_timeout(
-            &mut reader,
-            &mut payload,
-            &mut state,
-            Duration::from_secs(30),
-            Duration::from_secs(5),
-            Duration::from_secs(120),
-        )
-        .expect("second call must complete the payload without error");
-        assert_eq!(
-            state.payload_read, PAYLOAD_LEN,
-            "state must reflect full payload completion"
-        );
-        assert_eq!(
-            payload, expected,
-            "every byte of the payload must land exactly once, in order"
-        );
-    }
-
-    /// Finding #3: the public `read_frame_into` entry point must
-    /// propagate drain-yields out to the caller (so the I/O loop
-    /// can service the command drain) and then resume cleanly on
-    /// the next call with the same state + buffer. This exercises
-    /// the full public API end-to-end.
-    ///
-    /// `OneByteAtATime` emits a `WouldBlock` before every byte; the
-    /// very first `WouldBlock` is pre-header (zero bytes in flight)
-    /// and surfaces as `Error::Io(WouldBlock)` -- the io_loop
-    /// treats this as a benign drain-cadence tick. Every subsequent
-    /// `WouldBlock` is mid-frame and may surface as a drain-yield
-    /// once the aggregate budget trips. The retry loop here accepts
-    /// both classes and spins until the full frame lands.
-    #[test]
-    fn read_frame_into_drain_yield_round_trip() {
-        // Build a 6-byte payload frame: [LEN=6, CODE=PING, 6 bytes...]
-        let mut wire = vec![0x06, StreamMsgType::Ping as u8];
-        wire.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
-        // Tiny per-stall sleep: this test does not depend on the yield
-        // actually firing (it tolerates zero yields), only on any yield
-        // being followed by clean resumption and the frame completing.
-        // Keeping the sleep small means the aggregate wall time stays
-        // orders of magnitude below the 5 s guard and the retry-count
-        // bound even under heavy CPU contention.
-        let mut reader = OneByteAtATime {
-            remaining: wire,
-            sleep_per_stall: Duration::from_millis(2),
-            stalled_since_last_byte: false,
-        };
-        let mut buf: Vec<u8> = Vec::new();
-        let mut state = FrameReadState::new();
-
-        // Spin until the frame completes, treating both drain-yields
-        // (mid-frame yield to caller) and pre-header IO WouldBlocks
-        // (caller-drain cadence) as benign retries. This mirrors the
-        // production io_loop's read branch.
-        let mut yields = 0u32;
-        let mut idle_ticks = 0u32;
-        let started = Instant::now();
-        let frame = loop {
-            match read_frame_into(&mut reader, &mut buf, &mut state) {
-                Ok(Some(frame)) => break frame,
-                Ok(None) => panic!("unexpected EOF"),
-                Err(ref e) if is_drain_yield(e) => {
-                    yields += 1;
-                    if started.elapsed() > Duration::from_secs(5) {
-                        panic!("test timeout waiting for frame");
-                    }
-                    continue;
-                }
-                Err(crate::error::Error::Io(ref io_err))
-                    if io_err.kind() == std::io::ErrorKind::WouldBlock =>
-                {
-                    idle_ticks += 1;
-                    if started.elapsed() > Duration::from_secs(5) {
-                        panic!("test timeout waiting for frame");
-                    }
-                    continue;
-                }
-                Err(e) => panic!("unexpected error: {e:?}"),
-            }
-        };
-
-        assert_eq!(frame.0, StreamMsgType::Ping);
-        assert_eq!(frame.1, 6);
-        assert_eq!(buf, vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
-        // Under production drain budget the yield may or may not
-        // fire depending on timer granularity; the key property
-        // the test pins is that ANY yield is followed by a clean
-        // resumption. So tolerate zero yields but assert the frame
-        // completed correctly.
-        assert!(
-            yields + idle_ticks <= 32,
-            "retries should not loop forever; yields={yields}, \
-             idle_ticks={idle_ticks}"
-        );
-    }
-
-    /// Finding #2: a peer trickling one byte per resume must be cut off
-    /// once the in-progress frame exceeds the per-frame hard cap — it
-    /// must NOT be held forever. This drives the exact I/O-loop re-entry
-    /// pattern: each `read_exact_payload_with_timeout` call yields to the
-    /// command drain (small `drain_budget`), then the loop re-enters with
-    /// the SAME `state`. The per-frame deadline persisted on `state`
-    /// accumulates across every resume, so after the cap elapses the read
-    /// fails FATALLY (not a drain-yield) and the watchdog/reconnect can
-    /// fire.
-    ///
-    /// Before the fix the drain deadline was a stack-local re-armed on
-    /// every resumed call, so this loop would yield-and-resume forever
-    /// and a single partial frame could pin the connection indefinitely.
-    ///
-    /// Load-robust: the per-byte gap (3 ms) is far below the per-stall
-    /// timeout (5 s, never trips) and the payload is large enough that
-    /// the trickle cannot complete within the per-frame cap (120 ms) even
-    /// when the scheduler is loose. The non-vacuousness is pinned by the
-    /// structural inequality below, not a tight wall-clock margin.
-    #[test]
-    fn trickling_peer_cut_off_at_per_frame_deadline() {
-        const PAYLOAD_LEN: usize = 200;
-        const GAP_MS: u64 = 3;
-        const DRAIN_BUDGET_MS: u64 = 20;
-        const FRAME_CAP_MS: u64 = 120;
-        // A byte lands per (gap + Ok); the trickle needs far longer than
-        // the per-frame cap to finish, so the cap MUST fire mid-frame.
-        const _: () = assert!(PAYLOAD_LEN as u64 * GAP_MS > FRAME_CAP_MS);
-        // The drain budget is well under the per-frame cap so yields fire
-        // and the loop genuinely re-enters across the deadline.
-        const _: () = assert!(DRAIN_BUDGET_MS < FRAME_CAP_MS);
-
-        let mut reader = OneByteAtATime {
-            remaining: (0..PAYLOAD_LEN).map(|i| (i % 256) as u8).collect(),
-            sleep_per_stall: Duration::from_millis(GAP_MS),
-            stalled_since_last_byte: false,
-        };
-        let mut payload = vec![0u8; PAYLOAD_LEN];
-        let mut state = FrameReadState::new();
-
-        let started = Instant::now();
-        let mut resumes = 0u32;
-        let fatal = loop {
-            match read_exact_payload_with_timeout(
-                &mut reader,
-                &mut payload,
-                &mut state,
-                Duration::from_secs(5),
-                Duration::from_millis(DRAIN_BUDGET_MS),
-                Duration::from_millis(FRAME_CAP_MS),
-            ) {
-                Ok(()) => panic!(
-                    "the trickle must never complete within the per-frame cap; \
-                     read {} of {PAYLOAD_LEN} bytes",
-                    state.payload_read
-                ),
-                Err(ref e) if is_drain_yield(e) => {
-                    // Service the (simulated) command drain and re-enter
-                    // with the SAME state — the per-frame deadline carries
-                    // across this boundary.
-                    resumes += 1;
-                    assert!(
-                        started.elapsed() < Duration::from_secs(5),
-                        "the per-frame cap must fire long before this guard; \
-                         the trickle is being held instead of cut off"
-                    );
-                    continue;
-                }
-                Err(e) => break e,
-            }
-        };
-
-        // The terminating error must be the FATAL per-frame deadline, not
-        // a drain-yield: only a fatal read makes the I/O loop reconnect.
-        assert!(
-            !is_drain_yield(&fatal),
-            "the cut-off must be a fatal read, not a recoverable drain-yield"
-        );
-        match &fatal {
-            crate::error::Error::Stream { kind, message } => {
-                assert_eq!(*kind, crate::error::StreamErrorKind::ProtocolError);
-                assert!(
-                    message.contains("frame deadline exceeded") && message.contains("mid-payload"),
-                    "expected a per-frame-deadline fatal, got: {message}"
-                );
-            }
-            other => panic!("expected a fatal Fpss ProtocolError, got {other:?}"),
-        }
-        // The frame was genuinely partial when cut off (held, then
-        // bounded — not completed), and the loop really did re-enter
-        // across the deadline rather than failing on the first call.
-        assert!(
-            state.payload_read < PAYLOAD_LEN,
-            "frame must be cut off mid-payload, not completed; got {} of {PAYLOAD_LEN}",
-            state.payload_read
-        );
-        assert!(
-            resumes >= 1,
-            "the per-frame deadline must persist across at least one \
-             drain-yield re-entry; resumes = {resumes}"
-        );
-    }
-
-    /// Finding #2: the same per-frame bound applies in the header phase.
-    /// A peer that delivers the first header byte and then trickles
-    /// (never the second byte) must be cut off once the per-frame cap
-    /// elapses, across resumed calls, with a FATAL error.
-    #[test]
-    fn trickling_header_cut_off_at_per_frame_deadline() {
-        const GAP_MS: u64 = 3;
-        const DRAIN_BUDGET_MS: u64 = 15;
-        const FRAME_CAP_MS: u64 = 90;
-
-        // Delivers byte one, then an unbounded run of short sleeping
-        // stalls before byte two — byte two never actually arrives within
-        // the cap, so the header can never complete.
-        let mut reader = FirstByteThenSleepingStall {
-            byte_one: Some(0x05),
-            byte_two: Some(StreamMsgType::Ping as u8),
-            sleep_per_stall: Duration::from_millis(GAP_MS),
-            // Far more stalls than the cap admits at GAP_MS each.
-            stalls_before_byte_two: (FRAME_CAP_MS / GAP_MS) as usize * 4,
-        };
-        let mut state = FrameReadState::new();
-
-        let started = Instant::now();
-        let mut resumes = 0u32;
-        let fatal = loop {
-            match read_header_with_timeout(
-                &mut reader,
-                &mut state,
-                Duration::from_secs(5),
-                Duration::from_millis(DRAIN_BUDGET_MS),
-                Duration::from_millis(FRAME_CAP_MS),
-            ) {
-                Ok(Some(_)) => panic!("header must not complete within the cap"),
-                Ok(None) => panic!("unexpected EOF"),
-                Err(ref e) if is_drain_yield(e) => {
-                    resumes += 1;
-                    assert!(
-                        started.elapsed() < Duration::from_secs(5),
-                        "per-frame cap must fire well before this guard"
-                    );
-                    continue;
-                }
-                Err(e) => break e,
-            }
-        };
-
-        assert!(
-            !is_drain_yield(&fatal),
-            "header cut-off must be fatal, not a drain-yield"
-        );
-        match &fatal {
-            crate::error::Error::Stream { kind, message } => {
-                assert_eq!(*kind, crate::error::StreamErrorKind::ProtocolError);
-                assert!(
-                    message.contains("frame deadline exceeded") && message.contains("mid-header"),
-                    "expected a mid-header per-frame-deadline fatal, got: {message}"
-                );
-            }
-            other => panic!("expected a fatal Fpss ProtocolError, got {other:?}"),
-        }
-        assert_eq!(
-            state.header_read, 1,
-            "the single delivered header byte stays banked at cut-off"
-        );
-        assert!(
-            resumes >= 1,
-            "the per-frame deadline must persist across header re-entries"
-        );
-    }
-
-    /// Finding #3: the `is_drain_yield` helper must correctly
-    /// classify every drain-yield error shape the readers produce,
-    /// and reject unrelated errors. The I/O loop relies on this
-    /// classifier to decide whether to drain-and-resume or
-    /// escalate to reconnect.
-    #[test]
-    fn is_drain_yield_classifier_is_precise() {
-        // Drain-yield with the expected marker -> true.
-        let dy = crate::error::Error::Stream {
-            kind: crate::error::StreamErrorKind::ProtocolError,
-            message: format!("{DRAIN_YIELD_MARKER}: mid-payload after 3 of 8 byte(s)"),
-        };
-        assert!(is_drain_yield(&dy));
-
-        // Unrelated protocol error -> false.
-        let other = crate::error::Error::Stream {
-            kind: crate::error::StreamErrorKind::ProtocolError,
-            message: "truncated FPSS header: got 1 byte(s), expected 2".to_string(),
-        };
-        assert!(!is_drain_yield(&other));
-
-        // IO error -> false (drain-yield is Fpss-kind only).
-        let io = crate::error::Error::Io(std::io::Error::new(
-            std::io::ErrorKind::WouldBlock,
-            "pre-header",
-        ));
-        assert!(!is_drain_yield(&io));
     }
 
     /// Windows `ERROR_IO_PENDING` (raw OS error 997) must classify as a
@@ -1569,70 +599,40 @@ mod tests {
         assert!(is_transient_read(&to));
     }
 
-    /// A mid-frame disconnect leaves `FrameReadState` parked in the
-    /// payload phase with a partial `payload_read`. Reusing that state to
-    /// read a brand-new session (the reconnect path) skips the header and
-    /// consumes the new session's leading bytes as the tail of a phantom
-    /// frame, classifying them under the previous frame's code byte and
-    /// desyncing every frame after it. Resetting the state to the
-    /// header-phase initial value (`FrameReadState::new()`) before the
-    /// reborn reader runs restores the frame-boundary invariant.
-    ///
-    /// This pins the contract the io_loop reconnect block relies on when
-    /// it resets `frame_state` after establishing a new connection.
+    /// A full frame that arrives in one shot decodes to the right code and
+    /// payload, and a subsequent independent call decodes the next frame:
+    /// consecutive single-call reads never bleed state into each other (the
+    /// frame-boundary invariant the reconnect path relies on).
     #[test]
-    fn reset_frame_state_recovers_frame_boundary_after_mid_frame_disconnect() {
-        // Build a state that looks exactly like the residue of a frame
-        // whose payload was cut mid-transmission: header decoded for a
-        // 4-byte ERROR frame, payload phase entered, 2 of 4 bytes read.
-        let mut frame_state = FrameReadState::new();
-        frame_state.header_buf = [0x04, StreamMsgType::Error as u8];
-        frame_state.header_read = 2;
-        frame_state.payload_phase = true;
-        frame_state.payload_len = 4;
-        frame_state.payload_read = 2;
-
-        // The reborn reader's first bytes are a fresh, well-formed PING
-        // frame from the new session: LEN=1, CODE=PING, one payload byte.
-        let fresh_session = encode_manual(StreamMsgType::Ping as u8, &[0xAA]);
-
-        // Without a reset, the stale payload phase swallows the first two
-        // bytes of the new session as the phantom frame's tail and
-        // classifies them under the stale ERROR code -- a desync.
-        {
-            let mut desynced_state = frame_state.clone();
-            // The io_loop reuses one `frame_buf` across frames; on the
-            // stale path it is still sized to the interrupted frame's
-            // payload because the resize only runs at header completion,
-            // which the skipped header phase never reaches.
-            let mut buf = vec![0u8; desynced_state.payload_len];
-            let mut cursor = Cursor::new(fresh_session.clone());
-            let (code, _len) = read_frame_into(&mut cursor, &mut buf, &mut desynced_state)
-                .unwrap()
-                .unwrap();
-            // The phantom frame is mis-attributed to the previous code,
-            // not the PING that actually began the new session.
-            assert_eq!(
-                code,
-                StreamMsgType::Error,
-                "without reset, the stale code byte mislabels the new session's bytes"
-            );
-        }
-
-        // With the reset the io_loop applies on reconnect, the reader
-        // starts at the new session's header boundary and decodes the
-        // PING frame correctly.
-        frame_state = FrameReadState::new();
-        assert!(!frame_state.payload_phase);
-        assert_eq!(frame_state.header_read, 0);
-        assert_eq!(frame_state.payload_read, 0);
-
+    fn read_frame_into_decodes_consecutive_frames() {
+        let mut bytes = encode_manual(StreamMsgType::Error as u8, b"hi");
+        bytes.extend(encode_manual(StreamMsgType::Ping as u8, &[0xAA]));
+        let mut cursor = Cursor::new(bytes);
         let mut buf = Vec::new();
-        let mut cursor = Cursor::new(fresh_session);
-        let (code, len) = read_frame_into(&mut cursor, &mut buf, &mut frame_state)
-            .unwrap()
-            .unwrap();
+
+        let (code, n) = read_frame_into(&mut cursor, &mut buf).unwrap().unwrap();
+        assert_eq!(code, StreamMsgType::Error);
+        assert_eq!(&buf[..n], b"hi");
+
+        let (code, n) = read_frame_into(&mut cursor, &mut buf).unwrap().unwrap();
         assert_eq!(code, StreamMsgType::Ping);
-        assert_eq!(&buf[..len], &[0xAA]);
+        assert_eq!(&buf[..n], &[0xAA]);
+
+        assert!(matches!(read_frame_into(&mut cursor, &mut buf), Ok(None)));
+    }
+
+    /// An unrecognized code is skipped (payload consumed to stay aligned)
+    /// and the reader continues to the next well-formed frame in the same
+    /// call, matching the terminal's tolerance for unknown codes.
+    #[test]
+    fn read_frame_into_skips_unknown_code() {
+        let mut bytes = encode_manual(0xFE, &[0x00, 0x01, 0x02]); // no such code
+        bytes.extend(encode_manual(StreamMsgType::Ping as u8, &[0xBB]));
+        let mut cursor = Cursor::new(bytes);
+        let mut buf = Vec::new();
+
+        let (code, n) = read_frame_into(&mut cursor, &mut buf).unwrap().unwrap();
+        assert_eq!(code, StreamMsgType::Ping);
+        assert_eq!(&buf[..n], &[0xBB]);
     }
 }

--- a/thetadatadx-rs/src/fpss/io_loop/login.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/login.rs
@@ -15,7 +15,7 @@ use crate::error::Error;
 
 use super::super::connection;
 use super::super::events::StreamControl;
-use super::super::framing::{is_drain_yield, read_frame_into_with_stall_timeout, FrameReadState};
+use super::super::framing::read_frame_into_with_stall_timeout;
 use super::super::protocol::parse_disconnect_reason;
 
 /// Outcome of a single login handshake.
@@ -76,15 +76,11 @@ pub fn wait_for_login(
 /// `deadline` is a wall-clock backstop that bounds a peer which streams
 /// control frames without ever completing the handshake: the per-read socket
 /// timeout alone cannot, because each frame resets it. `now` injects the
-/// clock so tests can drive the deadline deterministically.
-///
-/// The read is driven through the resumable
-/// [`read_frame_into_with_stall_timeout`] path with `stall_timeout` as the
-/// per-stall budget. A mid-frame drain-yield re-checks `deadline` before
-/// resuming, so the wall-clock cap bounds *mid-frame* reads too — a peer that
-/// dribbles a partial frame in slowly cannot hold the handshake past the cap
-/// (the previous `read_frame` wrapper looped on drain-yields internally without
-/// consulting the deadline, so a trickling partial frame could run far past it).
+/// clock so tests can drive the deadline deterministically. It is checked
+/// between complete frames; a single frame's read is bounded by
+/// `stall_timeout` (the per-stall no-progress budget the reader enforces),
+/// so a peer that dribbles a partial frame and then goes silent is cut off
+/// by that stall timeout rather than held indefinitely.
 fn wait_for_login_generic<R, C>(
     stream: &mut R,
     pending_control: &mut Vec<StreamControl>,
@@ -96,11 +92,9 @@ where
     R: std::io::Read,
     C: FnMut() -> Instant,
 {
-    // Reused across frames and across mid-frame drain-yield resumptions:
-    // `frame_state` preserves the exact byte offset of a partially-read frame
-    // so a resume after a deadline re-check does not lose or re-read bytes.
+    // Reused across frames. Each read consumes one complete frame bounded by
+    // the per-stall timeout; the wall-clock deadline is checked between frames.
     let mut frame_buf: Vec<u8> = Vec::new();
-    let mut frame_state = FrameReadState::new();
     loop {
         if now() >= deadline {
             return Err(Error::Stream {
@@ -110,26 +104,17 @@ where
             });
         }
 
-        let (code, payload_len) = match read_frame_into_with_stall_timeout(
-            stream,
-            &mut frame_buf,
-            &mut frame_state,
-            stall_timeout,
-        ) {
-            Ok(Some(frame)) => frame,
-            Ok(None) => {
-                return Err(Error::Stream {
-                    kind: crate::error::StreamErrorKind::Disconnected,
-                    message: "connection closed during login handshake".to_string(),
-                })
-            }
-            // Mid-frame yield: the partial-frame bytes are preserved on
-            // `frame_state`. Loop back to re-check the wall-clock deadline
-            // BEFORE resuming, so a trickling partial frame is cut off at
-            // the cap instead of retrying indefinitely.
-            Err(ref e) if is_drain_yield(e) => continue,
-            Err(e) => return Err(e),
-        };
+        let (code, payload_len) =
+            match read_frame_into_with_stall_timeout(stream, &mut frame_buf, stall_timeout) {
+                Ok(Some(frame)) => frame,
+                Ok(None) => {
+                    return Err(Error::Stream {
+                        kind: crate::error::StreamErrorKind::Disconnected,
+                        message: "connection closed during login handshake".to_string(),
+                    })
+                }
+                Err(e) => return Err(e),
+            };
         let payload = &frame_buf[..payload_len];
 
         match code {
@@ -500,60 +485,47 @@ mod tests {
         }
     }
 
-    /// Finding: the wall-clock handshake deadline must bound MID-FRAME reads,
-    /// not only the gaps between completed frames. A peer that dribbles a
-    /// partial frame (one header byte) and then stalls makes the resumable
-    /// reader drain-yield repeatedly; the handshake must re-check the deadline
-    /// on each resumption and cut the peer off at the cap, rather than looping
-    /// on drain-yields forever. The previous `read_frame` wrapper swallowed
-    /// drain-yields internally with no deadline check, so this peer could hold
-    /// login/reconnect far past the advertised cap.
+    /// A peer that dribbles a partial frame (a complete header and part of
+    /// the payload) and then goes permanently silent must be cut off by the
+    /// per-stall no-progress timeout — not held indefinitely. The reader
+    /// blocks inside the payload read until `stall_timeout` elapses with zero
+    /// progress, then surfaces a fatal `ProtocolError`, which the handshake
+    /// propagates. This is the terminal's only mid-frame bound.
     #[test]
-    fn wait_for_login_partial_frame_stall_hits_deadline_mid_frame() {
-        // A complete header (LEN=4, CODE=Ping) and 2 of 4 payload bytes, then a
-        // permanent mid-payload stall: the frame can never complete. The
-        // mid-payload reader drain-yields after its budget, handing control
-        // back so the handshake can re-check the wall-clock deadline.
+    fn wait_for_login_partial_frame_silence_hits_stall_timeout() {
+        // A complete header (LEN=4, CODE=Ping) and 2 of 4 payload bytes, then
+        // a permanent mid-payload stall: the frame can never complete.
         let mut reader = PartialThenStallForever {
             prefix: vec![0x04, StreamMsgType::Ping as u8, 0x01, 0x02],
             pos: 0,
-            sleep_per_stall: Duration::from_millis(5),
-        };
-
-        // Injected clock: report `start` until the reader has drain-yielded at
-        // least once (the partial byte landed, then the mid-frame budget
-        // elapsed), then jump past the deadline. This proves the deadline is
-        // consulted BETWEEN mid-frame resumptions — a long stall_timeout means
-        // the per-stall budget alone would never fire.
-        let start = Instant::now();
-        let deadline = start + Duration::from_secs(10);
-        let mut ticks = 0u32;
-        let clock = move || {
-            ticks += 1;
-            if ticks > 2 {
-                deadline + Duration::from_secs(1)
-            } else {
-                start
-            }
+            sleep_per_stall: Duration::from_millis(2),
         };
 
         let mut pending: Vec<StreamControl> = Vec::new();
         let result = wait_for_login_generic(
             &mut reader,
             &mut pending,
-            deadline,
-            // Long per-stall budget so only the wall-clock deadline (not the
-            // per-stall timeout) can end the handshake.
-            Duration::from_secs(30),
-            clock,
+            // Far-future wall-clock deadline: the per-stall timeout is what
+            // must end the handshake here.
+            Instant::now() + Duration::from_secs(3_600),
+            // Short per-stall budget: the permanent mid-payload silence trips
+            // it quickly.
+            Duration::from_millis(30),
+            Instant::now,
         );
         match result {
-            Err(Error::Stream { kind, .. }) => assert!(
-                matches!(kind, crate::error::StreamErrorKind::Timeout),
-                "a mid-frame trickle past the deadline must surface as a handshake timeout"
-            ),
-            Err(other) => panic!("expected an Fpss timeout error, got {other:?}"),
-            Ok(_) => panic!("a partial-frame stall past the deadline must trip the cap"),
+            Err(Error::Stream { kind, message }) => {
+                assert!(
+                    matches!(kind, crate::error::StreamErrorKind::ProtocolError),
+                    "a mid-frame silence must surface as a fatal protocol error, got {kind:?}"
+                );
+                assert!(
+                    message.contains("mid-payload") && message.contains("without progress"),
+                    "expected a per-stall no-progress error, got: {message}"
+                );
+            }
+            Err(other) => panic!("expected an Fpss protocol error, got {other:?}"),
+            Ok(_) => panic!("a partial-frame silence must trip the stall timeout"),
         }
     }
 }

--- a/thetadatadx-rs/src/fpss/io_loop/mod.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/mod.rs
@@ -54,8 +54,7 @@ use super::decode::decode_frame;
 use super::delta::DeltaState;
 use super::events::{FpssEventInternal, IoCommand, StreamControl};
 use super::framing::{
-    self, is_drain_yield, read_frame_into_with_stall_timeout, write_raw_frame,
-    write_raw_frame_no_flush, FrameReadState,
+    self, read_frame_into_with_stall_timeout, write_raw_frame, write_raw_frame_no_flush,
 };
 use super::protocol::{self, build_login_payload, Contract};
 use super::reconnect_delay;
@@ -435,12 +434,6 @@ where
     // Reusable frame payload buffer.
     let mut frame_buf: Vec<u8> = Vec::with_capacity(framing::MAX_PAYLOAD_LEN);
 
-    // Per-frame resumption state. Preserved across `read_frame_into`
-    // calls so a drain-yield can hand control back to the command
-    // drain without losing the bytes already delivered by the TLS
-    // socket. Reset to idle on every complete frame.
-    let mut frame_state = FrameReadState::new();
-
     // Outer reconnection loop: each iteration runs one connection session.
     // On involuntary disconnect, the policy decides whether to reconnect.
     //
@@ -533,12 +526,8 @@ where
                 }
 
                 // --- Phase 1: Try to read a frame (short blocking read) ---
-                match read_frame_into_with_stall_timeout(
-                    &mut reader,
-                    &mut frame_buf,
-                    &mut frame_state,
-                    read_timeout,
-                ) {
+                match read_frame_into_with_stall_timeout(&mut reader, &mut frame_buf, read_timeout)
+                {
                     Ok(Some((code, payload_len))) => {
                         last_frame_at = Instant::now();
                         last_event_at_ns.store(unix_nanos_now(), Ordering::Relaxed);
@@ -649,23 +638,6 @@ where
                             break 'inner RemoveReason::TimedOut;
                         }
                         // Otherwise, fall through to drain commands.
-                    }
-                    Err(ref e) if is_drain_yield(e) => {
-                        // Mid-frame reader yielded so the command drain can
-                        // keep up. `frame_state` has
-                        // been updated with the exact byte offset in the
-                        // header / payload, so the next `read_frame_into`
-                        // call resumes without desync. Do NOT count this
-                        // toward `consecutive_timeouts` -- the TLS socket
-                        // IS delivering bytes, just slowly; a sustained
-                        // drain-yield is expected behaviour on a trickling
-                        // sender, not a sign of a dead connection. Fall
-                        // through to the Phase 2 drain.
-                        metrics::counter!("thetadatadx.fpss.drain_yields").increment(1);
-                        tracing::trace!(
-                            "mid-frame drain-yield -- draining outbound commands \
-                         before re-entering read"
-                        );
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "FPSS read error");
@@ -1186,15 +1158,11 @@ where
         delta_state.clear();
         local_contracts.clear();
 
-        // Reset the frame reader to a clean header boundary. A drop that
-        // interrupted a partially transmitted frame leaves `frame_state`
-        // with `payload_phase == true` and a partial `payload_read`. The
-        // reborn reader below reads a brand-new session whose bytes start
-        // at a frame header, so a stale mid-frame position would consume
-        // the new session's leading bytes as the tail of a phantom frame
-        // and desync every frame after it. The invariant: a new
-        // connection always begins at a frame boundary.
-        frame_state = FrameReadState::new();
+        // The frame reader holds no cross-call state: each read consumes one
+        // complete frame from a header boundary, so a mid-frame disconnect
+        // leaves no residue for the reborn reader to desync on. The
+        // "a new connection always begins at a frame boundary" invariant
+        // holds by construction.
 
         // Fresh authenticated session. The stable-window anchor was already
         // cleared once at the reconnect decision (see `last_data_at = None`

--- a/thetadatadx-rs/src/fpss/mod.rs
+++ b/thetadatadx-rs/src/fpss/mod.rs
@@ -79,7 +79,7 @@ pub mod __test_internals {
     pub use super::decode::decode_frame;
     pub use super::delta::DeltaState;
     pub use super::events::FpssEventInternal;
-    pub use super::framing::{read_frame_into, FrameReadState, MAX_PAYLOAD_LEN};
+    pub use super::framing::{read_frame_into, MAX_PAYLOAD_LEN};
 
     // Production ring-constructor surface, re-exported so the streaming
     // channel bench can time the exact pipeline the live client builds:
@@ -110,8 +110,8 @@ pub mod internals {
     pub use super::delta::DeltaState;
     pub use super::events::FpssEventInternal;
     pub use super::framing::{
-        is_drain_yield, is_transient_read, read_frame_into_with_stall_timeout, write_raw_frame,
-        write_raw_frame_no_flush, FrameReadState, MAX_PAYLOAD_LEN,
+        is_transient_read, read_frame_into_with_stall_timeout, write_raw_frame,
+        write_raw_frame_no_flush, MAX_PAYLOAD_LEN,
     };
     pub use super::io_loop::{wait_for_login, LoginResult};
     pub use super::protocol::wire::{

--- a/thetadatadx-rs/tests/decode_fuzz_property.rs
+++ b/thetadatadx-rs/tests/decode_fuzz_property.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use proptest::prelude::*;
 
 use thetadatadx::fpss::__test_internals::{
-    decode_frame, read_frame_into, DeltaState, FrameReadState, MAX_PAYLOAD_LEN,
+    decode_frame, read_frame_into, DeltaState, MAX_PAYLOAD_LEN,
 };
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::StreamMsgType;
@@ -46,10 +46,9 @@ fn drive_fuzz_input(bytes: Vec<u8>) {
     let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
     let mut delta_state = DeltaState::new();
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
     for _ in 0..MAX_FRAMES {
-        match read_frame_into(&mut cursor, &mut buf, &mut state) {
+        match read_frame_into(&mut cursor, &mut buf) {
             Ok(Some((code, n))) => {
                 // Frame buffer must never exceed the wire-protocol cap.
                 assert!(

--- a/thetadatadx-rs/tests/midframe_disconnect.rs
+++ b/thetadatadx-rs/tests/midframe_disconnect.rs
@@ -12,12 +12,12 @@
 //! - The reader does NOT block on a stuck Read source.
 //! - The reader returns `Ok(None)` on clean pre-header EOF, or a typed
 //!   `Error::Stream { kind: ProtocolError }` on truncation.
-//! - `FrameReadState` resets cleanly between attempts so the next
-//!   reconnect-cycle reader does not desync on stale partial bytes.
+//! - Each read is independent (no cross-call state), so a torn read
+//!   leaves no residue for the next reconnect-cycle reader to desync on.
 
 use std::io::{Cursor, Error as IoError, ErrorKind, Read};
 
-use thetadatadx::fpss::__test_internals::{read_frame_into, FrameReadState, MAX_PAYLOAD_LEN};
+use thetadatadx::fpss::__test_internals::{read_frame_into, MAX_PAYLOAD_LEN};
 
 // ---------------------------------------------------------------------------
 // Read adapters
@@ -87,22 +87,17 @@ impl Read for PrefixThenUnexpectedEof {
 // ---------------------------------------------------------------------------
 
 /// Pre-header EOF (no bytes delivered yet) is a graceful close.
-/// `read_frame_into` returns `Ok(None)` and resets `FrameReadState` to
-/// idle so the reconnect path re-enters with a clean slate.
+/// `read_frame_into` returns `Ok(None)`, and a follow-up call on the
+/// still-exhausted reader returns `Ok(None)` again — no residue carried.
 #[test]
-fn pre_header_clean_eof_returns_none_and_resets_state() {
+fn pre_header_clean_eof_returns_none() {
     let mut reader = PrefixThenEof::new(Vec::new());
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
-    let result = read_frame_into(&mut reader, &mut buf, &mut state);
+    let result = read_frame_into(&mut reader, &mut buf);
     assert!(matches!(result, Ok(None)), "got {result:?}");
 
-    // After a clean pre-header EOF the state must be idle: a fresh
-    // `FrameReadState::default()` should be byte-for-byte equivalent
-    // to what we hold, exercised through a follow-up call that
-    // immediately returns Ok(None) again.
-    let result = read_frame_into(&mut reader, &mut buf, &mut state);
+    let result = read_frame_into(&mut reader, &mut buf);
     assert!(matches!(result, Ok(None)), "got {result:?}");
 }
 
@@ -112,9 +107,8 @@ fn pre_header_clean_eof_returns_none_and_resets_state() {
 fn mid_header_clean_eof_returns_protocol_error() {
     let mut reader = PrefixThenEof::new(vec![0x05]); // single header byte
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
-    let result = read_frame_into(&mut reader, &mut buf, &mut state);
+    let result = read_frame_into(&mut reader, &mut buf);
     assert!(
         result.is_err(),
         "mid-header EOF must surface as error; got {result:?}"
@@ -133,9 +127,8 @@ fn mid_payload_truncation_returns_protocol_error() {
 
     let mut reader = PrefixThenEof::new(bytes);
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
-    let result = read_frame_into(&mut reader, &mut buf, &mut state);
+    let result = read_frame_into(&mut reader, &mut buf);
     assert!(
         result.is_err(),
         "mid-payload truncation must surface as error; got {result:?}"
@@ -153,21 +146,20 @@ fn mid_payload_unexpected_eof_returns_protocol_error() {
 
     let mut reader = PrefixThenUnexpectedEof::new(bytes);
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
-    let result = read_frame_into(&mut reader, &mut buf, &mut state);
+    let result = read_frame_into(&mut reader, &mut buf);
     assert!(
         result.is_err(),
         "UnexpectedEof mid-payload must surface as error; got {result:?}"
     );
 }
 
-/// Reconnect cycle: after a torn read, instantiating a fresh
-/// `FrameReadState` and pointing at a clean stream must succeed
-/// without carrying half-decoded leftover bytes from the previous
-/// connection.
+/// Reconnect cycle: after a torn read, a fresh reader on a clean stream
+/// must decode without carrying half-decoded leftover bytes from the
+/// previous connection. Because reads hold no cross-call state, this
+/// holds by construction.
 #[test]
-fn fresh_state_after_torn_read_decodes_cleanly() {
+fn clean_stream_after_torn_read_decodes_cleanly() {
     // Cycle 1: torn mid-payload.
     let mut bytes = Vec::new();
     bytes.push(50u8);
@@ -176,11 +168,9 @@ fn fresh_state_after_torn_read_decodes_cleanly() {
 
     let mut torn_reader = PrefixThenUnexpectedEof::new(bytes);
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
-    let _ = read_frame_into(&mut torn_reader, &mut buf, &mut state);
+    let _ = read_frame_into(&mut torn_reader, &mut buf);
 
-    // Cycle 2: fresh state on a clean stream — must decode without
-    // carrying torn bytes.
+    // Cycle 2: a clean stream must decode without carrying torn bytes.
     let mut clean = Vec::new();
     let payload = b"hello";
     clean.push(payload.len() as u8);
@@ -189,8 +179,7 @@ fn fresh_state_after_torn_read_decodes_cleanly() {
 
     let mut clean_reader = Cursor::new(clean);
     let mut buf2: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut fresh_state = FrameReadState::new();
-    let result = read_frame_into(&mut clean_reader, &mut buf2, &mut fresh_state);
+    let result = read_frame_into(&mut clean_reader, &mut buf2);
     let (_code, n) = result
         .expect("fresh stream must decode")
         .expect("fresh stream must yield a frame");
@@ -205,10 +194,9 @@ fn fresh_state_after_torn_read_decodes_cleanly() {
 fn fully_dead_reader_does_not_loop() {
     let mut reader = PrefixThenUnexpectedEof::new(Vec::new());
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
     // Bound iterations strictly: a single call must terminate in O(1).
-    let result = read_frame_into(&mut reader, &mut buf, &mut state);
+    let result = read_frame_into(&mut reader, &mut buf);
     // Pre-header `UnexpectedEof` with zero bytes seen returns
     // `Ok(None)` per `read_header_with_timeout`'s contract — graceful
     // close.

--- a/thetadatadx-rs/tests/reconnect_storm.rs
+++ b/thetadatadx-rs/tests/reconnect_storm.rs
@@ -10,9 +10,9 @@
 //! What we CAN exercise without a live socket is the load-bearing
 //! invariant on every reconnect cycle:
 //!
-//! - The framing-layer state (`FrameReadState`, `frame_buf`) must
-//!   reset to idle between sessions so the new connection's bytes
-//!   land on the correct offset.
+//! - The framing reader holds no cross-call state, so each session's
+//!   bytes land on the correct offset with no residue from the last;
+//!   `frame_buf` is simply reused.
 //! - The decoder state (`DeltaState`, `local_contracts`) must survive
 //!   N session cycles without unbounded memory growth or stale
 //!   contract IDs leaking into the next session.
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use thetadatadx::StreamMsgType;
 
 use thetadatadx::fpss::__test_internals::{
-    decode_frame, read_frame_into, DeltaState, FrameReadState, MAX_PAYLOAD_LEN,
+    decode_frame, read_frame_into, DeltaState, MAX_PAYLOAD_LEN,
 };
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::fpss::{StreamControl, StreamEvent};
@@ -104,13 +104,12 @@ fn reconnect_storm_preserves_framing_invariants() {
         // frame, so the SDK must not carry stale ids forward.
         let mut local: HashMap<i32, Arc<Contract>> = HashMap::new();
         let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-        let mut state = FrameReadState::new();
 
         let bytes = build_session_bytes(cycle);
         let mut cursor = Cursor::new(bytes);
 
         loop {
-            match read_frame_into(&mut cursor, &mut buf, &mut state) {
+            match read_frame_into(&mut cursor, &mut buf) {
                 Ok(Some((code, n))) => {
                     let primary = decode_frame(
                         code,
@@ -143,14 +142,9 @@ fn reconnect_storm_preserves_framing_invariants() {
             }
         }
 
-        // Per-cycle invariant: the framing state must be idle at the
-        // bottom of the cycle. A drain-yield that left
-        // `header_read > 0` would be detected here on the next
-        // iteration through `read_frame_into` (next cycle starts with
-        // a fresh state — but a leak in state would be observable
-        // through unexpected behaviour on the next call). Since
-        // `state` is dropped at the end of each cycle, the absence of
-        // a panic is the contract.
+        // Per-cycle invariant: the reader carries nothing across frames,
+        // so each cycle's session decodes independently. The absence of a
+        // panic above (no error surfaced mid-storm) is the contract.
         assert!(
             local.contains_key(&1),
             "cycle {cycle}: contract id 1 must be in local cache after ContractAssigned",
@@ -190,9 +184,8 @@ fn post_storm_normal_operation_resumes_immediately() {
     // Burn through 5 cycles of storm.
     for cycle in 0..5 {
         let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-        let mut state = FrameReadState::new();
         let mut cursor = Cursor::new(build_session_bytes(cycle));
-        while let Ok(Some((code, n))) = read_frame_into(&mut cursor, &mut buf, &mut state) {
+        while let Ok(Some((code, n))) = read_frame_into(&mut cursor, &mut buf) {
             let _ = decode_frame(
                 code,
                 &buf[..n],
@@ -216,10 +209,9 @@ fn post_storm_normal_operation_resumes_immediately() {
     push_frame(&mut bytes, StreamMsgType::Contract as u8, &payload);
 
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
     let mut cursor = Cursor::new(bytes);
     let mut events = Vec::new();
-    while let Ok(Some((code, n))) = read_frame_into(&mut cursor, &mut buf, &mut state) {
+    while let Ok(Some((code, n))) = read_frame_into(&mut cursor, &mut buf) {
         let p = decode_frame(
             code,
             &buf[..n],

--- a/thetadatadx-rs/tests/replay_capture.rs
+++ b/thetadatadx-rs/tests/replay_capture.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use thetadatadx::{RemoveReason, SecType, StreamMsgType};
 
 use thetadatadx::fpss::__test_internals::{
-    decode_frame, read_frame_into, DeltaState, FrameReadState, MAX_PAYLOAD_LEN,
+    decode_frame, read_frame_into, DeltaState, MAX_PAYLOAD_LEN,
 };
 use thetadatadx::fpss::protocol::test_wire::{
     build_credentials_payload, build_full_type_subscribe_payload, build_ping_payload,
@@ -202,7 +202,7 @@ fn build_pathological_fixture() -> Vec<u8> {
 
     // Mid-frame disconnect: declare a 200-byte payload but only
     // include 50 bytes before the file ends. The reader must NOT
-    // panic; it must surface a truncation / drain-yield error.
+    // panic; it must surface a truncation error.
     bytes.push(200u8); // len prefix
     bytes.push(StreamMsgType::Quote as u8); // code
     bytes.extend(std::iter::repeat_n(0xAB, 50));
@@ -229,12 +229,11 @@ fn replay_success_fixture_emits_expected_event_sequence() {
     let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
     let mut delta_state = DeltaState::new();
     let mut frame_buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut frame_state = FrameReadState::new();
 
     let mut events: Vec<StreamEvent> = Vec::new();
 
     loop {
-        match read_frame_into(&mut cursor, &mut frame_buf, &mut frame_state) {
+        match read_frame_into(&mut cursor, &mut frame_buf) {
             Ok(Some((code, payload_len))) => {
                 let primary = decode_frame(
                     code,
@@ -338,7 +337,6 @@ fn replay_pathological_fixture_never_panics_or_blocks() {
     let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
     let mut delta_state = DeltaState::new();
     let mut frame_buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut frame_state = FrameReadState::new();
 
     let mut events: Vec<StreamEvent> = Vec::new();
     let mut errored = false;
@@ -347,7 +345,7 @@ fn replay_pathological_fixture_never_panics_or_blocks() {
     // truncation error and spins instead trips this watchdog.
     let mut frames_seen: usize = 0;
     while frames_seen < 64 {
-        match read_frame_into(&mut cursor, &mut frame_buf, &mut frame_state) {
+        match read_frame_into(&mut cursor, &mut frame_buf) {
             Ok(Some((code, payload_len))) => {
                 let primary = decode_frame(
                     code,
@@ -365,7 +363,7 @@ fn replay_pathological_fixture_never_panics_or_blocks() {
             }
             Ok(None) => break, // clean EOF
             Err(_) => {
-                // Truncation / drain-yield surfaces as a typed error.
+                // Truncation surfaces as a typed error.
                 // The reader does NOT panic and the cursor stays bounded.
                 errored = true;
                 break;

--- a/thetadatadx-rs/tests/vendor_schema_drift.rs
+++ b/thetadatadx-rs/tests/vendor_schema_drift.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use thetadatadx::StreamMsgType;
 
 use thetadatadx::fpss::__test_internals::{
-    decode_frame, read_frame_into, DeltaState, FrameReadState, MAX_PAYLOAD_LEN,
+    decode_frame, read_frame_into, DeltaState, MAX_PAYLOAD_LEN,
 };
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::fpss::{StreamControl, StreamEvent};
@@ -58,11 +58,10 @@ fn single_unknown_opcode_skipped_without_desync() {
     let mut local: HashMap<i32, Arc<Contract>> = HashMap::new();
     let mut delta = DeltaState::new();
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
     let mut events: Vec<StreamEvent> = Vec::new();
 
     for _ in 0..16 {
-        match read_frame_into(&mut cursor, &mut buf, &mut state) {
+        match read_frame_into(&mut cursor, &mut buf) {
             Ok(Some((code, n))) => {
                 let p = decode_frame(
                     code,
@@ -121,11 +120,10 @@ fn consecutive_unknown_opcodes_are_all_skipped() {
 
     let mut cursor = Cursor::new(bytes);
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
     // A single read consumes and skips the entire run of unknown frames,
     // returning clean EOF — never a typed frame, never an error.
-    match read_frame_into(&mut cursor, &mut buf, &mut state) {
+    match read_frame_into(&mut cursor, &mut buf) {
         Ok(None) => {}
         Ok(Some(_)) => panic!("unknown opcode must not yield a typed frame"),
         Err(e) => panic!("a run of unknown opcodes must not escalate to an error: {e}"),
@@ -146,11 +144,10 @@ fn alternating_known_and_unknown_does_not_escalate() {
 
     let mut cursor = Cursor::new(bytes);
     let mut buf: Vec<u8> = Vec::with_capacity(MAX_PAYLOAD_LEN);
-    let mut state = FrameReadState::new();
 
     let mut frames = 0;
     for _ in 0..64 {
-        match read_frame_into(&mut cursor, &mut buf, &mut state) {
+        match read_frame_into(&mut cursor, &mut buf) {
             Ok(Some(_)) => frames += 1,
             Ok(None) => break,
             Err(e) => panic!("alternating sparse drift must not escalate: {e}"),


### PR DESCRIPTION
Removes the mid-frame drain-yield and per-frame wall-clock deadline machinery from the FPSS frame reader, an SDK-invented mechanism with no basis in the terminal. The reader is now stateless: it reads one full frame per call, bounded by a single no-progress stall timeout — the same read-N-bytes-under-a-stall-timeout shape the terminal uses.

## Removed

- `MID_FRAME_DRAIN_WINDOW_MS` and `DRAIN_YIELD_MARKER` consts, `is_drain_yield`, and the `FrameReadState` resumption struct (`framing.rs`).
- The per-frame wall-clock deadline (`frame_deadline` / `frame_cap`) and both drain-yield branches in the header and payload readers.
- The io_loop / login yield arms that consumed the drain-yield marker, the threaded `FrameReadState` argument, and the reconnect-time state reset (now unnecessary — a stateless reader always begins at a frame boundary).

## Reader shape after

Both readers are `loop { read(buf[n..]); on progress re-arm the stall clock; fatal only once stall_timeout elapses with zero forward progress }`. A pre-header transient (`n == 0`) still surfaces as an I/O error so the io_loop's existing command-drain / timeout classification is unchanged — commands drain at frame boundaries, exactly as before. On a slow socket a frame spanning read slices now completes (bounded by the stall timeout) rather than yielding mid-frame; the terminal does not drain mid-frame either. No replacement cap or retry budget was added — the single stall timeout is the only bound.

## Kept

The per-stall no-progress read timeout, all reconnect / backoff / jitter, and login's own between-frames handshake deadline (a distinct backstop against a chatty peer, not part of the removed per-frame machinery).

## Verification

Binding surface is zero: no FFI / C++ / Python / TypeScript reference to any removed symbol, and no parity or config-surface rows. Core + ffi build; 973 lib tests plus the framing / midframe-disconnect / reconnect-storm / replay-capture / pool-reconnect integration suites pass; `clippy --workspace --all-targets --locked` clean; rustfmt clean.

Net -1086 lines (`framing.rs` 1370 -> 649).

Closes #1050
