### PR TITLE
feat(fpss): expose contract_id on streaming data events

### DIFF
--- a/docs-site/docs/streaming/indices/market-value.md
+++ b/docs-site/docs/streaming/indices/market-value.md
@@ -120,6 +120,7 @@ Each update arrives as a `MarketValue` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `market_bid` | f64 | Calculated market-value bid (stocks and options only). |
 | `market_ask` | f64 | Calculated market-value ask (stocks and options only). |

--- a/docs-site/docs/streaming/indices/price.md
+++ b/docs-site/docs/streaming/indices/price.md
@@ -120,6 +120,7 @@ Each update arrives as a `Trade` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `sequence` | i32 | Exchange-assigned trade sequence number. |
 | `condition` | i32 | Trade condition code. |

--- a/docs-site/docs/streaming/options/full-open-interest.md
+++ b/docs-site/docs/streaming/options/full-open-interest.md
@@ -127,6 +127,7 @@ Each update arrives as a `OpenInterest` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `open_interest` | i32 | Total outstanding contracts. |
 | `date` | i32 | Trading date as a YYYYMMDD integer. |

--- a/docs-site/docs/streaming/options/full-trade.md
+++ b/docs-site/docs/streaming/options/full-trade.md
@@ -181,6 +181,7 @@ Each update arrives as a `Quote` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `bid_size` | i32 | Last NBBO bid size. |
 | `bid_exchange` | i32 | Exchange code of the NBBO bid. |
@@ -202,6 +203,7 @@ Each update arrives as a `Ohlcvc` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `open` | f64 | Opening trade price of the bar. |
 | `high` | f64 | Highest traded price of the bar. |
@@ -221,6 +223,7 @@ Each update arrives as a `Trade` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `sequence` | i32 | Exchange-assigned trade sequence number. |
 | `condition` | i32 | Trade condition code. |

--- a/docs-site/docs/streaming/options/market-value.md
+++ b/docs-site/docs/streaming/options/market-value.md
@@ -122,6 +122,7 @@ Each update arrives as a `MarketValue` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `market_bid` | f64 | Calculated market-value bid (stocks and options only). |
 | `market_ask` | f64 | Calculated market-value ask (stocks and options only). |

--- a/docs-site/docs/streaming/options/open-interest.md
+++ b/docs-site/docs/streaming/options/open-interest.md
@@ -128,6 +128,7 @@ Each update arrives as a `OpenInterest` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `open_interest` | i32 | Total outstanding contracts. |
 | `date` | i32 | Trading date as a YYYYMMDD integer. |

--- a/docs-site/docs/streaming/options/quote.md
+++ b/docs-site/docs/streaming/options/quote.md
@@ -122,6 +122,7 @@ Each update arrives as a `Quote` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `bid_size` | i32 | Last NBBO bid size. |
 | `bid_exchange` | i32 | Exchange code of the NBBO bid. |

--- a/docs-site/docs/streaming/options/trade.md
+++ b/docs-site/docs/streaming/options/trade.md
@@ -122,6 +122,7 @@ Each update arrives as a `Trade` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `sequence` | i32 | Exchange-assigned trade sequence number. |
 | `condition` | i32 | Trade condition code. |

--- a/docs-site/docs/streaming/stocks/full-trade.md
+++ b/docs-site/docs/streaming/stocks/full-trade.md
@@ -176,6 +176,7 @@ Each update arrives as a `Quote` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `bid_size` | i32 | Last BBO bid size. |
 | `bid_exchange` | i32 | Exchange code of the BBO bid. |
@@ -197,6 +198,7 @@ Each update arrives as a `Ohlcvc` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `open` | f64 | Opening trade price of the bar. |
 | `high` | f64 | Highest traded price of the bar. |
@@ -216,6 +218,7 @@ Each update arrives as a `Trade` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `sequence` | i32 | Exchange-assigned trade sequence number. |
 | `condition` | i32 | Trade condition code. |

--- a/docs-site/docs/streaming/stocks/market-value.md
+++ b/docs-site/docs/streaming/stocks/market-value.md
@@ -120,6 +120,7 @@ Each update arrives as a `MarketValue` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `market_bid` | f64 | Calculated market-value bid (stocks and options only). |
 | `market_ask` | f64 | Calculated market-value ask (stocks and options only). |

--- a/docs-site/docs/streaming/stocks/quote.md
+++ b/docs-site/docs/streaming/stocks/quote.md
@@ -120,6 +120,7 @@ Each update arrives as a `Quote` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `bid_size` | i32 | Last BBO bid size. |
 | `bid_exchange` | i32 | Exchange code of the BBO bid. |

--- a/docs-site/docs/streaming/stocks/trade.md
+++ b/docs-site/docs/streaming/stocks/trade.md
@@ -120,6 +120,7 @@ Each update arrives as a `Trade` event with these fields:
 | Field | Type | Description |
 |---|---|---|
 | `contract` | contract | Resolved contract identity (symbol, security type, and option fields). |
+| `contract_id` | i32 | Stable numeric contract registry key; a join key, not identity. |
 | `ms_of_day` | i32 | Milliseconds since midnight Eastern Time. |
 | `sequence` | i32 | Exchange-assigned trade sequence number. |
 | `condition` | i32 | Trade condition code. |

--- a/thetadatadx-cpp/include/fpss_event_structs.h.inc
+++ b/thetadatadx-cpp/include/fpss_event_structs.h.inc
@@ -57,6 +57,7 @@ int32_t strike_thousandths;
 /* Streaming MarketValue tick (wire code 25). A calculated theoretical market value derived from the real-time bid/ask — `market_bid` / `market_ask` are the quote bid/ask after a size-imbalance + spread-aware nudge, `market_price` is their integer midpoint. Per-contract only (no full-stream variant). */
 typedef struct {
     ThetaDataDxContract contract;
+    int32_t contract_id;
     int32_t ms_of_day;
     double market_bid;
     double market_ask;
@@ -68,6 +69,7 @@ typedef struct {
 /* Streaming OHLCVC bar. */
 typedef struct {
     ThetaDataDxContract contract;
+    int32_t contract_id;
     int32_t ms_of_day;
     double open;
     double high;
@@ -82,6 +84,7 @@ typedef struct {
 /* Streaming OpenInterest tick. */
 typedef struct {
     ThetaDataDxContract contract;
+    int32_t contract_id;
     int32_t ms_of_day;
     int32_t open_interest;
     int32_t date;
@@ -91,6 +94,7 @@ typedef struct {
 /* Streaming Quote tick. */
 typedef struct {
     ThetaDataDxContract contract;
+    int32_t contract_id;
     int32_t ms_of_day;
     int32_t bid_size;
     int32_t bid_exchange;
@@ -107,6 +111,7 @@ typedef struct {
 /* Streaming Trade tick. */
 typedef struct {
     ThetaDataDxContract contract;
+    int32_t contract_id;
     int32_t ms_of_day;
     int32_t sequence;
     int32_t condition;

--- a/thetadatadx-cpp/include/fpss_layout_asserts.hpp.inc
+++ b/thetadatadx-cpp/include/fpss_layout_asserts.hpp.inc
@@ -23,7 +23,9 @@ static_assert(offsetof(ThetaDataDxContract, strike_thousandths) == 32,
 
 static_assert(offsetof(ThetaDataDxStreamMarketValue, contract) == 0,
               "ThetaDataDxStreamMarketValue::contract offset drifted");
-static_assert(offsetof(ThetaDataDxStreamMarketValue, ms_of_day) == 40,
+static_assert(offsetof(ThetaDataDxStreamMarketValue, contract_id) == 40,
+              "ThetaDataDxStreamMarketValue::contract_id offset drifted");
+static_assert(offsetof(ThetaDataDxStreamMarketValue, ms_of_day) == 44,
               "ThetaDataDxStreamMarketValue::ms_of_day offset drifted");
 static_assert(offsetof(ThetaDataDxStreamMarketValue, market_bid) == 48,
               "ThetaDataDxStreamMarketValue::market_bid offset drifted");
@@ -40,7 +42,9 @@ static_assert(sizeof(ThetaDataDxStreamMarketValue) == 88,
 
 static_assert(offsetof(ThetaDataDxStreamOhlcvc, contract) == 0,
               "ThetaDataDxStreamOhlcvc::contract offset drifted");
-static_assert(offsetof(ThetaDataDxStreamOhlcvc, ms_of_day) == 40,
+static_assert(offsetof(ThetaDataDxStreamOhlcvc, contract_id) == 40,
+              "ThetaDataDxStreamOhlcvc::contract_id offset drifted");
+static_assert(offsetof(ThetaDataDxStreamOhlcvc, ms_of_day) == 44,
               "ThetaDataDxStreamOhlcvc::ms_of_day offset drifted");
 static_assert(offsetof(ThetaDataDxStreamOhlcvc, open) == 48,
               "ThetaDataDxStreamOhlcvc::open offset drifted");
@@ -63,11 +67,13 @@ static_assert(sizeof(ThetaDataDxStreamOhlcvc) == 112,
 
 static_assert(offsetof(ThetaDataDxStreamOpenInterest, contract) == 0,
               "ThetaDataDxStreamOpenInterest::contract offset drifted");
-static_assert(offsetof(ThetaDataDxStreamOpenInterest, ms_of_day) == 40,
+static_assert(offsetof(ThetaDataDxStreamOpenInterest, contract_id) == 40,
+              "ThetaDataDxStreamOpenInterest::contract_id offset drifted");
+static_assert(offsetof(ThetaDataDxStreamOpenInterest, ms_of_day) == 44,
               "ThetaDataDxStreamOpenInterest::ms_of_day offset drifted");
-static_assert(offsetof(ThetaDataDxStreamOpenInterest, open_interest) == 44,
+static_assert(offsetof(ThetaDataDxStreamOpenInterest, open_interest) == 48,
               "ThetaDataDxStreamOpenInterest::open_interest offset drifted");
-static_assert(offsetof(ThetaDataDxStreamOpenInterest, date) == 48,
+static_assert(offsetof(ThetaDataDxStreamOpenInterest, date) == 52,
               "ThetaDataDxStreamOpenInterest::date offset drifted");
 static_assert(offsetof(ThetaDataDxStreamOpenInterest, received_at_ns) == 56,
               "ThetaDataDxStreamOpenInterest::received_at_ns offset drifted");
@@ -76,11 +82,13 @@ static_assert(sizeof(ThetaDataDxStreamOpenInterest) == 64,
 
 static_assert(offsetof(ThetaDataDxStreamQuote, contract) == 0,
               "ThetaDataDxStreamQuote::contract offset drifted");
-static_assert(offsetof(ThetaDataDxStreamQuote, ms_of_day) == 40,
+static_assert(offsetof(ThetaDataDxStreamQuote, contract_id) == 40,
+              "ThetaDataDxStreamQuote::contract_id offset drifted");
+static_assert(offsetof(ThetaDataDxStreamQuote, ms_of_day) == 44,
               "ThetaDataDxStreamQuote::ms_of_day offset drifted");
-static_assert(offsetof(ThetaDataDxStreamQuote, bid_size) == 44,
+static_assert(offsetof(ThetaDataDxStreamQuote, bid_size) == 48,
               "ThetaDataDxStreamQuote::bid_size offset drifted");
-static_assert(offsetof(ThetaDataDxStreamQuote, bid_exchange) == 48,
+static_assert(offsetof(ThetaDataDxStreamQuote, bid_exchange) == 52,
               "ThetaDataDxStreamQuote::bid_exchange offset drifted");
 static_assert(offsetof(ThetaDataDxStreamQuote, bid) == 56,
               "ThetaDataDxStreamQuote::bid offset drifted");
@@ -103,15 +111,17 @@ static_assert(sizeof(ThetaDataDxStreamQuote) == 104,
 
 static_assert(offsetof(ThetaDataDxStreamTrade, contract) == 0,
               "ThetaDataDxStreamTrade::contract offset drifted");
-static_assert(offsetof(ThetaDataDxStreamTrade, ms_of_day) == 40,
+static_assert(offsetof(ThetaDataDxStreamTrade, contract_id) == 40,
+              "ThetaDataDxStreamTrade::contract_id offset drifted");
+static_assert(offsetof(ThetaDataDxStreamTrade, ms_of_day) == 44,
               "ThetaDataDxStreamTrade::ms_of_day offset drifted");
-static_assert(offsetof(ThetaDataDxStreamTrade, sequence) == 44,
+static_assert(offsetof(ThetaDataDxStreamTrade, sequence) == 48,
               "ThetaDataDxStreamTrade::sequence offset drifted");
-static_assert(offsetof(ThetaDataDxStreamTrade, condition) == 48,
+static_assert(offsetof(ThetaDataDxStreamTrade, condition) == 52,
               "ThetaDataDxStreamTrade::condition offset drifted");
-static_assert(offsetof(ThetaDataDxStreamTrade, size) == 52,
+static_assert(offsetof(ThetaDataDxStreamTrade, size) == 56,
               "ThetaDataDxStreamTrade::size offset drifted");
-static_assert(offsetof(ThetaDataDxStreamTrade, exchange) == 56,
+static_assert(offsetof(ThetaDataDxStreamTrade, exchange) == 60,
               "ThetaDataDxStreamTrade::exchange offset drifted");
 static_assert(offsetof(ThetaDataDxStreamTrade, price) == 64,
               "ThetaDataDxStreamTrade::price offset drifted");

--- a/thetadatadx-ffi/src/fpss_event_converter.rs
+++ b/thetadatadx-ffi/src/fpss_event_converter.rs
@@ -22,6 +22,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
     match event {
         StreamEvent::Data(StreamData::MarketValue {
             contract,
+            contract_id,
             ms_of_day,
             market_bid,
             market_ask,
@@ -54,6 +55,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
                     kind: ThetaDataDxStreamEventKind::MarketValue,
                     market_value: ThetaDataDxStreamMarketValue {
                         contract: thetadatadx_contract,
+                        contract_id: *contract_id,
                         ms_of_day: *ms_of_day,
                         market_bid: *market_bid,
                         market_ask: *market_ask,
@@ -72,6 +74,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
 
         StreamEvent::Data(StreamData::Ohlcvc {
             contract,
+            contract_id,
             ms_of_day,
             open,
             high,
@@ -107,6 +110,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
                     kind: ThetaDataDxStreamEventKind::Ohlcvc,
                     ohlcvc: ThetaDataDxStreamOhlcvc {
                         contract: thetadatadx_contract,
+                        contract_id: *contract_id,
                         ms_of_day: *ms_of_day,
                         open: *open,
                         high: *high,
@@ -128,6 +132,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
 
         StreamEvent::Data(StreamData::OpenInterest {
             contract,
+            contract_id,
             ms_of_day,
             open_interest,
             date,
@@ -158,6 +163,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
                     kind: ThetaDataDxStreamEventKind::OpenInterest,
                     open_interest: ThetaDataDxStreamOpenInterest {
                         contract: thetadatadx_contract,
+                        contract_id: *contract_id,
                         ms_of_day: *ms_of_day,
                         open_interest: *open_interest,
                         date: *date,
@@ -174,6 +180,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
 
         StreamEvent::Data(StreamData::Quote {
             contract,
+            contract_id,
             ms_of_day,
             bid_size,
             bid_exchange,
@@ -211,6 +218,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
                     kind: ThetaDataDxStreamEventKind::Quote,
                     quote: ThetaDataDxStreamQuote {
                         contract: thetadatadx_contract,
+                        contract_id: *contract_id,
                         ms_of_day: *ms_of_day,
                         bid_size: *bid_size,
                         bid_exchange: *bid_exchange,
@@ -234,6 +242,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
 
         StreamEvent::Data(StreamData::Trade {
             contract,
+            contract_id,
             ms_of_day,
             sequence,
             condition,
@@ -268,6 +277,7 @@ pub(crate) fn fpss_event_to_ffi(event: &thetadatadx::fpss::StreamEvent) -> FfiBu
                     kind: ThetaDataDxStreamEventKind::Trade,
                     trade: ThetaDataDxStreamTrade {
                         contract: thetadatadx_contract,
+                        contract_id: *contract_id,
                         ms_of_day: *ms_of_day,
                         sequence: *sequence,
                         condition: *condition,

--- a/thetadatadx-ffi/src/fpss_event_structs.rs
+++ b/thetadatadx-ffi/src/fpss_event_structs.rs
@@ -110,6 +110,8 @@ strike_thousandths: 0,
 pub struct ThetaDataDxStreamMarketValue {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
+    /// Server-assigned registry key (raw wire id). A join / index key, not contract identity.
+    pub contract_id: i32,
     /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Calculated market bid (dollars), nudged from the quote bid.
@@ -129,6 +131,8 @@ pub struct ThetaDataDxStreamMarketValue {
 pub struct ThetaDataDxStreamOhlcvc {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
+    /// Server-assigned registry key (raw wire id). A join / index key, not contract identity.
+    pub contract_id: i32,
     /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Opening price of the bar.
@@ -154,6 +158,8 @@ pub struct ThetaDataDxStreamOhlcvc {
 pub struct ThetaDataDxStreamOpenInterest {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
+    /// Server-assigned registry key (raw wire id). A join / index key, not contract identity.
+    pub contract_id: i32,
     /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Number of outstanding open contracts.
@@ -169,6 +175,8 @@ pub struct ThetaDataDxStreamOpenInterest {
 pub struct ThetaDataDxStreamQuote {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
+    /// Server-assigned registry key (raw wire id). A join / index key, not contract identity.
+    pub contract_id: i32,
     /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Number of contracts/shares resting at the bid.
@@ -198,6 +206,8 @@ pub struct ThetaDataDxStreamQuote {
 pub struct ThetaDataDxStreamTrade {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
+    /// Server-assigned registry key (raw wire id). A join / index key, not contract identity.
+    pub contract_id: i32,
     /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Exchange sequence number for ordering trades within the day.
@@ -525,6 +535,7 @@ const _: () = {
 // Zero-initialized defaults for inactive union-style fields.
 pub(crate) const ZERO_MARKET_VALUE: ThetaDataDxStreamMarketValue = ThetaDataDxStreamMarketValue {
     contract: ZERO_CONTRACT_STRUCT,
+    contract_id: 0,
     ms_of_day: 0,
     market_bid: 0.0,
     market_ask: 0.0,
@@ -534,6 +545,7 @@ pub(crate) const ZERO_MARKET_VALUE: ThetaDataDxStreamMarketValue = ThetaDataDxSt
 };
 pub(crate) const ZERO_OHLCVC: ThetaDataDxStreamOhlcvc = ThetaDataDxStreamOhlcvc {
     contract: ZERO_CONTRACT_STRUCT,
+    contract_id: 0,
     ms_of_day: 0,
     open: 0.0,
     high: 0.0,
@@ -546,6 +558,7 @@ pub(crate) const ZERO_OHLCVC: ThetaDataDxStreamOhlcvc = ThetaDataDxStreamOhlcvc 
 };
 pub(crate) const ZERO_OI: ThetaDataDxStreamOpenInterest = ThetaDataDxStreamOpenInterest {
     contract: ZERO_CONTRACT_STRUCT,
+    contract_id: 0,
     ms_of_day: 0,
     open_interest: 0,
     date: 0,
@@ -553,6 +566,7 @@ pub(crate) const ZERO_OI: ThetaDataDxStreamOpenInterest = ThetaDataDxStreamOpenI
 };
 pub(crate) const ZERO_QUOTE: ThetaDataDxStreamQuote = ThetaDataDxStreamQuote {
     contract: ZERO_CONTRACT_STRUCT,
+    contract_id: 0,
     ms_of_day: 0,
     bid_size: 0,
     bid_exchange: 0,
@@ -567,6 +581,7 @@ pub(crate) const ZERO_QUOTE: ThetaDataDxStreamQuote = ThetaDataDxStreamQuote {
 };
 pub(crate) const ZERO_TRADE: ThetaDataDxStreamTrade = ThetaDataDxStreamTrade {
     contract: ZERO_CONTRACT_STRUCT,
+    contract_id: 0,
     ms_of_day: 0,
     sequence: 0,
     condition: 0,

--- a/thetadatadx-py/src/_generated/fpss_event_classes.rs
+++ b/thetadatadx-py/src/_generated/fpss_event_classes.rs
@@ -160,6 +160,7 @@ impl MarketOpen {
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct MarketValue {
     pub contract: fpss::protocol::Contract,
+    #[pyo3(get)] pub contract_id: i32,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub market_bid: f64,
     #[pyo3(get)] pub market_ask: f64,
@@ -170,7 +171,7 @@ pub(crate) struct MarketValue {
 #[pymethods]
 impl MarketValue {
     fn __repr__(&self) -> String {
-        format!("MarketValue(ms_of_day={}, market_bid={}, market_ask={}, market_price={}, date={})", self.ms_of_day, self.market_bid, self.market_ask, self.market_price, self.date)
+        format!("MarketValue(contract_id={}, ms_of_day={}, market_bid={}, market_ask={}, market_price={}, date={})", self.contract_id, self.ms_of_day, self.market_bid, self.market_ask, self.market_price, self.date)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -190,6 +191,7 @@ impl MarketValue {
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct Ohlcvc {
     pub contract: fpss::protocol::Contract,
+    #[pyo3(get)] pub contract_id: i32,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub open: f64,
     #[pyo3(get)] pub high: f64,
@@ -203,7 +205,7 @@ pub(crate) struct Ohlcvc {
 #[pymethods]
 impl Ohlcvc {
     fn __repr__(&self) -> String {
-        format!("Ohlcvc(ms_of_day={}, open={}, high={}, low={}, close={}, volume={})", self.ms_of_day, self.open, self.high, self.low, self.close, self.volume)
+        format!("Ohlcvc(contract_id={}, ms_of_day={}, open={}, high={}, low={}, close={})", self.contract_id, self.ms_of_day, self.open, self.high, self.low, self.close)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -223,6 +225,7 @@ impl Ohlcvc {
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct OpenInterest {
     pub contract: fpss::protocol::Contract,
+    #[pyo3(get)] pub contract_id: i32,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub open_interest: i32,
     #[pyo3(get)] pub date: i32,
@@ -231,7 +234,7 @@ pub(crate) struct OpenInterest {
 #[pymethods]
 impl OpenInterest {
     fn __repr__(&self) -> String {
-        format!("OpenInterest(ms_of_day={}, open_interest={}, date={})", self.ms_of_day, self.open_interest, self.date)
+        format!("OpenInterest(contract_id={}, ms_of_day={}, open_interest={}, date={})", self.contract_id, self.ms_of_day, self.open_interest, self.date)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -281,6 +284,7 @@ impl Ping {
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct Quote {
     pub contract: fpss::protocol::Contract,
+    #[pyo3(get)] pub contract_id: i32,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub bid_size: i32,
     #[pyo3(get)] pub bid_exchange: i32,
@@ -296,7 +300,7 @@ pub(crate) struct Quote {
 #[pymethods]
 impl Quote {
     fn __repr__(&self) -> String {
-        format!("Quote(ms_of_day={}, bid_size={}, bid_exchange={}, bid={}, bid_condition={}, ask_size={})", self.ms_of_day, self.bid_size, self.bid_exchange, self.bid, self.bid_condition, self.ask_size)
+        format!("Quote(contract_id={}, ms_of_day={}, bid_size={}, bid_exchange={}, bid={}, bid_condition={})", self.contract_id, self.ms_of_day, self.bid_size, self.bid_exchange, self.bid, self.bid_condition)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -436,6 +440,7 @@ impl ServerError {
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct Trade {
     pub contract: fpss::protocol::Contract,
+    #[pyo3(get)] pub contract_id: i32,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub sequence: i32,
     #[pyo3(get)] pub condition: i32,
@@ -448,7 +453,7 @@ pub(crate) struct Trade {
 #[pymethods]
 impl Trade {
     fn __repr__(&self) -> String {
-        format!("Trade(ms_of_day={}, sequence={}, condition={}, size={}, exchange={}, price={})", self.ms_of_day, self.sequence, self.condition, self.size, self.exchange, self.price)
+        format!("Trade(contract_id={}, ms_of_day={}, sequence={}, condition={}, size={}, exchange={})", self.contract_id, self.ms_of_day, self.sequence, self.condition, self.size, self.exchange)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -505,6 +510,7 @@ pub(crate) fn fpss_event_to_typed(
         fpss::StreamEvent::Data(data) => match data {
             fpss::StreamData::MarketValue {
                 contract,
+                contract_id,
                 ms_of_day,
                 market_bid,
                 market_ask,
@@ -516,6 +522,7 @@ pub(crate) fn fpss_event_to_typed(
                 py,
                 MarketValue {
                     contract: (**contract).clone(),
+                    contract_id: *contract_id,
                     ms_of_day: *ms_of_day,
                     market_bid: *market_bid,
                     market_ask: *market_ask,
@@ -527,6 +534,7 @@ pub(crate) fn fpss_event_to_typed(
             .map(|p| p.into_any()),
             fpss::StreamData::Ohlcvc {
                 contract,
+                contract_id,
                 ms_of_day,
                 open,
                 high,
@@ -541,6 +549,7 @@ pub(crate) fn fpss_event_to_typed(
                 py,
                 Ohlcvc {
                     contract: (**contract).clone(),
+                    contract_id: *contract_id,
                     ms_of_day: *ms_of_day,
                     open: *open,
                     high: *high,
@@ -555,6 +564,7 @@ pub(crate) fn fpss_event_to_typed(
             .map(|p| p.into_any()),
             fpss::StreamData::OpenInterest {
                 contract,
+                contract_id,
                 ms_of_day,
                 open_interest,
                 date,
@@ -564,6 +574,7 @@ pub(crate) fn fpss_event_to_typed(
                 py,
                 OpenInterest {
                     contract: (**contract).clone(),
+                    contract_id: *contract_id,
                     ms_of_day: *ms_of_day,
                     open_interest: *open_interest,
                     date: *date,
@@ -573,6 +584,7 @@ pub(crate) fn fpss_event_to_typed(
             .map(|p| p.into_any()),
             fpss::StreamData::Quote {
                 contract,
+                contract_id,
                 ms_of_day,
                 bid_size,
                 bid_exchange,
@@ -589,6 +601,7 @@ pub(crate) fn fpss_event_to_typed(
                 py,
                 Quote {
                     contract: (**contract).clone(),
+                    contract_id: *contract_id,
                     ms_of_day: *ms_of_day,
                     bid_size: *bid_size,
                     bid_exchange: *bid_exchange,
@@ -605,6 +618,7 @@ pub(crate) fn fpss_event_to_typed(
             .map(|p| p.into_any()),
             fpss::StreamData::Trade {
                 contract,
+                contract_id,
                 ms_of_day,
                 sequence,
                 condition,
@@ -618,6 +632,7 @@ pub(crate) fn fpss_event_to_typed(
                 py,
                 Trade {
                     contract: (**contract).clone(),
+                    contract_id: *contract_id,
                     ms_of_day: *ms_of_day,
                     sequence: *sequence,
                     condition: *condition,

--- a/thetadatadx-py/src/_generated/fpss_event_classes.rs
+++ b/thetadatadx-py/src/_generated/fpss_event_classes.rs
@@ -205,7 +205,7 @@ pub(crate) struct Ohlcvc {
 #[pymethods]
 impl Ohlcvc {
     fn __repr__(&self) -> String {
-        format!("Ohlcvc(contract_id={}, ms_of_day={}, open={}, high={}, low={}, close={})", self.contract_id, self.ms_of_day, self.open, self.high, self.low, self.close)
+        format!("Ohlcvc(contract_id={}, ms_of_day={}, open={}, high={}, low={}, close={}, volume={})", self.contract_id, self.ms_of_day, self.open, self.high, self.low, self.close, self.volume)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -300,7 +300,7 @@ pub(crate) struct Quote {
 #[pymethods]
 impl Quote {
     fn __repr__(&self) -> String {
-        format!("Quote(contract_id={}, ms_of_day={}, bid_size={}, bid_exchange={}, bid={}, bid_condition={})", self.contract_id, self.ms_of_day, self.bid_size, self.bid_exchange, self.bid, self.bid_condition)
+        format!("Quote(contract_id={}, ms_of_day={}, bid_size={}, bid_exchange={}, bid={}, bid_condition={}, ask_size={})", self.contract_id, self.ms_of_day, self.bid_size, self.bid_exchange, self.bid, self.bid_condition, self.ask_size)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,
@@ -453,7 +453,7 @@ pub(crate) struct Trade {
 #[pymethods]
 impl Trade {
     fn __repr__(&self) -> String {
-        format!("Trade(contract_id={}, ms_of_day={}, sequence={}, condition={}, size={}, exchange={})", self.contract_id, self.ms_of_day, self.sequence, self.condition, self.size, self.exchange)
+        format!("Trade(contract_id={}, ms_of_day={}, sequence={}, condition={}, size={}, exchange={}, price={})", self.contract_id, self.ms_of_day, self.sequence, self.condition, self.size, self.exchange, self.price)
     }
 
     /// Streaming contract identity (`symbol`, `sec_type`,

--- a/thetadatadx-py/src/bench_streaming.rs
+++ b/thetadatadx-py/src/bench_streaming.rs
@@ -90,6 +90,7 @@ unsafe impl Sync for RingSlot {}
 fn make_event(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
     StreamEvent::Data(StreamData::Trade {
         contract: Arc::clone(contract),
+        contract_id: idx as i32,
         ms_of_day: (idx % 86_400_000) as i32,
         sequence: idx as i32,
         condition: 0,

--- a/thetadatadx-py/tests/test_fpss_control_variants.py
+++ b/thetadatadx-py/tests/test_fpss_control_variants.py
@@ -151,6 +151,26 @@ def test_data_classes_still_exported(thetadatadx_mod):
         assert cls.__name__ == variant
 
 
+def test_data_events_expose_contract_id_getter(thetadatadx_mod):
+    """Every streaming data-event pyclass surfaces the server-assigned
+    `contract_id` join key as a `#[pyo3(get)]` field getter.
+
+    pyo3 generates a getter on each `#[pyo3(get)]` field, so `dir(cls)`
+    exposes `contract_id`. We do not construct the class from Python
+    (frozen + skip_from_py_object, no `#[new]`), so this pins structural
+    presence — the same offline-safe contract the control-variant field
+    tests above assert. The value path (contract_id == the wire id) is
+    pinned by the Rust decode test `decode_frame_surfaces_wire_contract_id_on_data_events`.
+    """
+    for variant in ("Quote", "Trade", "OpenInterest", "Ohlcvc", "MarketValue"):
+        cls = getattr(thetadatadx_mod, variant, None)
+        assert cls is not None, f"thetadatadx.{variant} missing"
+        assert "contract_id" in dir(cls), (
+            f"thetadatadx.{variant} missing field getter 'contract_id'; "
+            f"check `[events.{variant}]` columns in fpss_event_schema.toml"
+        )
+
+
 def test_simple_class_removed(thetadatadx_mod):
     """The flat `Simple` envelope is gone -- typed-per-variant control
     classes replace it. Pin its absence so accidental re-introduction

--- a/thetadatadx-rs/benches/bench_fpss_event.rs
+++ b/thetadatadx-rs/benches/bench_fpss_event.rs
@@ -32,6 +32,7 @@ fn sample_contract() -> Arc<Contract> {
 fn sample_quote() -> StreamEvent {
     StreamEvent::Data(StreamData::Quote {
         contract: sample_contract(),
+        contract_id: 1,
         ms_of_day: 34_200_000,
         bid_size: 100,
         bid_exchange: 1,
@@ -49,6 +50,7 @@ fn sample_quote() -> StreamEvent {
 fn sample_trade() -> StreamEvent {
     StreamEvent::Data(StreamData::Trade {
         contract: sample_contract(),
+        contract_id: 1,
         ms_of_day: 34_200_001,
         sequence: 42,
         condition: 50,
@@ -63,6 +65,7 @@ fn sample_trade() -> StreamEvent {
 fn sample_ohlcvc() -> StreamEvent {
     StreamEvent::Data(StreamData::Ohlcvc {
         contract: sample_contract(),
+        contract_id: 1,
         ms_of_day: 34_200_000,
         open: 449.5,
         high: 450.3,

--- a/thetadatadx-rs/benches/streaming_throughput.rs
+++ b/thetadatadx-rs/benches/streaming_throughput.rs
@@ -81,6 +81,7 @@ type BoxedHandler = Mutex<Box<dyn FnMut(&StreamEvent) + Send>>;
 fn make_event(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
     StreamEvent::Data(StreamData::Trade {
         contract: Arc::clone(contract),
+        contract_id: idx as i32,
         ms_of_day: (idx % 86_400_000) as i32,
         sequence: idx as i32,
         condition: 0,

--- a/thetadatadx-rs/build_support_bin/endpoints/docs_render/streaming.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/docs_render/streaming.rs
@@ -54,6 +54,7 @@ fn event_field_doc(name: &str, book: &str) -> String {
 fn event_field_doc_static(name: &str) -> &'static str {
     match name {
         "contract" => "Resolved contract identity (symbol, security type, and option fields).",
+        "contract_id" => "Stable numeric contract registry key; a join key, not identity.",
         "received_at_ns" => "Local receive timestamp, nanoseconds since the Unix epoch.",
         "ms_of_day" => "Milliseconds since midnight Eastern Time.",
         "date" => "Trading date as a YYYYMMDD integer.",

--- a/thetadatadx-rs/build_support_bin/fpss_events/ffi_rust.rs
+++ b/thetadatadx-rs/build_support_bin/fpss_events/ffi_rust.rs
@@ -133,6 +133,9 @@ fn fpss_column_doc(name: &str) -> String {
         "condition" => "Primary trade condition code.",
         "condition_flags" => "Bit flags qualifying the trade conditions.",
         "contract" => "Contract this event refers to.",
+        "contract_id" => {
+            "Server-assigned registry key (raw wire id). A join / index key, not contract identity."
+        }
         "count" => "Number of trades aggregated into the bar.",
         "date" => "Trading date as `YYYYMMDD`.",
         "delay_ms" => "Delay, in milliseconds, before the attempt fires.",

--- a/thetadatadx-rs/build_support_bin/fpss_events/python.rs
+++ b/thetadatadx-rs/build_support_bin/fpss_events/python.rs
@@ -174,12 +174,14 @@ fn render_python_event_class_struct(event_name: &str, def: &EventDef) -> String 
     // tick-class renderer in `ticks/python_classes.rs::render_python_tick_class_struct`)
     // so pdb, Jupyter, pytest short-repr, and print()-based debugging
     // show actionable diagnostic data instead of an opaque
-    // `"Ohlcvc(...)"` placeholder. Cap at six columns to stay one-line
-    // readable; `Vec<u8>` payload columns (e.g. `UnknownFrame.payload`)
+    // `"Ohlcvc(...)"` placeholder. Cap at seven columns to stay one-line
+    // readable while still showing the leading `contract_id` join key and
+    // the primary payload field of every variant (price / bid+ask_size /
+    // volume); `Vec<u8>` payload columns (e.g. `UnknownFrame.payload`)
     // and `received_at_ns` are skipped because the first is unbounded
     // and the second is a timestamp that dwarfs the other fields
     // visually.
-    let repr_fields = fpss_event_repr_fields(&def.columns, 6);
+    let repr_fields = fpss_event_repr_fields(&def.columns, 7);
     if repr_fields.is_empty() {
         // Defensive fallback — every schema event has columns, but keep
         // the fallback so a future zero-column variant still compiles.

--- a/thetadatadx-rs/fpss_event_schema.toml
+++ b/thetadatadx-rs/fpss_event_schema.toml
@@ -30,7 +30,7 @@
 # nullable shape (`Option<..>` in Rust, `Option<..>` in napi, `Optional[..]`
 # in Python via pyo3 `Option<..>`, `std::optional<..>` in C++).
 
-version = 9
+version = 10
 
 # ── Data variants — market-data ticks ─────────────────────────────────
 
@@ -39,6 +39,7 @@ kind = "data"
 doc = "Streaming Quote tick."
 columns = [
     { name = "contract",      type = "Contract" },
+    { name = "contract_id",   type = "i32" },
     { name = "ms_of_day",     type = "i32" },
     { name = "bid_size",      type = "i32" },
     { name = "bid_exchange",  type = "i32" },
@@ -57,6 +58,7 @@ kind = "data"
 doc = "Streaming Trade tick."
 columns = [
     { name = "contract",        type = "Contract" },
+    { name = "contract_id",     type = "i32" },
     { name = "ms_of_day",       type = "i32" },
     { name = "sequence",        type = "i32" },
     { name = "condition",       type = "i32" },
@@ -72,6 +74,7 @@ kind = "data"
 doc = "Streaming OpenInterest tick."
 columns = [
     { name = "contract",      type = "Contract" },
+    { name = "contract_id",   type = "i32" },
     { name = "ms_of_day",     type = "i32" },
     { name = "open_interest", type = "i32" },
     { name = "date",          type = "i32" },
@@ -83,6 +86,7 @@ kind = "data"
 doc = "Streaming OHLCVC bar."
 columns = [
     { name = "contract",       type = "Contract" },
+    { name = "contract_id",    type = "i32" },
     { name = "ms_of_day",      type = "i32" },
     { name = "open",           type = "f64" },
     { name = "high",           type = "f64" },
@@ -99,6 +103,7 @@ kind = "data"
 doc = "Streaming MarketValue tick (wire code 25). A calculated theoretical market value derived from the real-time bid/ask — `market_bid` / `market_ask` are the quote bid/ask after a size-imbalance + spread-aware nudge, `market_price` is their integer midpoint. Per-contract only (no full-stream variant)."
 columns = [
     { name = "contract",      type = "Contract" },
+    { name = "contract_id",   type = "i32" },
     { name = "ms_of_day",     type = "i32" },
     { name = "market_bid",    type = "f64" },
     { name = "market_ask",    type = "f64" },

--- a/thetadatadx-rs/src/fpss/batch_reader.rs
+++ b/thetadatadx-rs/src/fpss/batch_reader.rs
@@ -918,6 +918,7 @@ pub(crate) mod test_harness {
     pub(crate) fn trade(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
         StreamEvent::Data(StreamData::Trade {
             contract: Arc::clone(contract),
+            contract_id: idx as i32,
             ms_of_day: (idx % 86_400_000) as i32,
             sequence: idx as i32,
             condition: 0,
@@ -933,6 +934,7 @@ pub(crate) mod test_harness {
     pub(crate) fn quote(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
         StreamEvent::Data(StreamData::Quote {
             contract: Arc::clone(contract),
+            contract_id: idx as i32,
             ms_of_day: (idx % 86_400_000) as i32,
             bid_size: 10,
             bid_exchange: 1,

--- a/thetadatadx-rs/src/fpss/batch_schema.rs
+++ b/thetadatadx-rs/src/fpss/batch_schema.rs
@@ -73,6 +73,10 @@ pub fn stream_batch_schema() -> Arc<Schema> {
         Field::new("expiration", DataType::Int32, true),
         Field::new("strike", DataType::Float64, true),
         Field::new("right", DataType::Utf8, true),
+        // Server-assigned registry key. A join / index key present on every
+        // data row (non-null), NOT contract identity — identity is the
+        // (symbol, expiration, strike, right) columns above.
+        Field::new("contract_id", DataType::Int32, false),
         // ── common to every data variant ──
         Field::new("ms_of_day", DataType::Int32, false),
         Field::new("date", DataType::Int32, false),
@@ -111,10 +115,10 @@ pub fn stream_batch_schema() -> Arc<Schema> {
 /// Approximate serialized bytes per row, used only to seed the Arrow IPC
 /// output buffer so it is written without re-growing from empty.
 ///
-/// Derived from the fixed [`stream_batch_schema`] columns: 15 `Int32` (4 B
-/// each = 60), 11 `Float64` + 1 `UInt64` + 2 `Int64` (8 B each = 112), and 3
+/// Derived from the fixed [`stream_batch_schema`] columns: 16 `Int32` (4 B
+/// each = 64), 11 `Float64` + 1 `UInt64` + 2 `Int64` (8 B each = 112), and 3
 /// `Utf8` columns (offset plus a short value, allowed ~16 B each = 48),
-/// totalling ~220 B; rounded up to 256 to cover per-row validity bits and
+/// totalling ~224 B; rounded up to 256 to cover per-row validity bits and
 /// alignment. This is a buffer-sizing HINT, never a correctness input — if a
 /// column is added to the schema, bump this alongside it. Sized so a full
 /// batch seeds at or above the real IPC body (no doubling regrow) while a tiny
@@ -122,7 +126,7 @@ pub fn stream_batch_schema() -> Arc<Schema> {
 pub(crate) const EST_IPC_BYTES_PER_ROW: usize = 256;
 
 /// Fixed Arrow IPC framing allowance added to the per-row estimate: the schema
-/// message (a flatbuffer over the 32-column schema, which measures ~8.5 KB on
+/// message (a flatbuffer over the 33-column schema, which measures ~8.5 KB on
 /// its own) plus the record-batch message header and stream end-of-stream
 /// marker. 16 KB covers the schema preamble for even the smallest batch, so a
 /// one-row batch (whose body is ~9.5 KB) seeds above its real IPC size and does
@@ -179,6 +183,7 @@ pub struct StreamBatchBuilder {
     expiration: Int32Builder,
     strike: Float64Builder,
     right: StringBuilder,
+    contract_id: Int32Builder,
 
     ms_of_day: Int32Builder,
     date: Int32Builder,
@@ -242,6 +247,7 @@ impl StreamBatchBuilder {
             expiration: Int32Builder::with_capacity(capacity),
             strike: Float64Builder::with_capacity(capacity),
             right: StringBuilder::with_capacity(capacity, capacity),
+            contract_id: Int32Builder::with_capacity(capacity),
             ms_of_day: Int32Builder::with_capacity(capacity),
             date: Int32Builder::with_capacity(capacity),
             received_at_ns: UInt64Builder::with_capacity(capacity),
@@ -322,6 +328,7 @@ impl StreamBatchBuilder {
         match data {
             StreamData::Quote {
                 contract,
+                contract_id,
                 ms_of_day,
                 bid_size,
                 bid_exchange,
@@ -337,6 +344,7 @@ impl StreamBatchBuilder {
                 self.push_header(
                     event_type::QUOTE,
                     contract,
+                    *contract_id,
                     *ms_of_day,
                     *date,
                     *received_at_ns,
@@ -358,6 +366,7 @@ impl StreamBatchBuilder {
             }
             StreamData::Trade {
                 contract,
+                contract_id,
                 ms_of_day,
                 sequence,
                 condition,
@@ -370,6 +379,7 @@ impl StreamBatchBuilder {
                 self.push_header(
                     event_type::TRADE,
                     contract,
+                    *contract_id,
                     *ms_of_day,
                     *date,
                     *received_at_ns,
@@ -387,6 +397,7 @@ impl StreamBatchBuilder {
             }
             StreamData::OpenInterest {
                 contract,
+                contract_id,
                 ms_of_day,
                 open_interest,
                 date,
@@ -395,6 +406,7 @@ impl StreamBatchBuilder {
                 self.push_header(
                     event_type::OPEN_INTEREST,
                     contract,
+                    *contract_id,
                     *ms_of_day,
                     *date,
                     *received_at_ns,
@@ -407,6 +419,7 @@ impl StreamBatchBuilder {
             }
             StreamData::Ohlcvc {
                 contract,
+                contract_id,
                 ms_of_day,
                 open,
                 high,
@@ -420,6 +433,7 @@ impl StreamBatchBuilder {
                 self.push_header(
                     event_type::OHLCVC,
                     contract,
+                    *contract_id,
                     *ms_of_day,
                     *date,
                     *received_at_ns,
@@ -437,6 +451,7 @@ impl StreamBatchBuilder {
             }
             StreamData::MarketValue {
                 contract,
+                contract_id,
                 ms_of_day,
                 market_bid,
                 market_ask,
@@ -447,6 +462,7 @@ impl StreamBatchBuilder {
                 self.push_header(
                     event_type::MARKET_VALUE,
                     contract,
+                    *contract_id,
                     *ms_of_day,
                     *date,
                     *received_at_ns,
@@ -484,7 +500,7 @@ impl StreamBatchBuilder {
         // `finish()` takes their backing buffer, leaving capacity at zero, so
         // re-sizing here is what keeps EVERY batch pre-allocated; without it
         // only the first batch would be sized and batches 2..N would re-grow
-        // each of the 40 columns from empty by doubling on the dispatcher
+        // every column from empty by doubling on the dispatcher
         // thread. Reusing the schema `Arc` keeps the output concat-safe and
         // avoids reallocating the schema per batch.
         let mut prev = std::mem::replace(
@@ -498,6 +514,7 @@ impl StreamBatchBuilder {
             Arc::new(prev.expiration.finish()) as ArrayRef,
             Arc::new(prev.strike.finish()) as ArrayRef,
             Arc::new(prev.right.finish()) as ArrayRef,
+            Arc::new(prev.contract_id.finish()) as ArrayRef,
             Arc::new(prev.ms_of_day.finish()) as ArrayRef,
             Arc::new(prev.date.finish()) as ArrayRef,
             Arc::new(prev.received_at_ns.finish()) as ArrayRef,
@@ -535,6 +552,7 @@ impl StreamBatchBuilder {
         &mut self,
         tag: &str,
         contract: &crate::fpss::protocol::Contract,
+        contract_id: i32,
         ms_of_day: i32,
         date: i32,
         received_at_ns: u64,
@@ -562,6 +580,7 @@ impl StreamBatchBuilder {
             // non-call/put right as absent rather than guessing a tag.
             Some(Right::Both) | None => self.right.append_null(),
         }
+        self.contract_id.append_value(contract_id);
         self.ms_of_day.append_value(ms_of_day);
         self.date.append_value(date);
         self.received_at_ns.append_value(received_at_ns);
@@ -615,6 +634,7 @@ mod tests {
     fn trade(contract: &std::sync::Arc<Contract>) -> StreamEvent {
         StreamEvent::Data(StreamData::Trade {
             contract: std::sync::Arc::clone(contract),
+            contract_id: 11,
             ms_of_day: 100,
             sequence: 7,
             condition: 0,
@@ -629,6 +649,7 @@ mod tests {
     fn quote(contract: &std::sync::Arc<Contract>) -> StreamEvent {
         StreamEvent::Data(StreamData::Quote {
             contract: std::sync::Arc::clone(contract),
+            contract_id: 12,
             ms_of_day: 200,
             bid_size: 10,
             bid_exchange: 1,
@@ -653,6 +674,7 @@ mod tests {
             "event_type",
             "symbol",
             "sec_type",
+            "contract_id",
             "ms_of_day",
             "date",
             "received_at_ns",
@@ -696,6 +718,16 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(event_type.value(0), event_type::TRADE);
+
+        // contract_id is a non-null join column carrying the wire id.
+        let contract_id = batch
+            .column_by_name("contract_id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert!(!contract_id.is_null(0), "contract_id is non-null");
+        assert_eq!(contract_id.value(0), 11, "contract_id carries the wire id");
 
         let price = batch
             .column_by_name("price")
@@ -767,6 +799,7 @@ mod tests {
         let mut b = StreamBatchBuilder::with_capacity(8);
         b.append(&StreamEvent::Data(StreamData::Trade {
             contract: std::sync::Arc::clone(&contract),
+            contract_id: 1,
             ms_of_day: 1,
             sequence: 0,
             condition: 0,

--- a/thetadatadx-rs/src/fpss/decode.rs
+++ b/thetadatadx-rs/src/fpss/decode.rs
@@ -384,6 +384,7 @@ pub fn decode_frame(
                     FPSS_QUOTE_EVENTS.increment(1);
                     Some(FpssEventInternal::Data(StreamData::Quote {
                         contract: resolve_contract(contract_id, local_contracts),
+                        contract_id,
                         ms_of_day: buf[0],
                         bid_size: buf[1],
                         bid_exchange: buf[2],
@@ -453,6 +454,7 @@ pub fn decode_frame(
                     let contract_arc = resolve_contract(contract_id, local_contracts);
                     let trade_event = FpssEventInternal::Data(StreamData::Trade {
                         contract: contract_arc,
+                        contract_id,
                         ms_of_day: buf[0],
                         sequence: buf[1],
                         condition: buf[3],
@@ -486,6 +488,7 @@ pub fn decode_frame(
                     FPSS_OI_EVENTS.increment(1);
                     Some(FpssEventInternal::Data(StreamData::OpenInterest {
                         contract: resolve_contract(contract_id, local_contracts),
+                        contract_id,
                         ms_of_day: buf[0],
                         open_interest: buf[1],
                         date: buf[2],
@@ -527,6 +530,7 @@ pub fn decode_frame(
                     let count = i64::from(buf[6] as u32);
                     Some(FpssEventInternal::Data(StreamData::Ohlcvc {
                         contract: resolve_contract(contract_id, local_contracts),
+                        contract_id,
                         ms_of_day: buf[0],
                         open: o,
                         high: h,
@@ -580,6 +584,7 @@ pub fn decode_frame(
                     FPSS_MARKET_VALUE_EVENTS.increment(1);
                     Some(FpssEventInternal::Data(StreamData::MarketValue {
                         contract: resolve_contract(contract_id, local_contracts),
+                        contract_id,
                         ms_of_day: buf[0],
                         market_bid,
                         market_ask,
@@ -876,6 +881,129 @@ mod tests {
                 assert_eq!(*date, 20250428);
             }
             other => panic!("expected StreamEvent::Data(Trade), got {other:?}"),
+        }
+    }
+
+    /// Every decoded data event surfaces the raw wire `contract_id` (FIT
+    /// field 0) as a read-only join key — present and correct for a Trade
+    /// and a Quote, and equal to the value the matching `ContractAssigned`
+    /// carries once the contract resolves. Populated from the wire id, not
+    /// the resolved contract, so it is right even for the unresolved case.
+    #[test]
+    fn decode_frame_surfaces_wire_contract_id_on_data_events() {
+        const CID: i32 = 4242;
+
+        let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
+        let authenticated = AtomicBool::new(true);
+        let shutdown = AtomicBool::new(false);
+        let mut delta_state = DeltaState::new();
+
+        // ── ContractAssigned publishes the same id we expect on the ticks.
+        let mut assign_payload = Vec::new();
+        assign_payload.extend_from_slice(&CID.to_be_bytes());
+        assign_payload.extend_from_slice(&Contract::stock("AAPL").to_bytes());
+        let assigned = decode_frame(
+            StreamMsgType::Contract,
+            &assign_payload,
+            &authenticated,
+            &mut local_contracts,
+            &shutdown,
+            &mut delta_state,
+        )
+        .expect("ContractAssigned must emit an event");
+        let assigned_id = match expect_public(&assigned) {
+            StreamEvent::Control(StreamControl::ContractAssigned { id, .. }) => *id,
+            other => panic!("expected ContractAssigned, got {other:?}"),
+        };
+        assert_eq!(assigned_id, CID);
+
+        // ── Trade: contract_id == wire id, and == the ContractAssigned id.
+        let trade_row =
+            encode_fit_row(&[CID, 34_200_000, 12_345, 50, 6, 5_500_000, 57, 6, 20_250_428]);
+        let trade = decode_frame(
+            StreamMsgType::Trade,
+            &trade_row,
+            &authenticated,
+            &mut local_contracts,
+            &shutdown,
+            &mut delta_state,
+        )
+        .expect("Trade must emit an event");
+        match expect_public(&trade) {
+            StreamEvent::Data(StreamData::Trade { contract_id, .. }) => {
+                assert_eq!(*contract_id, CID, "Trade must carry the wire contract_id");
+                assert_eq!(
+                    *contract_id, assigned_id,
+                    "resolved Trade contract_id must match the ContractAssigned id"
+                );
+            }
+            other => panic!("expected Data(Trade), got {other:?}"),
+        }
+
+        // ── Quote: same contract_id on a different tick shape.
+        let quote_row = encode_fit_row(&[
+            CID, 34_200_001, 10, 4, 15_025, 0, 12, 4, 15_030, 0, 6, 20_250_428,
+        ]);
+        let quote = decode_frame(
+            StreamMsgType::Quote,
+            &quote_row,
+            &authenticated,
+            &mut local_contracts,
+            &shutdown,
+            &mut delta_state,
+        )
+        .expect("Quote must emit an event");
+        match expect_public(&quote) {
+            StreamEvent::Data(StreamData::Quote { contract_id, .. }) => {
+                assert_eq!(*contract_id, CID, "Quote must carry the wire contract_id");
+            }
+            other => panic!("expected Data(Quote), got {other:?}"),
+        }
+    }
+
+    /// A tick that arrives before its `ContractAssigned` still surfaces the
+    /// wire `contract_id`: it is populated from the FIT wire id, not the
+    /// resolved contract, so the unresolved-sentinel case carries the real
+    /// id even though `contract.sec_type == Unknown`.
+    #[test]
+    fn decode_frame_surfaces_contract_id_even_when_unresolved() {
+        const CID: i32 = 987_654;
+        let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
+        let authenticated = AtomicBool::new(true);
+        let shutdown = AtomicBool::new(false);
+        let mut delta_state = DeltaState::new();
+
+        // No ContractAssigned seeded: the lookup misses, the contract is the
+        // unresolved sentinel, but contract_id is the raw wire id regardless.
+        let quote_row = encode_fit_row(&[
+            CID, 34_200_000, 10, 4, 15_025, 0, 12, 4, 15_030, 0, 6, 20_250_428,
+        ]);
+        let quote = decode_frame(
+            StreamMsgType::Quote,
+            &quote_row,
+            &authenticated,
+            &mut local_contracts,
+            &shutdown,
+            &mut delta_state,
+        )
+        .expect("Quote must emit an event");
+        match expect_public(&quote) {
+            StreamEvent::Data(StreamData::Quote {
+                contract,
+                contract_id,
+                ..
+            }) => {
+                assert_eq!(
+                    contract.sec_type,
+                    crate::tdbe::types::enums::SecType::Unknown,
+                    "unresolved tick must carry the sentinel contract"
+                );
+                assert_eq!(
+                    *contract_id, CID,
+                    "contract_id must be the raw wire id even when unresolved"
+                );
+            }
+            other => panic!("expected Data(Quote), got {other:?}"),
         }
     }
 

--- a/thetadatadx-rs/src/fpss/events.rs
+++ b/thetadatadx-rs/src/fpss/events.rs
@@ -16,10 +16,11 @@ use super::protocol::Contract;
 ///
 /// Every variant carries the fully parsed [`Contract`] as `Arc<Contract>` —
 /// users identify the contract via `contract.symbol`, `contract.expiration`,
-/// `contract.strike_thousandths`, `contract.is_call`. The wire-internal numeric id the
-/// FPSS server assigns is no longer surfaced on data events; downstream code
-/// that needs an id-keyed map builds it from the
-/// [`StreamControl::ContractAssigned`] event stream.
+/// `contract.strike_thousandths`, `contract.is_call`. Each variant also
+/// carries the server-assigned `contract_id` (the raw wire registry key) as a
+/// read-only join / index key; it is NOT contract identity (see the field
+/// docs) and matches the id on the corresponding
+/// [`StreamControl::ContractAssigned`] event.
 ///
 /// The I/O thread populates an internal `contract_id -> Arc<Contract>` cache
 /// on [`StreamControl::ContractAssigned`] so each decoded event only pays a
@@ -38,9 +39,11 @@ use super::protocol::Contract;
 /// the `__pending:` prefix (e.g. `"__pending:42"`). Production
 /// callbacks should NOT parse this prefix — it is a diagnostic payload
 /// that the WS bridge surfaces as `unresolved_contract_id` for
-/// operator visibility. SDK consumers identify contracts by
-/// `(symbol, expiration, right, strike)` per the removal of
-/// wire ids from public data events.
+/// operator visibility. The same id is available directly and
+/// type-safely as the event's `contract_id` field even in the
+/// unresolved case, so consumers never need the prefix. SDK consumers
+/// identify contracts by `(symbol, expiration, right, strike)`;
+/// `contract_id` is a join key, not identity.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum StreamData {
@@ -52,6 +55,14 @@ pub enum StreamData {
         /// when the server has not yet sent the matching
         /// `ContractAssigned` frame.
         contract: Arc<Contract>,
+        /// Stable numeric contract key assigned by the ThetaData registry
+        /// in first-ingest order. Constant for every tick of a given
+        /// contract and stable across reconnects within a session. A join
+        /// / index key — NOT contract identity: identity is (symbol,
+        /// expiration, strike, right). Opaque: it does not encode
+        /// expiration or strike. Resolve human-readable fields via the
+        /// contract or the `ContractAssigned` mapping.
+        contract_id: i32,
         /// Milliseconds since midnight Eastern Time when the quote was recorded.
         ms_of_day: i32,
         /// Number of contracts/shares resting at the bid.
@@ -83,6 +94,14 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
+        /// Stable numeric contract key assigned by the ThetaData registry
+        /// in first-ingest order. Constant for every tick of a given
+        /// contract and stable across reconnects within a session. A join
+        /// / index key — NOT contract identity: identity is (symbol,
+        /// expiration, strike, right). Opaque: it does not encode
+        /// expiration or strike. Resolve human-readable fields via the
+        /// contract or the `ContractAssigned` mapping.
+        contract_id: i32,
         /// Milliseconds since midnight Eastern Time when the trade printed.
         ms_of_day: i32,
         /// Exchange sequence number for ordering trades within the day.
@@ -108,6 +127,14 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
+        /// Stable numeric contract key assigned by the ThetaData registry
+        /// in first-ingest order. Constant for every tick of a given
+        /// contract and stable across reconnects within a session. A join
+        /// / index key — NOT contract identity: identity is (symbol,
+        /// expiration, strike, right). Opaque: it does not encode
+        /// expiration or strike. Resolve human-readable fields via the
+        /// contract or the `ContractAssigned` mapping.
+        contract_id: i32,
         /// Milliseconds since midnight Eastern Time when the open interest was recorded.
         ms_of_day: i32,
         /// Number of outstanding open contracts.
@@ -127,6 +154,14 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
+        /// Stable numeric contract key assigned by the ThetaData registry
+        /// in first-ingest order. Constant for every tick of a given
+        /// contract and stable across reconnects within a session. A join
+        /// / index key — NOT contract identity: identity is (symbol,
+        /// expiration, strike, right). Opaque: it does not encode
+        /// expiration or strike. Resolve human-readable fields via the
+        /// contract or the `ContractAssigned` mapping.
+        contract_id: i32,
         /// Milliseconds since midnight Eastern Time at the bar's open.
         ms_of_day: i32,
         /// Opening price of the bar.
@@ -161,6 +196,14 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
+        /// Stable numeric contract key assigned by the ThetaData registry
+        /// in first-ingest order. Constant for every tick of a given
+        /// contract and stable across reconnects within a session. A join
+        /// / index key — NOT contract identity: identity is (symbol,
+        /// expiration, strike, right). Opaque: it does not encode
+        /// expiration or strike. Resolve human-readable fields via the
+        /// contract or the `ContractAssigned` mapping.
+        contract_id: i32,
         /// Milliseconds since midnight Eastern Time when the market value was computed.
         ms_of_day: i32,
         /// Calculated market bid (dollars), nudged from the quote bid.
@@ -560,6 +603,7 @@ mod tests {
         let contract = Arc::new(Contract::stock("DISC"));
         let internal_data = FpssEventInternal::Data(StreamData::Quote {
             contract: Arc::clone(&contract),
+            contract_id: 0,
             ms_of_day: 0,
             bid_size: 0,
             bid_exchange: 0,
@@ -577,6 +621,7 @@ mod tests {
         });
         let public_data = StreamEvent::Data(StreamData::Quote {
             contract: Arc::clone(&contract),
+            contract_id: 0,
             ms_of_day: 0,
             bid_size: 0,
             bid_exchange: 0,
@@ -631,6 +676,7 @@ mod tests {
         let contract = Arc::new(Contract::stock("MSFT"));
         let internal = FpssEventInternal::Data(StreamData::Trade {
             contract: Arc::clone(&contract),
+            contract_id: 55,
             ms_of_day: 12_345,
             sequence: 7,
             condition: 0,
@@ -646,6 +692,7 @@ mod tests {
         match public {
             StreamEvent::Data(StreamData::Trade {
                 contract: pub_contract,
+                contract_id,
                 ms_of_day,
                 sequence,
                 price,
@@ -655,6 +702,9 @@ mod tests {
                     Arc::ptr_eq(pub_contract, &contract),
                     "reborrow must preserve the Arc<Contract> pointer identity",
                 );
+                // The wire contract_id must survive the layout-compat
+                // reborrow byte-for-byte alongside the other scalars.
+                assert_eq!(*contract_id, 55);
                 assert_eq!(*ms_of_day, 12_345);
                 assert_eq!(*sequence, 7);
                 // Decimal-ms price round-trips exactly through
@@ -745,6 +795,7 @@ mod tests {
         let contract = Arc::new(Contract::stock("AAPL"));
         let data_evt = StreamEvent::Data(StreamData::Trade {
             contract: Arc::clone(&contract),
+            contract_id: 0,
             ms_of_day: 0,
             sequence: 0,
             condition: 0,

--- a/thetadatadx-rs/src/fpss/ring.rs
+++ b/thetadatadx-rs/src/fpss/ring.rs
@@ -442,6 +442,7 @@ mod tests {
         producer.publish(|slot| {
             slot.event = FpssEventInternal::Data(StreamData::Quote {
                 contract: std::sync::Arc::clone(&ring_contract),
+                contract_id: 0,
                 ms_of_day: 34200000,
                 bid_size: 100,
                 bid_exchange: 1,
@@ -542,6 +543,7 @@ mod tests {
             producer.publish(|slot| {
                 slot.event = FpssEventInternal::Data(StreamData::Quote {
                     contract: contract_clone,
+                    contract_id: 0,
                     ms_of_day: 0,
                     bid_size: 0,
                     bid_exchange: 0,

--- a/thetadatadx-ts/__tests__/fpss_control_variants.test.mjs
+++ b/thetadatadx-ts/__tests__/fpss_control_variants.test.mjs
@@ -118,3 +118,25 @@ describe('StreamControl typed variants', () => {
     );
   });
 });
+
+describe('StreamData typed variants', () => {
+  // Every `kind = "data"` schema variant. napi-rs lowers the Rust
+  // `contract_id: i32` field to `contractId: number` on each interface.
+  const DATA_VARIANTS = ['Quote', 'Trade', 'OpenInterest', 'Ohlcvc', 'MarketValue'];
+
+  it('every data event interface carries a contractId: number join key', () => {
+    const dts = readFileSync(dtsPath, 'utf8');
+    for (const name of DATA_VARIANTS) {
+      const interfaceRe = new RegExp(`export interface ${name}\\s*\\{[^}]*\\}`, 's');
+      const match = dts.match(interfaceRe);
+      assert.ok(match, `interface ${name} missing from index.d.ts`);
+      // napi lowers `i32` to `number`; snake_case `contract_id` to camel
+      // `contractId`. The field is non-optional (present on every tick).
+      assert.match(
+        match[0],
+        /\bcontractId\s*:\s*number\b/,
+        `interface ${name} missing 'contractId: number' join key`
+      );
+    }
+  });
+});

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -3829,6 +3829,7 @@ export interface MarketOpen {
 /** Streaming MarketValue tick (wire code 25). A calculated theoretical market value derived from the real-time bid/ask — `market_bid` / `market_ask` are the quote bid/ask after a size-imbalance + spread-aware nudge, `market_price` is their integer midpoint. Per-contract only (no full-stream variant). */
 export interface MarketValue {
   contract: Contract
+  contractId: number
   msOfDay: number
   marketBid: number
   marketAsk: number
@@ -3898,6 +3899,7 @@ export declare function ohlcTickToArrowIpc(rows: Array<OhlcTick>): Buffer
 /** Streaming OHLCVC bar. */
 export interface Ohlcvc {
   contract: Contract
+  contractId: number
   msOfDay: number
   open: number
   high: number
@@ -3912,6 +3914,7 @@ export interface Ohlcvc {
 /** Streaming OpenInterest tick. */
 export interface OpenInterest {
   contract: Contract
+  contractId: number
   msOfDay: number
   openInterest: number
   date: number
@@ -5078,6 +5081,7 @@ export declare function priceTickToArrowIpc(rows: Array<PriceTick>): Buffer
 /** Streaming Quote tick. */
 export interface Quote {
   contract: Contract
+  contractId: number
   msOfDay: number
   bidSize: number
   bidExchange: number
@@ -5556,6 +5560,7 @@ export interface StreamEvent {
 /** Streaming Trade tick. */
 export interface Trade {
   contract: Contract
+  contractId: number
   msOfDay: number
   sequence: number
   condition: number

--- a/thetadatadx-ts/src/_generated/buffered_event.rs
+++ b/thetadatadx-ts/src/_generated/buffered_event.rs
@@ -27,6 +27,7 @@ pub(crate) enum BufferedEvent {
     /// Streaming MarketValue tick (wire code 25). A calculated theoretical market value derived from the real-time bid/ask — `market_bid` / `market_ask` are the quote bid/ask after a size-imbalance + spread-aware nudge, `market_price` is their integer midpoint. Per-contract only (no full-stream variant).
     MarketValue {
         contract: fpss::protocol::Contract,
+        contract_id: i32,
         ms_of_day: i32,
         market_bid: f64,
         market_ask: f64,
@@ -37,6 +38,7 @@ pub(crate) enum BufferedEvent {
     /// Streaming OHLCVC bar.
     Ohlcvc {
         contract: fpss::protocol::Contract,
+        contract_id: i32,
         ms_of_day: i32,
         open: f64,
         high: f64,
@@ -50,6 +52,7 @@ pub(crate) enum BufferedEvent {
     /// Streaming OpenInterest tick.
     OpenInterest {
         contract: fpss::protocol::Contract,
+        contract_id: i32,
         ms_of_day: i32,
         open_interest: i32,
         date: i32,
@@ -66,6 +69,7 @@ pub(crate) enum BufferedEvent {
     /// Streaming Quote tick.
     Quote {
         contract: fpss::protocol::Contract,
+        contract_id: i32,
         ms_of_day: i32,
         bid_size: i32,
         bid_exchange: i32,
@@ -107,6 +111,7 @@ pub(crate) enum BufferedEvent {
     /// Streaming Trade tick.
     Trade {
         contract: fpss::protocol::Contract,
+        contract_id: i32,
         ms_of_day: i32,
         sequence: i32,
         condition: i32,
@@ -130,6 +135,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
         fpss::StreamEvent::Data(data) => match data {
             fpss::StreamData::MarketValue {
                 contract,
+                contract_id,
                 ms_of_day,
                 market_bid,
                 market_ask,
@@ -139,6 +145,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
                 ..
             } => BufferedEvent::MarketValue {
                 contract: (**contract).clone(),
+                contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
                 market_bid: *market_bid,
                 market_ask: *market_ask,
@@ -148,6 +155,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
             },
             fpss::StreamData::Ohlcvc {
                 contract,
+                contract_id,
                 ms_of_day,
                 open,
                 high,
@@ -160,6 +168,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
                 ..
             } => BufferedEvent::Ohlcvc {
                 contract: (**contract).clone(),
+                contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
                 open: *open,
                 high: *high,
@@ -172,6 +181,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
             },
             fpss::StreamData::OpenInterest {
                 contract,
+                contract_id,
                 ms_of_day,
                 open_interest,
                 date,
@@ -179,6 +189,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
                 ..
             } => BufferedEvent::OpenInterest {
                 contract: (**contract).clone(),
+                contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
                 open_interest: *open_interest,
                 date: *date,
@@ -186,6 +197,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
             },
             fpss::StreamData::Quote {
                 contract,
+                contract_id,
                 ms_of_day,
                 bid_size,
                 bid_exchange,
@@ -200,6 +212,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
                 ..
             } => BufferedEvent::Quote {
                 contract: (**contract).clone(),
+                contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
                 bid_size: *bid_size,
                 bid_exchange: *bid_exchange,
@@ -214,6 +227,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
             },
             fpss::StreamData::Trade {
                 contract,
+                contract_id,
                 ms_of_day,
                 sequence,
                 condition,
@@ -225,6 +239,7 @@ pub(crate) fn fpss_event_to_buffered(event: &fpss::StreamEvent) -> BufferedEvent
                 ..
             } => BufferedEvent::Trade {
                 contract: (**contract).clone(),
+                contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
                 sequence: *sequence,
                 condition: *condition,

--- a/thetadatadx-ts/src/_generated/fpss_event_classes.rs
+++ b/thetadatadx-ts/src/_generated/fpss_event_classes.rs
@@ -35,6 +35,7 @@ pub struct Contract {
 #[derive(Clone)]
 pub struct MarketValue {
     pub contract: Contract,
+    pub contract_id: i32,
     pub ms_of_day: i32,
     pub market_bid: f64,
     pub market_ask: f64,
@@ -49,6 +50,7 @@ pub struct MarketValue {
 #[derive(Clone)]
 pub struct Ohlcvc {
     pub contract: Contract,
+    pub contract_id: i32,
     pub ms_of_day: i32,
     pub open: f64,
     pub high: f64,
@@ -66,6 +68,7 @@ pub struct Ohlcvc {
 #[derive(Clone)]
 pub struct OpenInterest {
     pub contract: Contract,
+    pub contract_id: i32,
     pub ms_of_day: i32,
     pub open_interest: i32,
     pub date: i32,
@@ -78,6 +81,7 @@ pub struct OpenInterest {
 #[derive(Clone)]
 pub struct Quote {
     pub contract: Contract,
+    pub contract_id: i32,
     pub ms_of_day: i32,
     pub bid_size: i32,
     pub bid_exchange: i32,
@@ -97,6 +101,7 @@ pub struct Quote {
 #[derive(Clone)]
 pub struct Trade {
     pub contract: Contract,
+    pub contract_id: i32,
     pub ms_of_day: i32,
     pub sequence: i32,
     pub condition: i32,
@@ -314,6 +319,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
     match event {
         BufferedEvent::MarketValue {
             contract,
+            contract_id,
             ms_of_day,
             market_bid,
             market_ask,
@@ -331,6 +337,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
                     strike: contract.strike_dollars(),
                     strike_thousandths: contract.strike_thousandths,
                 },
+                contract_id,
                 ms_of_day,
                 market_bid,
                 market_ask,
@@ -341,6 +348,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
         }
         BufferedEvent::Ohlcvc {
             contract,
+            contract_id,
             ms_of_day,
             open,
             high,
@@ -361,6 +369,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
                     strike: contract.strike_dollars(),
                     strike_thousandths: contract.strike_thousandths,
                 },
+                contract_id,
                 ms_of_day,
                 open,
                 high,
@@ -374,6 +383,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
         }
         BufferedEvent::OpenInterest {
             contract,
+            contract_id,
             ms_of_day,
             open_interest,
             date,
@@ -389,6 +399,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
                     strike: contract.strike_dollars(),
                     strike_thousandths: contract.strike_thousandths,
                 },
+                contract_id,
                 ms_of_day,
                 open_interest,
                 date,
@@ -397,6 +408,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
         }
         BufferedEvent::Quote {
             contract,
+            contract_id,
             ms_of_day,
             bid_size,
             bid_exchange,
@@ -419,6 +431,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
                     strike: contract.strike_dollars(),
                     strike_thousandths: contract.strike_thousandths,
                 },
+                contract_id,
                 ms_of_day,
                 bid_size,
                 bid_exchange,
@@ -434,6 +447,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
         }
         BufferedEvent::Trade {
             contract,
+            contract_id,
             ms_of_day,
             sequence,
             condition,
@@ -453,6 +467,7 @@ pub(crate) fn buffered_event_to_typed(event: BufferedEvent) -> StreamEvent {
                     strike: contract.strike_dollars(),
                     strike_thousandths: contract.strike_thousandths,
                 },
+                contract_id,
                 ms_of_day,
                 sequence,
                 condition,

--- a/thetadatadx-ts/src/bench_streaming.rs
+++ b/thetadatadx-ts/src/bench_streaming.rs
@@ -53,6 +53,7 @@ use crate::{buffered_event_to_typed, fpss_event_to_buffered};
 fn make_event(contract: &Arc<Contract>, idx: u64) -> CoreStreamEvent {
     fpss::StreamEvent::Data(StreamData::Trade {
         contract: Arc::clone(contract),
+        contract_id: idx as i32,
         ms_of_day: (idx % 86_400_000) as i32,
         sequence: idx as i32,
         condition: 0,

--- a/tools/server/src/ws/contract_map.rs
+++ b/tools/server/src/ws/contract_map.rs
@@ -34,6 +34,7 @@ mod tests {
     fn make_quote(contract: Arc<Contract>) -> StreamEvent {
         StreamEvent::Data(StreamData::Quote {
             contract,
+            contract_id: 0,
             ms_of_day: 0,
             bid_size: 0,
             bid_exchange: 0,

--- a/tools/server/src/ws/format.rs
+++ b/tools/server/src/ws/format.rs
@@ -104,10 +104,10 @@ pub(super) fn fpss_event_to_ws_json(
                     // exactly: `ms_of_day, sequence, size, condition,
                     // price, exchange, date`. The SDK-only extras carried
                     // on the event but omitted from the wire frame are
-                    // just `contract` (the WS envelope identifies the
-                    // contract separately) and `received_at_ns`, so a
-                    // strict terminal WS client sees only the columns it
-                    // parses.
+                    // `contract` and `contract_id` (the WS envelope
+                    // identifies the contract separately) and
+                    // `received_at_ns`, so a strict terminal WS client
+                    // sees only the columns it parses.
                     sonic_rs::json!({
                         "ms_of_day": ms_of_day,
                         "sequence": sequence,
@@ -346,6 +346,7 @@ mod tests {
     fn make_quote(contract: Arc<Contract>) -> StreamEvent {
         StreamEvent::Data(StreamData::Quote {
             contract,
+            contract_id: 0,
             ms_of_day: 0,
             bid_size: 0,
             bid_exchange: 0,
@@ -363,6 +364,7 @@ mod tests {
     fn make_trade(contract: Arc<Contract>) -> StreamEvent {
         StreamEvent::Data(StreamData::Trade {
             contract,
+            contract_id: 0,
             ms_of_day: 1,
             sequence: 2,
             condition: 7,
@@ -377,6 +379,7 @@ mod tests {
     fn make_market_value(contract: Arc<Contract>) -> StreamEvent {
         StreamEvent::Data(StreamData::MarketValue {
             contract,
+            contract_id: 0,
             ms_of_day: 1,
             market_bid: 2.5,
             market_ask: 3.5,
@@ -700,6 +703,7 @@ mod tests {
         // OpenInterest tick -> no OPEN_INTEREST frame.
         let oi = StreamEvent::Data(StreamData::OpenInterest {
             contract: Arc::new(Contract::option_raw("SPY", 20_260_417, true, 550_000)),
+            contract_id: 0,
             ms_of_day: 1,
             open_interest: 123,
             date: 20_260_417,


### PR DESCRIPTION
Surfaces the FPSS `contract_id` as a read-only `contract_id: i32` field on every streaming data event (Quote, Trade, OpenInterest, Ohlcvc, MarketValue), across all bindings. It is the server-assigned registry key the wire carries as field 0 of every tick — a stable numeric join key, empirically identical across reconnects.

## What

- `contract_id: i32` added to each data event in the `fpss_event_schema.toml` codegen SSOT (version 9 -> 10), propagated to the Python / TypeScript / C++ / FFI event structs, the BufferedEvent bridge, and the `.pyi` / `.d.ts` / header stubs.
- Populated in the decoder from the raw wire id, so it is correct even before the matching `ContractAssigned` resolves the symbol (the unresolved-sentinel case).
- Added to the Arrow columnar streaming schema (`batch_schema.rs`) as a non-null `Int32` column alongside the contract-identity columns.

## Not

- `contract_id` is not added to `Contract`: that type derives `Eq` / `Hash` for the symbolic identity `(symbol, expiration, strike, right)` and is what callers build for subscriptions, so adding the id would pollute equality. Identity stays symbolic; the id rides the event as a join key.
- The terminal-parity WS bridge omits it (an SDK-only extra, not part of the terminal's frame), the same as `received_at_ns`.

## Semantics

`contract_id` is ThetaData's contract-registry key, assigned in first-ingest order (the oldest mega-ETFs hold the lowest ids). It is constant for every tick of a contract and stable across reconnects within a session. It is a join / index key, not identity, and is opaque — it does not encode expiration or strike. Resolve human-readable fields via the contract or the `ContractAssigned` mapping.

## Verification

Core + ffi + cpp build; 975 lib tests plus ffi 91, cpp Catch2 70, py 59, server 184 pass; `clippy --workspace --all-targets --locked` clean; rustfmt clean; codegen drift, cross-binding parity, and C-ABI completeness clean.
