### PR TITLE
chore(release): 13.0.0-rc.11

### DIFF
--- a/.github/release-notes/v13.0.0-rc.11.md
+++ b/.github/release-notes/v13.0.0-rc.11.md
@@ -1,0 +1,22 @@
+## ThetaDataDx 13.0.0-rc.11
+
+This release candidate simplifies the FPSS streaming layer — removing a configuration knob and internal machinery with no counterpart on the wire — trims some dead API, and fixes a C++ callback lifetime bug. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.11/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- **Simpler streaming configuration:** the configurable ring wait-strategy and its tuning knobs (`wait_strategy`, `wait_spin_iters`, `wait_yield_iters`, `wait_park_us`) are removed; the streaming consumer now runs a single fixed low-latency wait. The frame reader and delta decoder also shed internal machinery, with no other change to the public streaming API.
+- **Leaner event shape:** streaming Trade and OHLCVC events now carry only the fields the wire provides.
+- **C++ callback lifetime fix:** a use-after-free in the callback-drain path is fixed — the retired callback is released after the in-flight invocation returns.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.11"`
+- MCP: `npx -y thetadatadx-mcp`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. If you hit a snag, open an issue and we will sort it out.

--- a/.github/release-notes/v13.0.0-rc.11.md
+++ b/.github/release-notes/v13.0.0-rc.11.md
@@ -6,7 +6,7 @@ This release candidate simplifies the FPSS streaming layer — removing a config
 
 - **Simpler streaming configuration:** the configurable ring wait-strategy and its tuning knobs (`wait_strategy`, `wait_spin_iters`, `wait_yield_iters`, `wait_park_us`) are removed; the streaming consumer now runs a single fixed low-latency wait. The frame reader and delta decoder also shed internal machinery, with no other change to the public streaming API.
 - **Leaner event shape:** streaming Trade and OHLCVC events now carry only the fields the wire provides.
-- **C++ callback lifetime fix:** a use-after-free in the callback-drain path is fixed — the retired callback is released after the in-flight invocation returns.
+- **C++ callback lifetime fix:** a use-after-free in the callback-drain path is fixed — a retired callback is dropped only after the consumer thread confirms quiescence, and if the quiescence cap elapses it is intentionally leaked (a bounded one-time leak) rather than destroyed under a possibly-live invocation.
 
 ### Installing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **C++ callback use-after-free:** when the drain cap elapses without a drain, the retired callback storage is now released after the in-flight invocation returns instead of being destroyed under it (#1056).
+- **C++ callback use-after-free:** a retired callback is now dropped only after the consumer thread confirms quiescence; if the quiescence cap elapses first, the node is intentionally leaked (a bounded one-time leak) rather than destroyed while an invocation may still be in flight (#1056).
 
 ## [13.0.0-rc.10] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.11] - 2026-07-01
+
+### Removed
+
+- The configurable ring wait-strategy and its tuning knobs (`wait_strategy`, `wait_spin_iters`, `wait_yield_iters`, `wait_park_us`) across every binding. The streaming consumer now runs a single fixed low-latency wait (#1057).
+- The `data_watchdog_ms` reconnect timer, which duplicated the read timeout under the default configuration (#1055).
+- The unused `flatfile_value_arrow_type` helper and several unused `DirectConfig` builder methods (#1058).
+
+### Changed
+
+- Streaming Trade and OHLCVC events carry only the fields the wire provides; the previously-synthesized extended-trade fields are removed (#1042).
+- Internal streaming simplifications with no public API or wire-behavior change: the FPSS frame reader lost its mid-frame drain-yield and per-frame deadline handling, and the delta decoder lost several unused runtime guards (#1055, #1059).
+
+### Fixed
+
+- **C++ callback use-after-free:** when the drain cap elapses without a drain, the retired callback storage is now released after the in-flight invocation returns instead of being destroyed under it (#1056).
+
 ## [13.0.0-rc.10] - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.10"
+thetadatadx = "13.0.0-rc.11"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.10"
+thetadatadx = "13.0.0-rc.11"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **C++ callback use-after-free:** when the drain cap elapses without a drain, the retired callback storage is now released after the in-flight invocation returns instead of being destroyed under it (#1056).
+- **C++ callback use-after-free:** a retired callback is now dropped only after the consumer thread confirms quiescence; if the quiescence cap elapses first, the node is intentionally leaked (a bounded one-time leak) rather than destroyed while an invocation may still be in flight (#1056).
 
 ## [13.0.0-rc.10] - 2026-06-30
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.11] - 2026-07-01
+
+### Removed
+
+- The configurable ring wait-strategy and its tuning knobs (`wait_strategy`, `wait_spin_iters`, `wait_yield_iters`, `wait_park_us`) across every binding. The streaming consumer now runs a single fixed low-latency wait (#1057).
+- The `data_watchdog_ms` reconnect timer, which duplicated the read timeout under the default configuration (#1055).
+- The unused `flatfile_value_arrow_type` helper and several unused `DirectConfig` builder methods (#1058).
+
+### Changed
+
+- Streaming Trade and OHLCVC events carry only the fields the wire provides; the previously-synthesized extended-trade fields are removed (#1042).
+- Internal streaming simplifications with no public API or wire-behavior change: the FPSS frame reader lost its mid-frame drain-yield and per-frame deadline handling, and the delta decoder lost several unused runtime guards (#1055, #1059).
+
+### Fixed
+
+- **C++ callback use-after-free:** when the drain cap elapses without a drain, the retired callback storage is now released after the in-flight invocation returns instead of being destroyed under it (#1056).
+
 ## [13.0.0-rc.10] - 2026-06-30
 
 ### Added

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.10
+  version: 13.0.0-rc.11
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.10"
+thetadatadx = "13.0.0-rc.11"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.10", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.11", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package-lock.json
+++ b/thetadatadx-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "13.0.0-rc.10",
+      "version": "13.0.0-rc.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
@@ -18,9 +18,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "13.0.0-rc.10",
-        "thetadatadx-linux-x64-gnu": "13.0.0-rc.10",
-        "thetadatadx-win32-x64-msvc": "13.0.0-rc.10"
+        "thetadatadx-darwin-arm64": "13.0.0-rc.11",
+        "thetadatadx-linux-x64-gnu": "13.0.0-rc.11",
+        "thetadatadx-win32-x64-msvc": "13.0.0-rc.11"
       }
     },
     "node_modules/@emnapi/core": {

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.10",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.10",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.10"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.11",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.11",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.11"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.10",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.10",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.10",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.10",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.10"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.11",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.11",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.11",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.11",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.11"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.10",
+  "version": "13.0.0-rc.11",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.10"
+version = "13.0.0-rc.11"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Release 13.0.0-rc.11.

Bumps every version pin in lockstep (via `scripts/release/bump_version.py` plus the README / OpenAPI / getting-started pins the script does not cover) and adds the CHANGELOG + `.github/release-notes/v13.0.0-rc.11.md`.

## Contents since rc.10

- **Removed** — the configurable ring wait-strategy and its tuning knobs (#1057); the redundant `data_watchdog_ms` reconnect timer (#1055); the unused `flatfile_value_arrow_type` helper and several unused `DirectConfig` methods (#1058).
- **Changed** — streaming Trade and OHLCVC events carry only wire-provided fields (#1042); internal FPSS frame-reader / delta-decoder simplifications with no public API or wire-behavior change (#1055, #1059).
- **Fixed** — the C++ callback use-after-free on the drain-cap path (#1056).

## Verification

`check_version_sync.py` clean; `check_docs_consistency.py` clean (both changelogs byte-identical, release notes present).

Tag `v13.0.0-rc.11` is cut only after this merges.
