### PR TITLE
fix(fpss): C++ teardown lifetime, wrong-width row handling, and login read-timeout bound

### DIFF
--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -597,6 +597,12 @@ inline void reclaim_after_drain(IsDrained is_drained, Release release) {
                 new Release(std::move(release));
                 return;
             }
+            // Sleep at the bottom of the loop so the reclaimer can never
+            // hot-spin regardless of what `is_drained` returns — an
+            // `is_drained` that reports "not drained" without itself blocking
+            // (e.g. an empty drain barrier that returns immediately) would
+            // otherwise busy-loop this thread until the cap.
+            std::this_thread::sleep_for(kReclaimPollStep);
         }
         // Confirmed quiescence: the consumer has finished its last
         // dereference of the retired node, so dropping it now cannot be
@@ -1003,7 +1009,13 @@ public:
                 // Block until the consumer thread quiesces. The 5 s
                 // budget matches `thetadatadx_streaming_free`'s internal barrier.
                 int drained = thetadatadx_streaming_await_drain(handle_.get(), 5000);
-                if (drained == 0) {
+                // Only rescue when a callback was actually installed: `callback_`
+                // is non-null only after a successful `set_callback`, the sole
+                // path that starts the consumer thread and wires a live `ctx`.
+                // With no callback there is nothing to outrun and `await_drain`
+                // returns 0 on the empty barrier, so fall through to the
+                // synchronous `callback_.reset()` below.
+                if (drained == 0 && callback_) {
                     // Drain barrier timed out: the consumer may still be
                     // firing through `callback_`'s storage. Hand the retired
                     // handle and storage to a reclaimer that drops them only

--- a/thetadatadx-cpp/src/thetadatadx.cpp
+++ b/thetadatadx-cpp/src/thetadatadx.cpp
@@ -70,7 +70,14 @@ StreamingClient::~StreamingClient() {
     if (handle_) {
         thetadatadx_streaming_shutdown(handle_.get());
         int drained = thetadatadx_streaming_await_drain(handle_.get(), 5000);
-        if (drained == 0) {
+        // Only rescue the retired session when a callback was actually
+        // installed: `callback_` is non-null only after a successful
+        // `set_callback`, which is the sole path that starts the consumer
+        // thread and wires a live `ctx`. With no callback there is no consumer
+        // to outrun, `await_drain` returns 0 on an empty barrier, and the
+        // members can destruct synchronously — `thetadatadx_streaming_free`
+        // skips its drain wait on the no-callback path.
+        if (drained == 0 && callback_) {
             const ThetaDataDxStreamHandle* raw = handle_.get();
             detail::reclaim_after_drain(
                 [raw]() {

--- a/thetadatadx-cpp/tests/fpss.cpp
+++ b/thetadatadx-cpp/tests/fpss.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -66,6 +67,57 @@ TEST_CASE("StreamingClient binds the observability surface",
     STATIC_REQUIRE(std::is_same_v<
         decltype(std::declval<const SC&>().active_full_subscriptions()),
         std::vector<thetadatadx::FullSubscription>>);
+}
+
+TEST_CASE("StreamingClient teardown without a callback completes promptly",
+          "[fpss][offline]") {
+    // `thetadatadx_streaming_connect` only allocates a handle and stashes the
+    // connection params; the FPSS TLS connection + consumer thread are created
+    // lazily at `set_callback`. So a StreamingClient can be constructed offline
+    // and, with no callback ever installed, has no consumer thread to drain.
+    // Teardown must NOT enter the retired-session reclaimer (whose poll runs
+    // for up to kReclaimQuiescenceCap = 300 s): with `callback_` null the
+    // members destruct synchronously. Regression guard for a teardown that
+    // hot-spun ~300 s and then leaked the credential-bearing handle.
+    auto creds = thetadatadx::Credentials::from_api_key("offline-test-key");
+    auto config = thetadatadx::Config::production();
+
+    const auto start = std::chrono::steady_clock::now();
+    {
+        thetadatadx::StreamingClient client(creds, config);
+        // Intentionally never call set_callback: no consumer thread, no ctx.
+    } // destructor runs here
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    // Well under a second; the pre-fix hot-spin path took ~300 s.
+    REQUIRE(elapsed < std::chrono::seconds(1));
+}
+
+TEST_CASE("StreamingClient teardown after a throwing set_callback completes promptly",
+          "[fpss][offline]") {
+    // Offline, `set_callback` opens the FPSS connection, fails to reach the
+    // server, and throws — leaving `callback_` null because the adopt happens
+    // only after the FFI reports success. Teardown of such a client must also
+    // skip the reclaimer (nothing was ever wired) and destruct synchronously.
+    auto creds = thetadatadx::Credentials::from_api_key("offline-test-key");
+    auto config = thetadatadx::Config::production();
+
+    // Optional so the destructor can be timed in isolation: the connect inside
+    // set_callback may take a bounded moment to fail offline, and only the
+    // teardown must be fast. Reset() below runs the destructor under the clock.
+    auto client = std::make_optional<thetadatadx::StreamingClient>(creds, config);
+    // No server reachable offline, so the connect inside set_callback must fail
+    // and throw; the callback is NOT adopted on the throw path (callback_ stays
+    // null).
+    REQUIRE_THROWS(client->set_callback(
+        [](const thetadatadx::StreamEvent& /*event*/) {}));
+
+    const auto start = std::chrono::steady_clock::now();
+    client.reset(); // destructor runs here, with callback_ still null
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    // Well under a second; the pre-fix hot-spin path took ~300 s.
+    REQUIRE(elapsed < std::chrono::seconds(1));
 }
 
 TEST_CASE("StreamingClient registers a callback and receives at least one event",

--- a/thetadatadx-rs/src/fpss/decode.rs
+++ b/thetadatadx-rs/src/fpss/decode.rs
@@ -413,32 +413,14 @@ pub fn decode_frame(
         StreamMsgType::Trade => {
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, TRADE_FIELDS, &mut buf) {
-                Some((contract_id, n_data)) => {
+                Some((contract_id, _n)) => {
                     warn_unknown_contract(contract_id, "trade", delta_state, local_contracts);
 
-                    // The FPSS stream trade is the 8-field layout, the only
-                    // width with a known cell map here. (The 16-field
+                    // `decode_tick` rejects any row whose width is not exactly
+                    // TRADE_FIELDS (the only stream-trade layout; the 16-field
                     // "extended" trade is an MDDS gRPC shape on a different
-                    // protocol and never reaches this decoder.) Any other
-                    // width would force the 8-field index set onto a payload
-                    // that does not match it, reading never-populated slots as
-                    // price / price_type / date and silently emitting a wrong
-                    // tick. Worse, the width is cached per contract on the
-                    // first absolute row, so a single off-spec width would
-                    // mis-decode every later delta row for that contract.
-                    // Treat it as a decode failure and surface `Unparseable`,
-                    // mirroring the invalid-price_type handling.
-                    if n_data != TRADE_FIELDS {
-                        FPSS_TRADE_DECODE_FAILURES.increment(1);
-                        tracing::warn!(
-                            contract_id,
-                            n_data,
-                            expected = TRADE_FIELDS,
-                            "unexpected trade field count; marking unparseable"
-                        );
-                        return Some(FpssEventInternal::Unparseable);
-                    }
-
+                    // protocol and never reaches this decoder), so a `Some`
+                    // here is guaranteed to be the 8-field layout.
                     // 8-field: [ms_of_day, sequence, size, condition, price, exchange, price_type, date]
                     let (price_idx, pt_idx) = (4, 6);
                     let pt = buf[pt_idx];
@@ -917,6 +899,66 @@ mod tests {
         assert!(
             matches!(primary, Some(FpssEventInternal::Unparseable)),
             "an off-spec trade width must decode as Unparseable, got {primary:?}"
+        );
+    }
+
+    /// A complete-but-narrow quote row (fewer than QUOTE_FIELDS data fields)
+    /// must reject as `Unparseable`, not emit a tick whose trailing fields
+    /// (date, price_type index) are silently read from never-populated slots.
+    /// The Quote arm reads fixed indices, so without a width guard a short row
+    /// would surface a zero-filled `date`/wrong price_type as real data.
+    #[test]
+    fn decode_frame_narrow_quote_width_is_unparseable_not_silently_wrong() {
+        // 9 data fields (+ contract_id = 10 FIT fields); QUOTE_FIELDS is 11.
+        let fit_payload = encode_fit_row(&[400, 34200000, 10, 5, 15025, 0, 20, 6, 15030, 0]);
+
+        let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
+        local_contracts.insert(400, Arc::new(Contract::stock("AAPL")));
+
+        let authenticated = AtomicBool::new(true);
+        let shutdown = AtomicBool::new(false);
+        let mut delta_state = DeltaState::new();
+        let primary = decode_frame(
+            StreamMsgType::Quote,
+            &fit_payload,
+            &authenticated,
+            &mut local_contracts,
+            &shutdown,
+            &mut delta_state,
+        );
+
+        assert!(
+            matches!(primary, Some(FpssEventInternal::Unparseable)),
+            "a narrow quote width must decode as Unparseable, got {primary:?}"
+        );
+    }
+
+    /// A complete-but-narrow OHLCVC row (fewer than OHLCVC_FIELDS data fields)
+    /// must reject as `Unparseable` rather than emit a bar whose high/low/close
+    /// or trailing volume/count/date come from unpopulated slots.
+    #[test]
+    fn decode_frame_narrow_ohlcvc_width_is_unparseable_not_silently_wrong() {
+        // 7 data fields (+ contract_id = 8 FIT fields); OHLCVC_FIELDS is 9.
+        let fit_payload = encode_fit_row(&[500, 34200000, 15000, 15100, 14900, 15050, 1000, 6]);
+
+        let mut local_contracts: HashMap<i32, Arc<Contract>> = HashMap::new();
+        local_contracts.insert(500, Arc::new(Contract::stock("AAPL")));
+
+        let authenticated = AtomicBool::new(true);
+        let shutdown = AtomicBool::new(false);
+        let mut delta_state = DeltaState::new();
+        let primary = decode_frame(
+            StreamMsgType::Ohlcvc,
+            &fit_payload,
+            &authenticated,
+            &mut local_contracts,
+            &shutdown,
+            &mut delta_state,
+        );
+
+        assert!(
+            matches!(primary, Some(FpssEventInternal::Unparseable)),
+            "a narrow ohlcvc width must decode as Unparseable, got {primary:?}"
         );
     }
 

--- a/thetadatadx-rs/src/fpss/delta.rs
+++ b/thetadatadx-rs/src/fpss/delta.rs
@@ -219,6 +219,19 @@ impl DeltaState {
         // wrong-width row leaves no state behind so a later correct absolute
         // row can re-seed cleanly.
         if is_absolute && tick_n != expected_fields {
+            // Wrong-width absolute row: reject before it seeds `prev` /
+            // `field_counts` (a wrong cached width would mis-decode every later
+            // delta row for this contract), mirroring the terminal, which
+            // requires each stream tick's exact length. `msg_code` identifies
+            // the shape; the caller surfaces `Unparseable` and bumps the
+            // per-shape decode-failure counter.
+            tracing::warn!(
+                msg_code,
+                contract_id,
+                got = tick_n,
+                expected = expected_fields,
+                "unexpected field count; marking unparseable"
+            );
             return None;
         }
 

--- a/thetadatadx-rs/src/fpss/delta.rs
+++ b/thetadatadx-rs/src/fpss/delta.rs
@@ -206,15 +206,19 @@ impl DeltaState {
         let is_absolute = !self.prev.contains_key(&key);
 
         // An absolute row defines the cached field width and seeds the delta
-        // baseline. It must not declare MORE fields than the tick shape holds:
-        // a row wider than `expected_fields` would have its trailing fields
-        // silently dropped (the scratch buffer is `total_fields` wide) and the
-        // cached width would over-report, so reject it as a decode failure.
-        // A truncated row is already rejected above via `row_complete`. A
-        // complete row with fewer fields is a legitimately narrower wire
-        // layout (e.g. the simple-format trade); the per-tick consumer
-        // validates that the narrower width is one it knows how to read.
-        if is_absolute && tick_n > expected_fields {
+        // baseline, so it must carry EXACTLY the tick shape's field count.
+        // Each stream shape has a single valid width (the terminal validates
+        // every stream tick's exact length), so a width mismatch is a decode
+        // failure regardless of direction: a wider row would have its trailing
+        // fields silently dropped (the scratch buffer is `total_fields` wide)
+        // and over-report the cached width, while a complete-but-narrow row
+        // (e.g. a 7-field trade) would seed `prev`/`field_counts` at the wrong
+        // width and mis-decode every later delta row for that contract. A
+        // truncated row is already rejected above via `row_complete`. Rejecting
+        // here, BEFORE any `prev`/`field_counts` insert, guarantees a
+        // wrong-width row leaves no state behind so a later correct absolute
+        // row can re-seed cleanly.
+        if is_absolute && tick_n != expected_fields {
             return None;
         }
 
@@ -294,6 +298,51 @@ mod tests {
 
     // A representative non-trade message code; the value only keys the maps.
     const QUOTE_CODE: u8 = 2;
+    // A representative trade message code; the value only keys the maps.
+    const TRADE_CODE: u8 = 1;
+
+    /// A complete-but-NARROW first row (fewer data fields than the shape's
+    /// width) must be rejected and leave NO cached baseline or width, so a
+    /// subsequent correct-width absolute row for the SAME key re-seeds cleanly.
+    /// Before the width guard rejected narrow rows, a 7-field trade passed the
+    /// (wider-only) absolute guard, seeded `prev`/`field_counts` at width 7,
+    /// and every later 8-field row for that contract decoded as a width-7 delta
+    /// and was rejected forever until session `clear()` (issue #1047).
+    #[test]
+    fn narrow_first_row_does_not_poison_width_for_later_absolute() {
+        let mut state = DeltaState::new();
+        let cid = 7;
+
+        // 7 data fields (+ contract_id = 8 values); TRADE_FIELDS is 8.
+        let narrow = encode_row(&[cid, 34_200_000, 12_345, 50, 6, 5_500_000, 57, 6]);
+        let mut out: TickFields = [0; MAX_DATA_FIELDS];
+        assert!(
+            state
+                .decode_tick(TRADE_CODE, &narrow, TRADE_FIELDS, &mut out)
+                .is_none(),
+            "a narrow first row must decode to None"
+        );
+        assert_eq!(
+            state.state_sizes(),
+            (0, 0),
+            "a rejected narrow row must leave no prev/field_counts state behind"
+        );
+
+        // A well-formed 8-field absolute row for the SAME contract must now
+        // decode cleanly at the full width — proving the narrow row did not
+        // trap the key.
+        let good = encode_row(&[cid, 34_200_001, 12_346, 51, 6, 5_500_100, 57, 6, 20_250_428]);
+        let (contract_id, n_data) = state
+            .decode_tick(TRADE_CODE, &good, TRADE_FIELDS, &mut out)
+            .expect("a correct-width row must decode after a rejected narrow row");
+        assert_eq!(contract_id, cid);
+        assert_eq!(n_data, TRADE_FIELDS);
+        assert_eq!(out[0], 34_200_001, "field 0 decodes from the clean re-seed");
+        assert_eq!(
+            out[7], 20_250_428,
+            "trailing field 7 decodes, not zero-filled"
+        );
+    }
 
     #[test]
     fn complete_quote_row_decodes_to_correct_tick() {

--- a/thetadatadx-rs/src/fpss/io_loop/login.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/login.rs
@@ -7,7 +7,7 @@
 //! captured for replay onto the event bus once the Disruptor producer
 //! is live.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::tdbe::types::enums::{RemoveReason, StreamMsgType};
 
@@ -22,18 +22,6 @@ use super::super::protocol::parse_disconnect_reason;
 pub enum LoginResult {
     Success(String),
     Disconnected(RemoveReason),
-}
-
-/// Wall-clock budget for a single handshake, independent of the per-read
-/// socket timeout. A chatty peer that sends a control frame just before each
-/// read timeout would otherwise reset the per-read deadline forever; this
-/// caps the total time the reconnect thread can spend in one handshake.
-fn handshake_deadline(read_timeout: Duration) -> Instant {
-    // Generous relative to a single read so a legitimately slow but
-    // progressing handshake is never cut off, yet bounded so a chatty
-    // no-`Metadata` peer cannot wedge the reconnect thread.
-    let budget = (read_timeout.saturating_mul(5)).max(Duration::from_secs(15));
-    Instant::now() + budget
 }
 
 /// Wait for the server's login response (blocking).
@@ -58,14 +46,7 @@ pub fn wait_for_login(
     pending_control: &mut Vec<StreamControl>,
     read_timeout: Duration,
 ) -> Result<LoginResult, Error> {
-    let deadline = handshake_deadline(read_timeout);
-    wait_for_login_generic(
-        stream,
-        pending_control,
-        deadline,
-        read_timeout,
-        Instant::now,
-    )
+    wait_for_login_generic(stream, pending_control, read_timeout)
 }
 
 /// Read-generic variant of [`wait_for_login`] for unit-testable handshake
@@ -73,37 +54,24 @@ pub fn wait_for_login(
 /// point above and in-memory test harnesses can drive it against a
 /// buffer of pre-canned frames.
 ///
-/// `deadline` is a wall-clock backstop that bounds a peer which streams
-/// control frames without ever completing the handshake: the per-read socket
-/// timeout alone cannot, because each frame resets it. `now` injects the
-/// clock so tests can drive the deadline deterministically. It is checked
-/// between complete frames; a single frame's read is bounded by
-/// `stall_timeout` (the per-stall no-progress budget the reader enforces),
-/// so a peer that dribbles a partial frame and then goes silent is cut off
-/// by that stall timeout rather than held indefinitely.
-fn wait_for_login_generic<R, C>(
+/// Login is bounded solely by the socket read timeout, exactly like the
+/// terminal: a mute peer that sends nothing surfaces a pre-header read
+/// timeout (`WouldBlock` / `TimedOut`) which propagates as an error the
+/// caller reconnects on, and a peer that dribbles a partial frame then goes
+/// silent is cut off by the per-stall no-progress budget (`stall_timeout`).
+/// There is no wall-clock handshake cap.
+fn wait_for_login_generic<R>(
     stream: &mut R,
     pending_control: &mut Vec<StreamControl>,
-    deadline: Instant,
     stall_timeout: Duration,
-    mut now: C,
 ) -> Result<LoginResult, Error>
 where
     R: std::io::Read,
-    C: FnMut() -> Instant,
 {
     // Reused across frames. Each read consumes one complete frame bounded by
-    // the per-stall timeout; the wall-clock deadline is checked between frames.
+    // the per-stall / socket read timeout.
     let mut frame_buf: Vec<u8> = Vec::new();
     loop {
-        if now() >= deadline {
-            return Err(Error::Stream {
-                kind: crate::error::StreamErrorKind::Timeout,
-                message: "login handshake did not complete within the handshake deadline"
-                    .to_string(),
-            });
-        }
-
         let (code, payload_len) =
             match read_frame_into_with_stall_timeout(stream, &mut frame_buf, stall_timeout) {
                 Ok(Some(frame)) => frame,
@@ -192,20 +160,14 @@ mod tests {
         v
     }
 
-    /// Drive the handshake with a far-future deadline that never trips, for
-    /// the dispatch/ordering tests.
+    /// Drive the handshake with a generous per-stall timeout for the
+    /// dispatch/ordering tests (the in-memory cursors always have a complete
+    /// frame ready, so the timeout never trips).
     fn run_handshake<R: std::io::Read>(
         stream: &mut R,
         pending_control: &mut Vec<StreamControl>,
     ) -> Result<LoginResult, Error> {
-        let deadline = Instant::now() + Duration::from_secs(3_600);
-        wait_for_login_generic(
-            stream,
-            pending_control,
-            deadline,
-            Duration::from_secs(10),
-            Instant::now,
-        )
+        wait_for_login_generic(stream, pending_control, Duration::from_secs(10))
     }
 
     /// A CONNECTED frame arriving BEFORE METADATA must be captured in
@@ -413,48 +375,46 @@ mod tests {
         assert!(matches!(pending[3], StreamControl::Restart));
     }
 
-    /// A peer that streams control frames without ever sending METADATA must
-    /// not wedge the handshake. With the per-read socket timeout reset by
-    /// every frame, the wall-clock deadline is the only backstop: once it
-    /// passes, the handshake returns a timeout instead of looping forever.
-    #[test]
-    fn wait_for_login_chatty_no_metadata_hits_deadline() {
-        // A long buffer of PING frames and no METADATA: read_frame always has
-        // a frame to return, so only the deadline can stop the loop.
-        let mut buf = Vec::new();
-        for _ in 0..1_000 {
-            buf.extend_from_slice(&wire_frame(StreamMsgType::Ping, &[0x00]));
+    /// Reader that models a mute peer: the socket read timeout (`SO_RCVTIMEO`)
+    /// fires before any byte arrives, so `read` returns `WouldBlock` / `TimedOut`
+    /// with zero bytes read.
+    struct MutePeer {
+        kind: std::io::ErrorKind,
+    }
+
+    impl std::io::Read for MutePeer {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(self.kind, "socket read timeout"))
         }
-        let mut cursor = std::io::Cursor::new(buf);
+    }
 
-        // A clock that jumps past the deadline after a few iterations,
-        // emulating wall-clock time advancing while the peer keeps talking.
-        let start = Instant::now();
-        let deadline = start + Duration::from_secs(10);
-        let mut ticks = 0u32;
-        let clock = move || {
-            ticks += 1;
-            if ticks > 3 {
-                deadline + Duration::from_secs(1)
-            } else {
-                start
+    /// A mute peer that never sends a login response must not wedge the
+    /// handshake: the socket read timeout fires pre-header and propagates as an
+    /// error the caller reconnects on. This is the terminal's only bound on a
+    /// silent peer — there is no separate wall-clock handshake cap. Both the
+    /// Linux/non-blocking (`WouldBlock`) and macOS/blocking (`TimedOut`)
+    /// spellings of `SO_RCVTIMEO` must terminate the handshake identically.
+    #[test]
+    fn wait_for_login_mute_peer_bounded_by_socket_read_timeout() {
+        for kind in [std::io::ErrorKind::WouldBlock, std::io::ErrorKind::TimedOut] {
+            let mut reader = MutePeer { kind };
+            let mut pending: Vec<StreamControl> = Vec::new();
+            let result = wait_for_login_generic(&mut reader, &mut pending, Duration::from_secs(10));
+            match result {
+                // A pre-header transient surfaces as `Error::Io`; the io_loop
+                // reconnect path treats any login `Err` as a failed attempt.
+                Err(Error::Io(_)) => {}
+                Ok(_) => panic!(
+                    "a mute peer that sends no login response must error, not succeed ({kind:?})"
+                ),
+                Err(other) => panic!(
+                    "a mute peer must surface the socket read timeout as Error::Io, got {other:?}"
+                ),
             }
-        };
-
-        let mut pending: Vec<StreamControl> = Vec::new();
-        let result = wait_for_login_generic(
-            &mut cursor,
-            &mut pending,
-            deadline,
-            Duration::from_secs(10),
-            clock,
-        );
-        match result {
-            Err(Error::Stream { kind, .. }) => {
-                assert!(matches!(kind, crate::error::StreamErrorKind::Timeout));
-            }
-            Err(other) => panic!("expected an Fpss timeout error, got {other:?}"),
-            Ok(_) => panic!("a chatty no-METADATA peer must trip the handshake deadline"),
+            assert!(
+                pending.is_empty(),
+                "a mute peer produced no control frames to buffer"
+            );
         }
     }
 
@@ -502,17 +462,10 @@ mod tests {
         };
 
         let mut pending: Vec<StreamControl> = Vec::new();
-        let result = wait_for_login_generic(
-            &mut reader,
-            &mut pending,
-            // Far-future wall-clock deadline: the per-stall timeout is what
-            // must end the handshake here.
-            Instant::now() + Duration::from_secs(3_600),
-            // Short per-stall budget: the permanent mid-payload silence trips
-            // it quickly.
-            Duration::from_millis(30),
-            Instant::now,
-        );
+        // Short per-stall budget: the permanent mid-payload silence trips it
+        // quickly. This per-stall no-progress timeout is the terminal's only
+        // mid-frame bound.
+        let result = wait_for_login_generic(&mut reader, &mut pending, Duration::from_millis(30));
         match result {
             Err(Error::Stream { kind, message }) => {
                 assert!(


### PR DESCRIPTION
Three fixes in the FPSS streaming layer and its C++ binding.

## C++ standalone `StreamingClient` teardown

Destroying (or move-assigning) a `StreamingClient` with no callback installed — never calling `set_callback`, or `set_callback` throwing — leaves an empty drain barrier, so `thetadatadx_streaming_await_drain` returns 0. The C++ destructor / `operator=` read that as a wedged callback and entered the deferred-reclaim path, whose poll loop had no sleep of its own and relied on `await_drain(50ms)` to pace; on the empty barrier that returns immediately, so it spun a CPU core for the full quiescence cap and then leaked the handle. Gate the reclaim on an installed callback (no callback → no consumer thread → synchronous teardown) and give the reclaim loop its own sleep. Teardown now returns in microseconds. Adds Catch2 coverage for the no-callback and throwing-`set_callback` teardown paths.

## Wrong-width absolute rows (closes #1047)

The delta decoder caches each contract's field width from its first (absolute) row. The absolute-row guard only rejected rows *wider* than the tick shape, so a complete-but-narrow row (e.g. a 7-field trade) seeded the cache at the wrong width; every later row for that contract then decoded at that width and was rejected, trapping the contract until the next session reset. Reject any absolute row whose width is not the shape's exact field count, before it seeds the cache, so a later correct row re-seeds cleanly. Each stream tick shape has a single valid width, so this applies uniformly across Quote / Trade / OHLCVC / OpenInterest / MarketValue; the now-redundant per-arm Trade guard is removed. Delta rows are unaffected — narrower partial deltas still apply onto the prior baseline. Closes #1047.

## Login timeout

Remove the separate wall-clock handshake deadline; login is now bounded solely by the socket read timeout, consistent with the rest of the read path. A mute peer hits the pre-header read timeout and reconnects; a partial-then-silent peer is bounded by the per-stall no-progress timeout.

## Verification

Core + ffi + cpp build; lib + fpss integration tests pass; the C++ Catch2 suite passes; `clippy --workspace --all-targets --locked` clean; rustfmt clean; cross-binding parity clean.

Closes #1047
