### PR TITLE
chore(release): 13.0.0-rc.12

### DIFF
--- a/.github/release-notes/v13.0.0-rc.12.md
+++ b/.github/release-notes/v13.0.0-rc.12.md
@@ -1,0 +1,22 @@
+## ThetaDataDx 13.0.0-rc.12
+
+This release candidate fixes a C++ teardown lifetime bug, corrects streaming decode of wrong-width rows, simplifies the login timeout, and fixes the Windows server-binary packaging. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.12/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- **C++ teardown fix:** destroying a `StreamingClient` that never installed a callback no longer spins a CPU core or leaks the handle.
+- **Wrong-width streaming rows:** a complete-but-narrow row (e.g. a 7-field trade) is rejected before it can trap a contract; a later correct row decodes cleanly. Applies to every tick shape, and dropped rows are logged and counted.
+- **Windows server binary:** the release now attaches the Windows `thetadatadx-server` archive (a packaging path bug previously dropped it).
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.12"`
+- MCP: `npx -y thetadatadx-mcp`
+
+### Thanks
+
+Thanks to everyone running the release candidates and sending feedback and patches. If you hit a snag, open an issue and we will sort it out.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,7 +827,10 @@ jobs:
           out="$(pwd)/${{ matrix.archive }}"
           if [ "${{ runner.os }}" = "Windows" ]; then
             # `7z` ships on GitHub Windows runners and produces a standard zip.
-            ( cd "$(dirname "$stage")" && 7z a -tzip "$out" "$(basename "$stage")" >/dev/null )
+            # `$out` is a Git-bash (MSYS) path (/d/a/...); native `7z` needs the
+            # Windows form (`cygpath -w`) or it writes the archive to a path the
+            # upload step cannot find.
+            ( cd "$(dirname "$stage")" && 7z a -tzip "$(cygpath -w "$out")" "$(basename "$stage")" >/dev/null )
           else
             tar -czf "$out" -C "$(dirname "$stage")" "$(basename "$stage")"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.12] - 2026-07-01
+
+### Fixed
+
+- **C++ standalone `StreamingClient` teardown.** Destroying (or move-assigning) a `StreamingClient` with no callback installed no longer spins a CPU core to the drain quiescence cap and then leaks the handle; the deferred reclaim is skipped when no callback is installed and the reclaim loop paces itself (#1064).
+- **Wrong-width streaming rows no longer trap a contract.** A complete-but-narrow first row (e.g. a 7-field trade) is rejected before it seeds the per-contract field-width cache, so a later correct row decodes cleanly instead of the contract being dropped until the next session reset. Applies uniformly to every stream tick shape; dropped rows are logged and counted (#1047).
+- **Windows server archive.** The `thetadatadx-server` Windows build now zips to the expected path, so the release attaches the Windows binary (previously the archive step wrote to a mismatched path and the upload found nothing).
+
+### Changed
+
+- Streaming login is bounded solely by the socket read timeout, consistent with the rest of the read path (the separate wall-clock handshake deadline is removed) (#1064).
+
 ## [13.0.0-rc.11] - 2026-07-01
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.11"
+thetadatadx = "13.0.0-rc.12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.11"
+thetadatadx = "13.0.0-rc.12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.12] - 2026-07-01
+
+### Fixed
+
+- **C++ standalone `StreamingClient` teardown.** Destroying (or move-assigning) a `StreamingClient` with no callback installed no longer spins a CPU core to the drain quiescence cap and then leaks the handle; the deferred reclaim is skipped when no callback is installed and the reclaim loop paces itself (#1064).
+- **Wrong-width streaming rows no longer trap a contract.** A complete-but-narrow first row (e.g. a 7-field trade) is rejected before it seeds the per-contract field-width cache, so a later correct row decodes cleanly instead of the contract being dropped until the next session reset. Applies uniformly to every stream tick shape; dropped rows are logged and counted (#1047).
+- **Windows server archive.** The `thetadatadx-server` Windows build now zips to the expected path, so the release attaches the Windows binary (previously the archive step wrote to a mismatched path and the upload found nothing).
+
+### Changed
+
+- Streaming login is bounded solely by the socket read timeout, consistent with the rest of the read path (the separate wall-clock handshake deadline is removed) (#1064).
+
 ## [13.0.0-rc.11] - 2026-07-01
 
 ### Removed

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.11
+  version: 13.0.0-rc.12
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.11"
+thetadatadx = "13.0.0-rc.12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.11", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.12", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package-lock.json
+++ b/thetadatadx-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "13.0.0-rc.11",
+      "version": "13.0.0-rc.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
@@ -18,9 +18,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "13.0.0-rc.11",
-        "thetadatadx-linux-x64-gnu": "13.0.0-rc.11",
-        "thetadatadx-win32-x64-msvc": "13.0.0-rc.11"
+        "thetadatadx-darwin-arm64": "13.0.0-rc.12",
+        "thetadatadx-linux-x64-gnu": "13.0.0-rc.12",
+        "thetadatadx-win32-x64-msvc": "13.0.0-rc.12"
       }
     },
     "node_modules/@emnapi/core": {

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.11",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.11",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.11"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.12",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.12",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.12"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.11",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.11",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.11",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.11",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.11"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.12",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.12",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.12",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.12",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.12"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.11"
+version = "13.0.0-rc.12"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Release 13.0.0-rc.12.

Bumps every version pin to 13.0.0-rc.12, adds the CHANGELOG + release notes, and fixes the Windows server-binary packaging that blocked the rc.11 GitHub Release.

## Contents since rc.11

- **Fixed** — the C++ standalone `StreamingClient` teardown (the no-callback path spun a CPU core and leaked the handle) (#1064); wrong-width streaming rows no longer trap a contract (#1047); the Windows `thetadatadx-server` archive now zips to the expected path so the release attaches it.
- **Changed** — streaming login is bounded by the socket read timeout (the separate wall-clock handshake deadline is removed) (#1064).

## Windows archive fix

The `build-server` Windows step handed native `7z` an MSYS path (`/d/a/...`); it now passes `cygpath -w "$out"` so the zip lands where the upload step looks. This is what lets the GitHub Release attach the Windows binary this release.

## Verification

`check_version_sync` and `check_docs_consistency` clean.

Tag `v13.0.0-rc.12` is cut only after this merges.
