### PR TITLE
ci: fix Windows release-archive upload and allow on-demand validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   merge_group:
+  # Manual trigger so the tag-only release-artifact jobs (the cross-platform
+  # server builds + their upload) can be validated on any ref without cutting a
+  # version tag. Publishing stays tag-gated, so a dispatch builds and never ships.
+  workflow_dispatch:
   schedule:
     # Off-peak, off-minute nightly run of the full heavy lane so the
     # cross-platform builds, semver check, and bench gate are proven
@@ -730,10 +734,12 @@ jobs:
   build-server:
     name: Build Server (${{ matrix.archive }})
     runs-on: ${{ matrix.os }}
-    # Tag-only: the server binaries are a release artifact. On a `v*` tag the
-    # `release` job below pulls these archives into the GitHub Release; nothing
-    # consumes them on a PR, so the cross-platform build stays off the PR path.
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Tag-only (plus manual dispatch): the server binaries are a release
+    # artifact. On a `v*` tag the `release` job below pulls these archives into
+    # the GitHub Release; nothing consumes them on a PR, so the cross-platform
+    # build stays off the PR path. `workflow_dispatch` runs it on demand so the
+    # packaging + upload can be proven on any ref before a tag is cut.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -775,7 +781,6 @@ jobs:
           CC_x86_64_unknown_linux_musl: musl-gcc
         run: cargo build --release --locked --manifest-path tools/server/Cargo.toml --target ${{ matrix.target }}
       - name: Package archive
-        id: package
         shell: bash
         run: |
           set -euo pipefail
@@ -828,18 +833,20 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             # `7z` ships on GitHub Windows runners and produces a standard zip.
             # `$out` is a Git-bash (MSYS) path (/d/a/...); native `7z` needs the
-            # Windows form (`cygpath -w`) or it writes the archive to a path the
-            # upload step cannot find.
+            # Windows form via `cygpath -w` to write to the right location.
             ( cd "$(dirname "$stage")" && 7z a -tzip "$(cygpath -w "$out")" "$(basename "$stage")" >/dev/null )
           else
             tar -czf "$out" -C "$(dirname "$stage")" "$(basename "$stage")"
           fi
-          echo "path=$out" >> "$GITHUB_OUTPUT"
       - name: Upload archive artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.archive }}
-          path: ${{ steps.package.outputs.path }}
+          # The archive is written to the workspace root. Reference it by the
+          # native workspace path so upload-artifact resolves it on every OS: a
+          # Git-bash /d/a/... path is not resolvable by the action's JS glob on
+          # Windows.
+          path: ${{ github.workspace }}/${{ matrix.archive }}
           if-no-files-found: error
 
   sdk-bindings:


### PR DESCRIPTION
## Problem

The Windows server archive builds correctly, but the upload step received the archive's Git-bash (`/d/a/ThetaDataDx/ThetaDataDx/thetadatadx-server-windows-x86_64.zip`) path. `actions/upload-artifact` resolves its `path` with a JavaScript glob that cannot resolve an MSYS-style path on Windows, so it logged `No files were found with the provided path` and skipped the upload. The GitHub Release then had no Windows server binary.

## Fix

Reference the archive by the native `${{ github.workspace }}` path, which resolves on every runner OS, and drop the unused `steps.package.outputs.path` plumbing.

## Prevent recurrence

The cross-platform server-archive build is tag-only, so this class of packaging error is only reachable on a real tag (it cannot be caught on a PR). Add a `workflow_dispatch` trigger and let the server-build job run on it, so the packaging and upload can be validated on any ref before a tag is cut. The release job stays tag-gated, so a manual run builds the archives and never publishes.