### PR TITLE
test(grpc): fix lost-wakeup flake in channel-pool mock signals

### DIFF
--- a/thetadatadx-rs/tests/grpc_mock_server.rs
+++ b/thetadatadx-rs/tests/grpc_mock_server.rs
@@ -312,7 +312,9 @@ pub async fn serve_one_connection(
                 completed = completed.saturating_add(1);
                 if let Some((notify, target)) = ping_pong_signal.as_ref() {
                     if completed == *target {
-                        notify.notify_waiters();
+                        // `notify_one` stores a permit if the waiter is not yet
+                        // parked, so this one-shot edge cannot be lost to a race.
+                        notify.notify_one();
                     }
                 }
                 tokio::time::sleep(interval).await;
@@ -456,7 +458,10 @@ async fn handle_request(
     // hooks above already inspect the drained body — this fires after
     // both so the test sees a coherent post-drain state.
     if let Some(notify) = behaviour.on_request_drained.as_ref() {
-        notify.notify_waiters();
+        // `notify_one`, not `notify_waiters`: the drain can fire before the test
+        // registers its waiter, and only `notify_one` stores a permit so the edge
+        // survives the race (the test awaits this signal exactly once).
+        notify.notify_one();
     }
     if let Some(d) = behaviour.pre_response_delay {
         tokio::time::sleep(d).await;


### PR DESCRIPTION
## Problem

`channel_pool_routes_around_saturated_channel` (and `channel_keepalive_survives_server_ping`) intermittently fail at their 5s barrier with `slow RPC reached the wire within 5s: Elapsed(())`.

The mock server signals `on_request_drained` and `ping_pong_signal` with `Notify::notify_waiters()`, which stores no permit. Each signal is awaited by a `Notified` future that is not registered as a waiter until the test reaches its `timeout(...)` barrier, which runs after the RPC is already spawned. On a loaded runner the producer chain (request-body drain, or the ping-pong counter hitting its target) can complete before the waiter registers, so `notify_waiters()` drops the edge and the awaiter blocks until the 5s guard fires.

## Fix

Switch both one-shot edges to `notify_one()`, which stores a permit when no waiter is parked and is therefore immune to producer/consumer ordering. Both signals are single-fire and single-waiter, so single-permit semantics are a strict improvement.

## Verification

Confirmed against the tokio source that `notify_waiters()` stores no permit while `notify_one()` does, and that a `Notified` future is only a registered waiter once polled. Every use site of both handles was checked: each is set, fired, and awaited exactly once, entirely within this test file; nothing relies on broadcast semantics.