### PR TITLE
fix(client): deterministic close() and deadlock-safe drop for base clients

### DIFF
--- a/parity.toml
+++ b/parity.toml
@@ -978,6 +978,36 @@ rust = true         # `Client::flat_files()` view accessor
 [method.signature]
 returns = "FlatFilesNamespace"
 
+# Deterministic base-client teardown (issue #1069). `close()` stops streaming
+# if live and releases the client; the language context-manager / RAII wrappers
+# (`__exit__`/`[Symbol.dispose]`/destructor) route through it. The
+# context-manager dunders themselves (`__enter__`/`__exit__`/`__aenter__`/
+# `__aexit__`, `[Symbol.dispose]`/`[Symbol.asyncDispose]`) are exempt from the
+# parity matrix by the collectors' lifecycle-dunder filter, so only the
+# cross-binding `close` verb carries a row.
+[[method]]
+class = "Client"
+name = "close"
+python = true       # `Client.close()` + `with` / `async with` context manager
+typescript = true   # napi `close(): void` + `[Symbol.dispose]` / `[Symbol.asyncDispose]`
+cpp = true          # `Client::close()` (explicit form of the RAII destructor)
+rust = true         # `Client::close()`
+[method.signature]
+returns = "()"
+
+# Historical-only sibling of `Client.close`. The historical surface never opens
+# streaming, so this releases the gRPC channel pool with no drain; present on
+# every binding so the base/historical lifecycle is uniform.
+[[method]]
+class = "HistoricalClient"
+name = "close"
+python = true       # `HistoricalClient.close()` + `with` / `async with` context manager
+typescript = true   # napi `close(): void` + `[Symbol.dispose]` / `[Symbol.asyncDispose]`
+cpp = true          # `HistoricalClient::close()` (explicit form of the RAII destructor)
+rust = true         # `HistoricalClient::close()`
+[method.signature]
+returns = "()"
+
 # Context-managed streaming session opener. A managed-binding ergonomic that
 # pairs `start_streaming` with a scope-exit `stop_streaming` + drain barrier:
 # Python `with client.streaming(cb) as session:` and TypeScript

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -1817,6 +1817,8 @@ def _collect_python_class_methods(py_src: pathlib.Path) -> dict[str, set[str]]:
         "__init__",
         "__enter__",
         "__exit__",
+        "__aenter__",
+        "__aexit__",
     }
     # `impl <Path> {` — `<Path>` may be `Name` or `crate::...::Name`.
     # Capture the last identifier segment before the opening brace.
@@ -2207,6 +2209,11 @@ CLIENT_REVERSE_ORPHAN_EXEMPT_MEMBERS: frozenset[str] = frozenset(
         "fromFile",
         "fromEnv",
         "fromDotenv",
+        # Private shared teardown behind `close` / `__exit__` / `__aexit__`;
+        # a plain (non-`#[pymethods]`) `impl Client` helper the collector still
+        # harvests. Not exposed to Python, so it carries no cross-binding
+        # contract and is enrolled by the public `close` row instead.
+        "closeImpl",
     }
 )
 

--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -882,6 +882,16 @@ public:
      *          credentials file or a connection / authentication failure. */
     static HistoricalClient from_file(const std::string& path, const Config& config = Config::production());
 
+    /** Deterministically close the historical client.
+     *
+     *  Releases the gRPC channel pool by dropping the underlying handle. The
+     *  historical-only surface never opens streaming, so there is no consumer
+     *  to drain; this is the explicit form of the RAII teardown the destructor
+     *  performs, provided so the historical surface matches the unified
+     *  `Client` lifecycle. Idempotent: a second call is a no-op and the
+     *  destructor after `close` frees nothing. */
+    void close() { handle_.reset(); }
+
     #include "historical.hpp.inc"
 
 private:
@@ -2216,6 +2226,56 @@ public:
     /// Raw handle for advanced consumers that want to call the C ABI
     /// directly. Ownership remains with this object.
     const ThetaDataDxClient* get() const noexcept { return handle_.get(); }
+
+    /** Deterministically close the client.
+     *
+     *  Stops streaming if it is live, waits for the streaming consumer thread
+     *  to finish firing the registered callback, then releases the handle (the
+     *  gRPC channel pool and any streaming session) and the callback state.
+     *  This is the explicit form of the RAII teardown the destructor performs;
+     *  calling it lets a caller release the client before it leaves scope.
+     *
+     *  Idempotent: a second call is a no-op, and the destructor after `close`
+     *  frees nothing (the handle is already released). Safe on a client that
+     *  only ran historical queries — the drain barrier is vacuous there.
+     *
+     *  On drain timeout the retired handle and callback state are handed to a
+     *  reclaimer that releases them only once the consumer is confirmed
+     *  quiesced (a bounded leak rather than a use-after-free), the same
+     *  discipline as move-assignment and `~StreamingClient`. */
+    void close() {
+        if (!handle_) {
+            return;
+        }
+        thetadatadx_client_stop_streaming(handle_.get());
+        int drained = thetadatadx_client_await_drain(handle_.get(), 5000);
+        if (drained == 0) {
+            // Consumer still firing: defer the release to the reclaimer so the
+            // handle backing the drain barrier — and the callback node the
+            // consumer invokes through — stay alive until quiescence. Handle
+            // freed first so its internal drain barrier still sees a live ctx,
+            // then the callback state, preserving the member-ordering invariant.
+            const ThetaDataDxClient* raw = handle_.get();
+            detail::reclaim_after_drain(
+                [raw]() {
+                    return thetadatadx_client_await_drain(
+                               raw,
+                               static_cast<uint64_t>(
+                                   detail::kReclaimPollStep.count())) == 1;
+                },
+                [retired_handle = std::move(handle_),
+                 retired_cb = std::move(callback_)]() mutable {
+                    retired_handle.reset();
+                    retired_cb.reset();
+                });
+        } else {
+            // Quiesced within the barrier: release inline, handle first so its
+            // free-time drain still observes a live callback node, then the
+            // callback state.
+            handle_.reset();
+            callback_.reset();
+        }
+    }
 
 private:
     explicit Client(ThetaDataDxClient* h)

--- a/thetadatadx-cpp/tests/lifecycle.cpp
+++ b/thetadatadx-cpp/tests/lifecycle.cpp
@@ -171,6 +171,18 @@ TEST_CASE("Config consumer_cpu round-trip", "[lifecycle][offline]") {
     REQUIRE(config.get_consumer_cpu() == THETADATADX_CONSUMER_CPU_UNPINNED);
 }
 
+// Compile-time surface pin (issue #1069): the base clients carry a
+// deterministic `void close()` teardown. Taking the member-function pointers
+// fails to compile if `close` is dropped or its signature drifts, so the
+// cross-binding lifecycle surface is enforced without a live connection.
+TEST_CASE("base clients expose a deterministic close()", "[lifecycle][offline]") {
+    void (thetadatadx::Client::*unified_close)() = &thetadatadx::Client::close;
+    void (thetadatadx::HistoricalClient::*historical_close)() =
+        &thetadatadx::HistoricalClient::close;
+    REQUIRE(unified_close != nullptr);
+    REQUIRE(historical_close != nullptr);
+}
+
 TEST_CASE("HistoricalClient::connect succeeds against the production server", "[lifecycle][live]") {
     const auto creds_path = env_or_empty("THETADATADX_LIVE_CREDS");
     if (creds_path.empty()) {
@@ -179,4 +191,25 @@ TEST_CASE("HistoricalClient::connect succeeds against the production server", "[
     auto creds = thetadatadx::Credentials::from_file(creds_path);
     auto config = thetadatadx::Config::production();
     REQUIRE_NOTHROW(thetadatadx::HistoricalClient::connect(creds, config));
+}
+
+TEST_CASE("close() is idempotent and safe before destruction", "[lifecycle][live]") {
+    const auto creds_path = env_or_empty("THETADATADX_LIVE_CREDS");
+    if (creds_path.empty()) {
+        SKIP("THETADATADX_LIVE_CREDS not set");
+    }
+    auto creds = thetadatadx::Credentials::from_file(creds_path);
+    auto config = thetadatadx::Config::production();
+
+    // Unified client: close explicitly, twice; the second is a no-op, and the
+    // subsequent destructor frees nothing (handle already released).
+    auto client = thetadatadx::Client::connect(creds, config);
+    REQUIRE_NOTHROW(client.close());
+    REQUIRE_NOTHROW(client.close());
+
+    // Historical-only client: same idempotent-close contract, no streaming to
+    // drain.
+    auto historical = thetadatadx::HistoricalClient::connect(creds, config);
+    REQUIRE_NOTHROW(historical.close());
+    REQUIRE_NOTHROW(historical.close());
 }

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -5463,6 +5463,32 @@ class Client:
         """
         ...
 
+    def close(self) -> None:
+        """Deterministically close the client.
+
+        Stops streaming if it is live (idempotent), waits for the streaming
+        consumer thread to finish firing the registered callback, and drops
+        the stored callback. Safe to call more than once and safe on a
+        client that only ran historical queries. Prefer the context manager
+        (``with Client(...) as c:``) so this runs on block exit.
+        """
+        ...
+
+    def __enter__(self) -> "Client": ...
+    def __exit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[object] = None,
+    ) -> bool: ...
+    async def __aenter__(self) -> "Client": ...
+    async def __aexit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[object] = None,
+    ) -> bool: ...
+
     # FLATFILES namespace getter + direct-to-disk helper.
     @property
     def flat_files(self) -> FlatFilesNamespace:
@@ -5613,6 +5639,23 @@ class AsyncClient:
     def __repr__(self) -> str:
         """Return a representation including historical and streaming state."""
         ...
+
+    def close(self) -> None:
+        """Deterministically close the async client.
+
+        Stops streaming if live, drains the consumer, and releases the
+        callback. Prefer ``async with await AsyncClient.connect(...) as c:``
+        so this runs on scope exit.
+        """
+        ...
+
+    async def __aenter__(self) -> "AsyncClient": ...
+    async def __aexit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[object] = None,
+    ) -> bool: ...
 
     def __getattr__(self, name: str) -> Any:
         """Resolve an ``*_async`` historical method or a streaming method.
@@ -5872,6 +5915,31 @@ class HistoricalClient:
     def __repr__(self) -> str:
         """Return a representation of the historical client."""
         ...
+
+    def close(self) -> None:
+        """Deterministically close the historical client.
+
+        The historical-only surface never opens streaming, so this releases
+        the gRPC channel pool with no drain. Idempotent. Prefer the context
+        manager (``with HistoricalClient(...) as c:``) so this runs on block
+        exit.
+        """
+        ...
+
+    def __enter__(self) -> "HistoricalClient": ...
+    def __exit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[object] = None,
+    ) -> bool: ...
+    async def __aenter__(self) -> "HistoricalClient": ...
+    async def __aexit__(
+        self,
+        exc_type: Optional[type] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[object] = None,
+    ) -> bool: ...
 
     def __getattr__(self, name: str) -> Any:
         """Resolve a historical method.

--- a/thetadatadx-py/src/_generated/streaming_methods.rs
+++ b/thetadatadx-py/src/_generated/streaming_methods.rs
@@ -65,11 +65,18 @@ impl StreamView {
         // a reference-count lifetime aid.
         let callback_arc: Arc<Py<PyAny>> = Arc::new(callback);
         let dispatch_cb = Arc::clone(&callback_arc);
-        // Capture a clone of the Rust client so the dispatcher closure can
-        // call `record_panic()` when the Python callback raises an exception.
-        // A `PyErr` is not a Rust panic; it does not unwind through
-        // `catch_unwind`, so the core counter is only bumped here.
-        let panic_recorder = Arc::clone(&self.client);
+        // Capture a WEAK handle to the Rust client so the dispatcher closure
+        // can call `record_panic()` when the Python callback raises an
+        // exception (a `PyErr` is not a Rust panic; it does not unwind through
+        // `catch_unwind`, so the core counter is only bumped here). It MUST be
+        // weak: a strong `Arc<Client>` held by the long-lived dispatcher
+        // closure would keep the core `Client` alive after the user drops
+        // their Python handle, so `Client::Drop` (which detaches the streaming
+        // teardown off the GIL thread) would never run and the session would
+        // leak until process exit. Upgrading only for the `record_panic()`
+        // call, and skipping it when the upgrade fails (the client is gone,
+        // so there is nothing to record on), keeps the cycle broken.
+        let panic_recorder = Arc::downgrade(&self.client);
 
         // Never hold the GIL across the blocking network connect.
         // `start_streaming_scoped` performs the FPSS TLS socket connect
@@ -127,7 +134,13 @@ impl StreamView {
                         };
                         if let Err(err) = dispatch_cb.call1(py, (typed,)) {
                             err.write_unraisable(py, None);
-                            panic_recorder.stream().record_panic();
+                            // Weak upgrade: record the callback failure only
+                            // while the client is still alive. If the user has
+                            // dropped it, teardown is already under way and
+                            // there is no counter to bump.
+                            if let Some(client) = panic_recorder.upgrade() {
+                                client.stream().record_panic();
+                            }
                         }
                     });
                 },
@@ -243,7 +256,10 @@ impl StreamView {
         };
         let callback_arc: Arc<Py<PyAny>> = Arc::new(stored);
         let dispatch_cb = Arc::clone(&callback_arc);
-        let panic_recorder = Arc::clone(&self.client);
+        // WEAK, not strong — see `start_streaming`: a strong `Arc<Client>` in
+        // the long-lived dispatcher closure would pin the core client alive
+        // past the user's drop and defeat `Client::Drop`'s teardown.
+        let panic_recorder = Arc::downgrade(&self.client);
 
         // Never hold the GIL across the blocking network reconnect.
         // `reconnect_streaming_scoped` tears the old session down, opens a
@@ -277,7 +293,10 @@ impl StreamView {
                         };
                         if let Err(err) = dispatch_cb.call1(py, (typed,)) {
                             err.write_unraisable(py, None);
-                            panic_recorder.stream().record_panic();
+                            // Weak upgrade — see `start_streaming`.
+                            if let Some(client) = panic_recorder.upgrade() {
+                                client.stream().record_panic();
+                            }
                         }
                     });
                 },

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -949,6 +949,128 @@ impl Client {
             callback: Arc::clone(&self.callback),
         }
     }
+
+    /// Deterministically close the client.
+    ///
+    /// Stops streaming if it is live (idempotent), waits for the streaming
+    /// consumer thread to finish firing the registered callback, and drops the
+    /// stored callback reference. Safe to call more than once and safe on a
+    /// client that only ran historical queries — those cases are a fast no-op.
+    ///
+    /// This is the recommended teardown. It runs on the calling thread with the
+    /// GIL released around the wait, so the dispatcher can re-acquire the GIL
+    /// via ``Python::attach`` to complete an in-flight callback before this
+    /// returns — unlike letting the object fall out of scope, which relies on
+    /// garbage collection timing. Prefer the context manager
+    /// (``with Client(...) as c:``) so close runs on block exit automatically.
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        self.close_impl(py)
+    }
+
+    /// Sync context-manager entry: returns ``self`` so
+    /// ``with Client(...) as c:`` binds the client.
+    fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    /// Sync context-manager exit: closes the client (stop + drain + drop the
+    /// callback). Returns ``False`` so an exception raised inside the ``with``
+    /// body is not swallowed.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> PyResult<bool> {
+        self.close_impl(py)?;
+        Ok(false)
+    }
+
+    /// Async context-manager entry: returns ``self`` so
+    /// ``async with Client(...) as c:`` binds the client.
+    fn __aenter__<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(slf) })
+            .map(pyo3::Bound::into_any)
+    }
+
+    /// Async context-manager exit: closes the client. The teardown itself
+    /// releases the GIL internally, so it runs inline before the returned
+    /// awaitable resolves; the awaitable exists to satisfy the async
+    /// context-manager protocol. Resolves to ``False`` so an exception in the
+    /// ``async with`` body is not swallowed.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.close_impl(py)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(false) })
+            .map(pyo3::Bound::into_any)
+    }
+}
+
+impl Client {
+    /// Shared teardown behind `close` / `__exit__` / `__aexit__`.
+    ///
+    /// Mirrors the `StreamingSession` context-manager exit and the C ABI
+    /// `thetadatadx_client_free` contract: stop streaming, wait on the
+    /// post-stop drain barrier so the consumer thread has finished firing the
+    /// callback (making the callback closure safe to release), then drop the
+    /// stored callback handle. The GIL is released across both the stop and the
+    /// drain so the dispatcher's `Python::attach` can make progress; nothing
+    /// here blocks the interpreter.
+    pub(crate) fn close_impl(&self, py: Python<'_>) -> PyResult<()> {
+        // Only a live streaming session has anything to drain. Snapshot that
+        // BEFORE stopping so we do not wait on a barrier that will never arm on
+        // a historical-only client (whose `prev_drained` slot stays empty).
+        let was_streaming = self.client.stream().is_streaming();
+        let drained = py.detach(|| {
+            self.client.close();
+            if was_streaming {
+                self.client
+                    .stream()
+                    .await_drain(std::time::Duration::from_millis(
+                        streaming_session::EXIT_DRAIN_TIMEOUT_MS,
+                    ))
+            } else {
+                // Nothing was streaming; the drain barrier is vacuously
+                // satisfied.
+                true
+            }
+        });
+        // Release the stored callback now the consumer is quiesced, matching
+        // `stop_streaming`'s explicit-handoff semantics: a closed client holds
+        // no captured Python reference past the teardown the caller has seen.
+        {
+            let mut guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
+            *guard = None;
+        }
+        if !drained {
+            // The streaming pipeline is already stopped; the drain is
+            // best-effort observability. Warn (matching the `StreamingSession`
+            // context-manager exit) rather than raise, so a `with` body's own
+            // exception is never masked by a teardown warning.
+            let warnings = py.import("warnings")?;
+            let msg = format!(
+                "client close drain timed out after {}ms; the streaming consumer \
+                 callback may still be firing.",
+                streaming_session::EXIT_DRAIN_TIMEOUT_MS,
+            );
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("stacklevel", 2_u32)?;
+            warnings.call_method(
+                "warn",
+                (msg, py.get_type::<pyo3::exceptions::PyRuntimeWarning>()),
+                Some(&kwargs),
+            )?;
+        }
+        Ok(())
+    }
 }
 
 #[pymethods]
@@ -1490,6 +1612,35 @@ impl AsyncClient {
         let bound = self.inner.bind(py);
         let inner_repr: String = bound.call_method0("__repr__")?.extract()?;
         Ok(inner_repr.replace("Client", "AsyncClient"))
+    }
+
+    /// Deterministically close the async client — stops streaming if live,
+    /// drains the consumer, and releases the callback. Forwards to the inner
+    /// [`Client::close`]; the GIL is released around the wait. Prefer
+    /// ``async with await AsyncClient.connect(...) as c:`` so this runs on exit.
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        self.inner.borrow(py).close_impl(py)
+    }
+
+    /// Async context-manager entry: returns ``self``.
+    fn __aenter__<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(slf) })
+            .map(pyo3::Bound::into_any)
+    }
+
+    /// Async context-manager exit: closes the client. Resolves to ``False`` so
+    /// an exception raised in the ``async with`` body is not swallowed.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.inner.borrow(py).close_impl(py)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(false) })
+            .map(pyo3::Bound::into_any)
     }
 }
 

--- a/thetadatadx-py/src/mdds_client.rs
+++ b/thetadatadx-py/src/mdds_client.rs
@@ -245,6 +245,58 @@ impl HistoricalClient {
         // out otherwise).
         "HistoricalClient(historical=connected)".to_string()
     }
+
+    /// Deterministically close the historical client.
+    ///
+    /// The historical-only surface never opens streaming, so there is no
+    /// dispatcher to drain; close forwards to the inner [`crate::Client::close`]
+    /// (a fast no-op teardown) and the gRPC channel pool releases when this
+    /// handle is dropped. Provided so the historical surface matches the
+    /// unified client's lifecycle across every binding. Idempotent. Prefer
+    /// ``with HistoricalClient(...) as c:`` so close runs on block exit.
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        self.inner.borrow(py).close_impl(py)
+    }
+
+    /// Sync context-manager entry: returns ``self``.
+    fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    /// Sync context-manager exit: closes the client. Returns ``False`` so an
+    /// exception raised inside the ``with`` body is not swallowed.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> PyResult<bool> {
+        self.inner.borrow(py).close_impl(py)?;
+        Ok(false)
+    }
+
+    /// Async context-manager entry: returns ``self``.
+    fn __aenter__<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(slf) })
+            .map(pyo3::Bound::into_any)
+    }
+
+    /// Async context-manager exit: closes the client. Resolves to ``False`` so
+    /// an exception raised in the ``async with`` body is not swallowed.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.inner.borrow(py).close_impl(py)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(false) })
+            .map(pyo3::Bound::into_any)
+    }
 }
 
 /// Introspection helper exposed as a module-level Python function for

--- a/thetadatadx-py/src/streaming_session.rs
+++ b/thetadatadx-py/src/streaming_session.rs
@@ -27,7 +27,7 @@ use crate::fpss_client::StreamingClient;
 /// parity matters more than tunability here -- a slow Python callback
 /// that needs >5 s to drain is already a contract violation worth
 /// surfacing.
-const EXIT_DRAIN_TIMEOUT_MS: u64 = 5_000;
+pub(crate) const EXIT_DRAIN_TIMEOUT_MS: u64 = 5_000;
 
 /// Typed handle carried by the context-manager pyclasses. Replaces a
 /// bare `Py<PyAny>` so the streaming lifecycle calls

--- a/thetadatadx-py/tests/test_context_manager.py
+++ b/thetadatadx-py/tests/test_context_manager.py
@@ -180,6 +180,58 @@ def test_double_enter_raises(client) -> None:
 # ─────────────────────────────────────────────────────────────────────
 
 
+def test_streaming_dispatcher_holds_a_weak_client_ref() -> None:
+    """Offline lifecycle guard: the unified streaming dispatcher closure must
+    capture a WEAK reference to the core client, never a strong `Arc`.
+
+    This is the invariant behind the forgetful-drop teardown. The dispatcher
+    closure outlives the `start_streaming` / `reconnect` call and runs on its
+    own thread for the whole session. If it captured a strong
+    `Arc<Client>` (e.g. `Arc::clone(&self.client)`) that strong reference
+    would keep the core client alive after the user drops their Python
+    handle, so `Client::Drop` — the detach that tears the streaming session
+    down off the GIL thread — would never run and the FPSS session would leak
+    until process exit. Capturing `Arc::downgrade(&self.client)` and
+    upgrading only for the `record_panic()` bump keeps the cycle broken.
+
+    Asserted against the generated source (no credentials needed) so a
+    regression of the generator template fails here even offline — the
+    live thread-teardown test above is the end-to-end proof but is gated on
+    a real FPSS handshake.
+    """
+    from pathlib import Path
+
+    here = Path(__file__).resolve().parent
+    src_root = None
+    for candidate in [here, *here.parents]:
+        target = candidate / "src"
+        if target.is_dir() and (target / "lib.rs").is_file():
+            src_root = target
+            break
+    assert src_root is not None, "could not locate thetadatadx-py/src"
+
+    generated = (src_root / "_generated" / "streaming_methods.rs").read_text()
+    # The dispatcher's client handle is bound to `panic_recorder`. It MUST be
+    # a weak downgrade, and there must be no strong clone of the client
+    # captured for the dispatcher.
+    assert "let panic_recorder = Arc::downgrade(&self.client);" in generated, (
+        "the streaming dispatcher must capture a WEAK client handle "
+        "(`Arc::downgrade(&self.client)`) so a forgetful drop still runs "
+        "Client::Drop and tears the session down"
+    )
+    assert "let panic_recorder = Arc::clone(&self.client);" not in generated, (
+        "the streaming dispatcher must NOT capture a strong `Arc<Client>` "
+        "(`Arc::clone(&self.client)`): it would pin the core client alive "
+        "past the user's drop and leak the streaming session"
+    )
+    # Both the start_streaming and reconnect dispatchers carry the capture,
+    # so the weak downgrade must appear on both paths.
+    assert generated.count("Arc::downgrade(&self.client)") >= 2, (
+        "both the start_streaming and reconnect dispatcher closures must "
+        "hold a weak client reference"
+    )
+
+
 def test_base_clients_expose_close_and_context_managers() -> None:
     """Offline surface pin: the base clients carry the deterministic
     teardown surface. `Client` / `HistoricalClient` are sync + async
@@ -237,18 +289,26 @@ def test_direct_start_streaming_then_drop_does_not_deadlock() -> None:
     A user calls `client.stream.start_streaming(cb)` (the DIRECT path, not
     the `with client.streaming(cb)` context manager) and then lets the
     `Client` fall out of scope WITHOUT calling `stop_streaming()`. The
-    final `Arc::drop` runs the core `Client::Drop`, which now detaches the
+    final `Arc::drop` runs the core `Client::Drop`, which detaches the
     dispatcher join off the dropping (GIL-holding) thread, so the drop
     returns instead of deadlocking against the dispatcher's `Python::attach`.
 
-    Driven under a watchdog thread: the test builds a client, starts
-    streaming, drops the sole reference, and asserts the drop-and-GC
-    completes within a bounded window. A regression (inline join under the
-    held GIL) hangs here and trips the deadline. Live-gated because
+    This asserts teardown ACTUALLY happens, not merely that the drop does
+    not hang. The bug the fix closes has two layers: (a) the dispatcher
+    closure must hold a WEAK reference to the core client, else the strong
+    `Arc` pins it alive and `Client::Drop` never runs at all; (b) once Drop
+    runs, its join must be detached off the GIL thread. Layer (a) is what a
+    "does not hang" test misses — with a strong ref the drop returns
+    instantly (nothing to tear down) yet the FPSS reader / dispatcher threads
+    run forever. So the test observes the live streaming worker threads
+    terminating: it snapshots the OS thread count with a stream live, drops
+    the client without `stop_streaming()`, and asserts the count falls back
+    toward the pre-stream baseline within a bounded window. A leaked session
+    keeps those threads and fails the assertion. Live-gated because
     `start_streaming` opens a real FPSS connection.
     """
     import gc
-    import threading
+    import time
 
     creds_path = os.environ.get("THETADATADX_TEST_CREDS")
     if not creds_path:
@@ -257,25 +317,49 @@ def test_direct_start_streaming_then_drop_does_not_deadlock() -> None:
         )
     mod = _import_module()
 
-    done = threading.Event()
+    def os_thread_count() -> int:
+        # OS-level thread count (Linux). Counts every kernel thread of this
+        # process, including the Rust-spawned FPSS reader / dispatcher /
+        # detach-helper threads that Python's `threading` module cannot see.
+        try:
+            return len(os.listdir("/proc/self/task"))
+        except FileNotFoundError:
+            pytest.skip("thread-count teardown check needs /proc (Linux)")
 
-    def run() -> None:
-        creds = mod.Credentials.from_file(creds_path)
-        client = mod.Client(creds, mod.Config.production())
-        client.stream.start_streaming(_noop_callback)
-        # Drop the sole reference WITHOUT stop_streaming(), then force the
-        # collection so the pyclass destructor (and the core `Client::Drop`)
-        # runs here, under the GIL, on this thread.
-        del client
-        gc.collect()
-        done.set()
+    baseline = os_thread_count()
 
-    worker = threading.Thread(target=run, name="drop-no-stop", daemon=True)
-    worker.start()
-    # 30s ceiling: the detached teardown returns in milliseconds; only a
-    # reintroduced GIL-reacquire deadlock would blow past this.
-    assert done.wait(timeout=30.0), (
-        "dropping a streaming Client without stop_streaming() deadlocked: "
-        "the core drop must detach the GIL-reacquiring dispatcher join"
+    client = mod.Client(mod.Credentials.from_file(creds_path), mod.Config.production())
+    client.stream.start_streaming(_noop_callback)
+    # Let the FPSS reader + dispatcher threads come up.
+    time.sleep(1.0)
+    streaming = os_thread_count()
+    assert streaming > baseline, (
+        "precondition: a live stream must have spawned OS worker threads "
+        f"(baseline={baseline}, streaming={streaming})"
     )
-    worker.join(timeout=5.0)
+
+    # Drop the sole reference WITHOUT stop_streaming(), then force collection
+    # so the pyclass destructor (and the core `Client::Drop`) runs now. If the
+    # dispatcher held a strong `Arc<Client>`, Drop would not run and the
+    # streaming threads would persist; the detach helper then joins them.
+    del client
+    gc.collect()
+
+    # The FPSS session must tear down and its threads join back to the
+    # baseline within a bounded window. Poll rather than sleep-once so a fast
+    # teardown returns promptly; a leaked session never converges and trips
+    # the deadline. The detach helper thread itself is short-lived (it joins
+    # the FPSS threads then exits), so the count returns to baseline.
+    deadline = time.monotonic() + 15.0
+    final = streaming
+    while time.monotonic() < deadline:
+        final = os_thread_count()
+        if final <= baseline:
+            break
+        time.sleep(0.1)
+    assert final <= baseline, (
+        "FPSS worker threads did not terminate after a forgetful drop: "
+        f"baseline={baseline}, still_running={final}. The dispatcher closure "
+        "is pinning the core Client with a strong Arc, so Client::Drop never "
+        "ran and the streaming session leaked."
+    )

--- a/thetadatadx-py/tests/test_context_manager.py
+++ b/thetadatadx-py/tests/test_context_manager.py
@@ -172,3 +172,110 @@ def test_double_enter_raises(client) -> None:
         pass
     with pytest.raises(RuntimeError, match="callback already consumed"):
         cm.__enter__()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Base-client lifecycle: `close()` + `with` / `async with` (issue #1069)
+# and the direct-start-then-drop deadlock-safety (issue 1).
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_base_clients_expose_close_and_context_managers() -> None:
+    """Offline surface pin: the base clients carry the deterministic
+    teardown surface. `Client` / `HistoricalClient` are sync + async
+    context managers with `close()`; `AsyncClient` is an async-only
+    context manager with `close()`. Asserted without credentials so a
+    regression that drops any of these fails even offline.
+    """
+    mod = _import_module()
+    for name in ("Client", "HistoricalClient"):
+        cls = getattr(mod, name)
+        for attr in ("close", "__enter__", "__exit__", "__aenter__", "__aexit__"):
+            assert hasattr(cls, attr), f"{name} must expose {attr}"
+    # AsyncClient is async-first: async CM + close, no sync CM.
+    async_cls = mod.AsyncClient
+    for attr in ("close", "__aenter__", "__aexit__"):
+        assert hasattr(async_cls, attr), f"AsyncClient must expose {attr}"
+
+
+def test_context_manager_closes_cleanly(client) -> None:
+    """`with Client(...) as c:` binds the client and closes it on exit.
+
+    The block exit runs `close()` (stop streaming if live + drain + drop
+    the callback). With no streaming started, close is a fast no-op and
+    the client is still bound inside the block. Live-gated because the
+    constructor needs a real handshake.
+    """
+    with client as bound:
+        assert bound is client
+        # A historical query still works inside the block (channel open).
+        assert bound.stream.is_streaming() is False
+    # After the block the client is closed; a second close is idempotent
+    # and must not raise.
+    client.close()
+
+
+def test_close_is_idempotent_and_safe_after_streaming(client) -> None:
+    """`close()` is idempotent and safe to call after a streaming session.
+
+    Start streaming, close once (stops + drains), then close again: the
+    second call is a no-op and must not raise or hang. Live-gated.
+    """
+    client.stream.start_streaming(_noop_callback)
+    assert client.stream.is_streaming() is True
+    client.close()
+    assert client.stream.is_streaming() is False
+    # Idempotent: calling close again on an already-closed client is a
+    # no-op, never a panic or a hang.
+    client.close()
+    client.close()
+
+
+def test_direct_start_streaming_then_drop_does_not_deadlock() -> None:
+    """The forgetful path is deadlock-safe (issue 1).
+
+    A user calls `client.stream.start_streaming(cb)` (the DIRECT path, not
+    the `with client.streaming(cb)` context manager) and then lets the
+    `Client` fall out of scope WITHOUT calling `stop_streaming()`. The
+    final `Arc::drop` runs the core `Client::Drop`, which now detaches the
+    dispatcher join off the dropping (GIL-holding) thread, so the drop
+    returns instead of deadlocking against the dispatcher's `Python::attach`.
+
+    Driven under a watchdog thread: the test builds a client, starts
+    streaming, drops the sole reference, and asserts the drop-and-GC
+    completes within a bounded window. A regression (inline join under the
+    held GIL) hangs here and trips the deadline. Live-gated because
+    `start_streaming` opens a real FPSS connection.
+    """
+    import gc
+    import threading
+
+    creds_path = os.environ.get("THETADATADX_TEST_CREDS")
+    if not creds_path:
+        pytest.skip(
+            "set THETADATADX_TEST_CREDS=path/to/creds.txt to enable this live test"
+        )
+    mod = _import_module()
+
+    done = threading.Event()
+
+    def run() -> None:
+        creds = mod.Credentials.from_file(creds_path)
+        client = mod.Client(creds, mod.Config.production())
+        client.stream.start_streaming(_noop_callback)
+        # Drop the sole reference WITHOUT stop_streaming(), then force the
+        # collection so the pyclass destructor (and the core `Client::Drop`)
+        # runs here, under the GIL, on this thread.
+        del client
+        gc.collect()
+        done.set()
+
+    worker = threading.Thread(target=run, name="drop-no-stop", daemon=True)
+    worker.start()
+    # 30s ceiling: the detached teardown returns in milliseconds; only a
+    # reintroduced GIL-reacquire deadlock would blow past this.
+    assert done.wait(timeout=30.0), (
+        "dropping a streaming Client without stop_streaming() deadlocked: "
+        "the core drop must detach the GIL-reacquiring dispatcher join"
+    )
+    worker.join(timeout=5.0)

--- a/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/reconnect_body.rs.tmpl
+++ b/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/reconnect_body.rs.tmpl
@@ -16,7 +16,10 @@
         };
         let callback_arc: Arc<Py<PyAny>> = Arc::new(stored);
         let dispatch_cb = Arc::clone(&callback_arc);
-        let panic_recorder = Arc::clone(&self.client);
+        // WEAK, not strong — see `start_streaming`: a strong `Arc<Client>` in
+        // the long-lived dispatcher closure would pin the core client alive
+        // past the user's drop and defeat `Client::Drop`'s teardown.
+        let panic_recorder = Arc::downgrade(&self.client);
 
         // Never hold the GIL across the blocking network reconnect.
         // `reconnect_streaming_scoped` tears the old session down, opens a
@@ -50,7 +53,10 @@
                         };
                         if let Err(err) = dispatch_cb.call1(py, (typed,)) {
                             err.write_unraisable(py, None);
-                            panic_recorder.stream().record_panic();
+                            // Weak upgrade — see `start_streaming`.
+                            if let Some(client) = panic_recorder.upgrade() {
+                                client.stream().record_panic();
+                            }
                         }
                     });
                 },

--- a/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
+++ b/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
@@ -19,11 +19,18 @@
         // a reference-count lifetime aid.
         let callback_arc: Arc<Py<PyAny>> = Arc::new(callback);
         let dispatch_cb = Arc::clone(&callback_arc);
-        // Capture a clone of the Rust client so the dispatcher closure can
-        // call `record_panic()` when the Python callback raises an exception.
-        // A `PyErr` is not a Rust panic; it does not unwind through
-        // `catch_unwind`, so the core counter is only bumped here.
-        let panic_recorder = Arc::clone(&self.client);
+        // Capture a WEAK handle to the Rust client so the dispatcher closure
+        // can call `record_panic()` when the Python callback raises an
+        // exception (a `PyErr` is not a Rust panic; it does not unwind through
+        // `catch_unwind`, so the core counter is only bumped here). It MUST be
+        // weak: a strong `Arc<Client>` held by the long-lived dispatcher
+        // closure would keep the core `Client` alive after the user drops
+        // their Python handle, so `Client::Drop` (which detaches the streaming
+        // teardown off the GIL thread) would never run and the session would
+        // leak until process exit. Upgrading only for the `record_panic()`
+        // call, and skipping it when the upgrade fails (the client is gone,
+        // so there is nothing to record on), keeps the cycle broken.
+        let panic_recorder = Arc::downgrade(&self.client);
 
         // Never hold the GIL across the blocking network connect.
         // `start_streaming_scoped` performs the FPSS TLS socket connect
@@ -81,7 +88,13 @@
                         };
                         if let Err(err) = dispatch_cb.call1(py, (typed,)) {
                             err.write_unraisable(py, None);
-                            panic_recorder.stream().record_panic();
+                            // Weak upgrade: record the callback failure only
+                            // while the client is still alive. If the user has
+                            // dropped it, teardown is already under way and
+                            // there is no counter to bump.
+                            if let Some(client) = panic_recorder.upgrade() {
+                                client.stream().record_panic();
+                            }
                         }
                     });
                 },

--- a/thetadatadx-rs/src/client.rs
+++ b/thetadatadx-rs/src/client.rs
@@ -286,6 +286,48 @@ impl StreamingState {
         }
     }
 
+    /// Quiesce off the calling thread: extract the teardown work under the
+    /// lock here (cheap, non-blocking), then finish the blocking part — the
+    /// FPSS client shutdown and the dispatcher join — on a detached helper
+    /// thread.
+    ///
+    /// This is the [`Client::drop`] path. A plain [`Self::quiesce`] would run
+    /// [`Self::run_teardown`], whose cross-thread dispatcher join blocks the
+    /// calling thread. When the last `Arc<Client>` is dropped while a binding
+    /// runtime lock is held — the Python GIL, most importantly, since the
+    /// dispatcher re-acquires it via `Python::attach` to finish an in-flight
+    /// callback — that inline join deadlocks: the drop thread waits on the
+    /// dispatcher, the dispatcher waits on the GIL the drop thread still holds.
+    /// Detaching the join breaks the cycle: the drop returns at once (releasing
+    /// the GIL / event loop), and the helper completes the join once the
+    /// dispatcher drains. Callers who want a synchronous barrier use the
+    /// explicit [`Client::close`] / `stop_streaming` + `await_drain` path,
+    /// which already releases the binding lock around the wait.
+    ///
+    /// Mirrors the self-join detach `StreamingClient::drop` uses (see
+    /// `fpss/mod.rs`): both spawn a named helper so cleanup still completes
+    /// instead of blocking a thread on work it cannot finish inline.
+    fn quiesce_detached(self: &Arc<Self>) {
+        let state = Arc::clone(self);
+        let detached = std::thread::Builder::new()
+            .name("thetadatadx-client-drop-detach".to_owned())
+            .spawn(move || state.quiesce());
+        if let Err(e) = detached {
+            // Spawning failed (thread limit / OOM). Fall back to an inline
+            // teardown: on the common no-streaming drop there is no dispatcher
+            // to join, so `quiesce` returns immediately and no deadlock is
+            // possible; only a forgetful streaming drop under a held runtime
+            // lock could still block, and that is strictly better than leaking
+            // the dispatcher thread and the FPSS connection.
+            tracing::warn!(
+                target: "thetadatadx::client",
+                error = %e,
+                "failed to spawn thetadatadx-client-drop-detach; running teardown inline",
+            );
+            self.quiesce();
+        }
+    }
+
     /// Retire the live session ONLY if the live stop-generation still equals
     /// `expected_gen`, atomically with the generation re-check.
     ///
@@ -1873,17 +1915,30 @@ impl Client {
 }
 
 impl Drop for Client {
-    /// Final cleanup: idempotently stops the streaming connection.
+    /// Final cleanup: idempotently stops the streaming connection, off the
+    /// dropping thread.
     ///
     /// `stop_streaming` swaps the state cell to `Stopped` and only
     /// signals the FPSS client when the previous slot was `Live`.
     /// The actual TLS reader + event-dispatch consumer join happens when
     /// the last `Arc<StreamingClient>` is dropped via `StreamingClient::Drop`.
     /// Calling once from `Drop` after the user already called
-    /// `stop_streaming` is therefore a no-op — the state machine
-    /// guarantees the shutdown signal runs exactly once.
+    /// [`Self::close`] / `stop_streaming` is therefore a no-op — the state
+    /// machine guarantees the shutdown signal runs exactly once.
+    ///
+    /// The teardown is **detached** onto a helper thread
+    /// (`StreamingState::quiesce_detached`) rather than run inline. A binding
+    /// that drops its last client handle while holding a runtime lock the
+    /// dispatcher re-enters — the Python GIL is the load-bearing case, since
+    /// the dispatcher re-acquires it via `Python::attach` to finish an
+    /// in-flight callback — would deadlock on an inline dispatcher join: the
+    /// drop thread blocks on the dispatcher, the dispatcher blocks on the lock.
+    /// Detaching lets the drop return immediately (releasing that lock) while
+    /// the helper finishes the join once the callback drains. Callers that need
+    /// a synchronous quiescence barrier use [`Self::close`] (or `stop_streaming`
+    /// + `await_drain`), which the bindings wrap in a lock-releasing region.
     fn drop(&mut self) {
-        self.stop_streaming();
+        self.streaming.quiesce_detached();
     }
 }
 
@@ -1910,6 +1965,34 @@ impl Client {
     #[must_use]
     pub fn historical(&self) -> &HistoricalClient {
         &self.historical
+    }
+
+    /// Deterministically tear the client down.
+    ///
+    /// Stops streaming if it is live (idempotent; a no-op when it was never
+    /// started or is already stopped). This is the deterministic teardown the
+    /// language bindings expose as `close()` / context-manager exit
+    /// (`__exit__`, `[Symbol.dispose]`, destructor): it runs on the calling
+    /// thread and, unlike the detached [`Drop`] path, retires the streaming
+    /// dispatcher synchronously so a subsequent request or reconnect sees a
+    /// truthfully-stopped session.
+    ///
+    /// The historical gRPC channel pool is released when the last client handle
+    /// is dropped: it is an `Arc`-backed set of idle HTTP/2 connections with no
+    /// worker thread to join, so its release is RAII, not an explicit signal.
+    /// The bindings drop their owning handle on `close()` / context-manager
+    /// exit, which is where that pool release becomes deterministic for the
+    /// caller.
+    ///
+    /// Idempotent and safe to call more than once: the streaming state machine
+    /// guarantees the shutdown signal fires exactly once.
+    ///
+    /// For a full callback-quiescence barrier (so a callback context can be
+    /// freed) pair `stop_streaming` with [`StreamSurface::await_drain`]; `close`
+    /// performs the stop but not the post-stop drain wait, matching the
+    /// non-blocking `stop_streaming` contract.
+    pub fn close(&self) {
+        self.stop_streaming();
     }
 
     /// Streaming surface — subscribe / unsubscribe, the dispatcher
@@ -2851,6 +2934,90 @@ mod tests {
             "quiesce must join the dispatcher thread and reset the session to \
              Idle so the client is reusable"
         );
+    }
+
+    /// The `Client` drop path (`quiesce_detached`) must NOT block the calling
+    /// thread on the dispatcher join — that is what makes a forgetful drop
+    /// deadlock-safe when the dropping thread holds a runtime lock the
+    /// dispatcher re-enters (the Python GIL). Modelled without Python: a
+    /// dispatcher thread parks on a gate the caller controls, is installed as
+    /// the `Running` session, and `quiesce_detached` is driven on the "GIL"
+    /// thread. The assertion is that the call RETURNS while the dispatcher is
+    /// still parked — an inline join would block here until the gate opens, so a
+    /// prompt return proves the join ran on the detached helper instead. Only
+    /// after the caller opens the gate does the detached helper's join complete.
+    #[test]
+    fn drop_detaches_the_dispatcher_join_off_the_calling_thread() {
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        // Gate the dispatcher thread the way an in-flight callback awaiting the
+        // GIL would: it will not exit (so the join cannot complete) until the
+        // caller releases it.
+        let gate = Arc::new(AtomicBool::new(false));
+        let gate_t = Arc::clone(&gate);
+        let dispatcher = std::thread::spawn(move || {
+            while !gate_t.load(O::Acquire) {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+        });
+
+        let state = Arc::new(StreamingState::new());
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: dispatcher,
+            on_teardown: None,
+            registers_drain_flag: false,
+        };
+
+        // The "GIL" thread's drop. If the join were inline this call would block
+        // until the gate opens; it must return promptly instead.
+        let start = std::time::Instant::now();
+        state.quiesce_detached();
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "quiesce_detached blocked on the dispatcher join instead of \
+             detaching it; a forgetful drop under a held GIL would deadlock",
+        );
+        assert!(
+            !gate.load(O::Acquire),
+            "precondition: dispatcher is still parked, so the prompt return \
+             above proves the join was detached rather than already complete",
+        );
+
+        // Release the parked dispatcher; the detached helper's join now
+        // completes and the session retires to Idle.
+        gate.store(true, O::Release);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !state.dispatcher_is_idle() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "detached teardown helper never retired the dispatcher session \
+                 after the gate opened",
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
+
+    /// `quiesce` / `close` are idempotent and safe to call repeatedly on a
+    /// never-started (and already-stopped) streaming state: the slot walks to
+    /// `Stopped`, stays there, and each call bumps the stop generation without
+    /// panicking or blocking. This is the base-client `close()` contract —
+    /// calling it twice, or on a client that only ran historical queries, is a
+    /// no-op teardown.
+    #[test]
+    fn quiesce_is_idempotent_on_a_never_started_state() {
+        let state = StreamingState::new();
+        assert_eq!(state.slot_label(), "Idle");
+
+        state.quiesce();
+        let gen1 = state.stop_generation();
+        assert_eq!(state.slot_label(), "Stopped");
+        assert!(state.dispatcher_is_idle());
+
+        // Second close: still safe, still Stopped, generation advances.
+        state.quiesce();
+        assert_eq!(state.slot_label(), "Stopped");
+        assert!(state.dispatcher_is_idle());
+        assert!(state.stop_generation() > gen1);
     }
 
     /// quiesce must not deadlock joining a columnar dispatcher parked in its

--- a/thetadatadx-rs/src/config/mdds.rs
+++ b/thetadatadx-rs/src/config/mdds.rs
@@ -78,8 +78,7 @@ pub struct HistoricalConfig {
     pub connect_timeout_secs: u64,
 
     /// Default per-request deadline for historical (gRPC) queries, in
-    /// seconds. `0` disables the default (no deadline unless the caller
-    /// sets one).
+    /// seconds.
     ///
     /// A server that holds the HTTP/2 stream open while sending no
     /// chunks would otherwise hang `collect_stream` / `stream(...)`
@@ -88,9 +87,17 @@ pub struct HistoricalConfig {
     /// request that did not call `with_deadline(...)`, so a stalled
     /// stream resolves to `Error::Timeout` instead of blocking forever.
     ///
+    /// Configuring `0` here does **not** disable the guard: to keep the
+    /// terminal-safe behaviour, [`DirectConfig::validate`] floors a `0`
+    /// back to the production default so a deadline-less request can never
+    /// hang the client forever. Opt a single request out with the per-call
+    /// escape hatch instead.
+    ///
     /// Per-call control overrides this: `with_deadline(Duration)` sets a
     /// shorter or longer bound, and `with_deadline(Duration::ZERO)`
     /// opts a single request out of any deadline.
+    ///
+    /// [`DirectConfig::validate`]: crate::config::DirectConfig::validate
     ///
     /// Default `300s` (5 min) — comfortably above the slowest realistic
     /// multi-million-row bulk pull while still bounding a wedged stream.

--- a/thetadatadx-rs/src/config/mdds.rs
+++ b/thetadatadx-rs/src/config/mdds.rs
@@ -13,6 +13,17 @@
 //! See `docs-site/docs/configuration.md` for the per-binding setter
 //! samples.
 
+/// Default per-request historical deadline in seconds (5 min).
+///
+/// The floor the effective-deadline resolver applies when a caller leaves the
+/// per-request deadline unset AND the configured `request_timeout_secs` is `0`:
+/// a `0` there would disable the gRPC hang guard for every deadline-less
+/// request, so a live-but-silent server could hang the client forever. Sits
+/// above the slowest realistic bulk pull. The per-call
+/// `with_deadline(Duration::ZERO)` opt-out is a separate, explicit path and is
+/// unaffected by this floor.
+pub(crate) const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 300;
+
 /// Historical client tuning.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -87,17 +98,15 @@ pub struct HistoricalConfig {
     /// request that did not call `with_deadline(...)`, so a stalled
     /// stream resolves to `Error::Timeout` instead of blocking forever.
     ///
-    /// Configuring `0` here does **not** disable the guard: to keep the
-    /// terminal-safe behaviour, [`DirectConfig::validate`] floors a `0`
-    /// back to the production default so a deadline-less request can never
-    /// hang the client forever. Opt a single request out with the per-call
-    /// escape hatch instead.
+    /// Configuring `0` here does **not** disable the guard: the effective-
+    /// deadline resolver every historical request routes through floors a `0`
+    /// to the production default (`300s`) so a deadline-less request can never
+    /// hang the client forever, regardless of whether the config was validated.
+    /// Opt a single request out with the per-call escape hatch instead.
     ///
     /// Per-call control overrides this: `with_deadline(Duration)` sets a
     /// shorter or longer bound, and `with_deadline(Duration::ZERO)`
     /// opts a single request out of any deadline.
-    ///
-    /// [`DirectConfig::validate`]: crate::config::DirectConfig::validate
     ///
     /// Default `300s` (5 min) — comfortably above the slowest realistic
     /// multi-million-row bulk pull while still bounding a wedged stream.
@@ -160,7 +169,7 @@ impl HistoricalConfig {
             // sending no chunks (h2 keepalive only catches a fully dead
             // peer). Sits above the slowest realistic bulk pull;
             // `with_deadline(Duration::ZERO)` opts a single request out.
-            request_timeout_secs: 300,
+            request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
             // 100 MiB — empirically catches bulk pulls (multi-million
             // row option-chain or multi-day backfill responses) while
             // staying silent on ad-hoc single-day quote / OHLC pulls

--- a/thetadatadx-rs/src/config/mod.rs
+++ b/thetadatadx-rs/src/config/mod.rs
@@ -735,8 +735,11 @@ impl DirectConfig {
     /// Validate configuration values and reject out-of-range tuning knobs.
     ///
     /// Returns the configuration with historical HTTP/2 window sizes clamped
-    /// into `[64, 1024]` KB on success. Returns
-    /// [`Error::Config`] when any wired streaming
+    /// into `[64, 1024]` KB and a `0` historical `request_timeout_secs` floored
+    /// back to the production default (a `0` there disables the gRPC hang guard
+    /// for every deadline-less request — terminal-unsafe; the per-call
+    /// `with_deadline(Duration::ZERO)` opt-out is unaffected) on success.
+    /// Returns [`Error::Config`] when any wired streaming
     /// knob (`timeout_ms`, `connect_timeout_ms`, `ping_interval_ms`)
     /// falls outside its documented range — silent rounding would
     /// rewrite the caller's stated tuning under their feet, so an
@@ -938,6 +941,17 @@ impl DirectConfig {
         self.historical.window_size_kb = self.historical.window_size_kb.clamp(64, 1_024);
         self.historical.connection_window_size_kb =
             self.historical.connection_window_size_kb.clamp(64, 1_024);
+        // Floor the default request deadline to the production value rather
+        // than leave the hang guard disabled. A `0` here would opt every
+        // deadline-less request out of the gRPC timeout, so a server that
+        // holds the stream open while sending no chunks (which the h2
+        // keepalive PING cannot detect) would hang the request forever — a
+        // terminal-unsafe default. Per-call `with_deadline(Duration::ZERO)`
+        // remains the deliberate single-request opt-out.
+        if self.historical.request_timeout_secs == 0 {
+            self.historical.request_timeout_secs =
+                crate::config::HistoricalConfig::production_defaults().request_timeout_secs;
+        }
         if !flatfiles_bounds::MAX_ATTEMPTS.contains(&self.flatfiles.max_attempts) {
             return Err(Error::config_out_of_range(
                 "flatfiles.max_attempts",
@@ -1999,6 +2013,27 @@ mod tests {
             .expect("historical window sizes are clamped");
         assert_eq!(config.historical.window_size_kb, 1_024);
         assert_eq!(config.historical.connection_window_size_kb, 64);
+    }
+
+    #[test]
+    fn validate_floors_zero_request_timeout_to_default() {
+        // A `0` default deadline would opt every deadline-less request out of
+        // the gRPC hang guard; validation floors it back to the production
+        // default so a silent-but-live server cannot hang the client forever.
+        let mut config = DirectConfig::production_defaults();
+        config.historical.request_timeout_secs = 0;
+        let config = config.validate().expect("zero request timeout is floored");
+        assert_eq!(
+            config.historical.request_timeout_secs,
+            HistoricalConfig::production_defaults().request_timeout_secs,
+        );
+        // A non-zero caller value is preserved untouched.
+        let mut config = DirectConfig::production_defaults();
+        config.historical.request_timeout_secs = 42;
+        let config = config
+            .validate()
+            .expect("non-zero request timeout is preserved");
+        assert_eq!(config.historical.request_timeout_secs, 42);
     }
 
     #[test]

--- a/thetadatadx-rs/src/config/mod.rs
+++ b/thetadatadx-rs/src/config/mod.rs
@@ -60,6 +60,7 @@ pub use fpss::{
     bounds as streaming_bounds, HostSelectionPolicy, StreamingConfig, StreamingFlushMode,
 };
 pub use mdds::HistoricalConfig;
+pub(crate) use mdds::DEFAULT_REQUEST_TIMEOUT_SECS;
 pub use metrics::MetricsConfig;
 pub use reconnect::{
     bounds as reconnect_bounds, ReconnectAttemptClass, ReconnectAttemptLimits, ReconnectConfig,
@@ -735,11 +736,8 @@ impl DirectConfig {
     /// Validate configuration values and reject out-of-range tuning knobs.
     ///
     /// Returns the configuration with historical HTTP/2 window sizes clamped
-    /// into `[64, 1024]` KB and a `0` historical `request_timeout_secs` floored
-    /// back to the production default (a `0` there disables the gRPC hang guard
-    /// for every deadline-less request — terminal-unsafe; the per-call
-    /// `with_deadline(Duration::ZERO)` opt-out is unaffected) on success.
-    /// Returns [`Error::Config`] when any wired streaming
+    /// into `[64, 1024]` KB on success. Returns
+    /// [`Error::Config`] when any wired streaming
     /// knob (`timeout_ms`, `connect_timeout_ms`, `ping_interval_ms`)
     /// falls outside its documented range — silent rounding would
     /// rewrite the caller's stated tuning under their feet, so an
@@ -941,17 +939,12 @@ impl DirectConfig {
         self.historical.window_size_kb = self.historical.window_size_kb.clamp(64, 1_024);
         self.historical.connection_window_size_kb =
             self.historical.connection_window_size_kb.clamp(64, 1_024);
-        // Floor the default request deadline to the production value rather
-        // than leave the hang guard disabled. A `0` here would opt every
-        // deadline-less request out of the gRPC timeout, so a server that
-        // holds the stream open while sending no chunks (which the h2
-        // keepalive PING cannot detect) would hang the request forever — a
-        // terminal-unsafe default. Per-call `with_deadline(Duration::ZERO)`
-        // remains the deliberate single-request opt-out.
-        if self.historical.request_timeout_secs == 0 {
-            self.historical.request_timeout_secs =
-                crate::config::HistoricalConfig::production_defaults().request_timeout_secs;
-        }
+        // NOTE: a `0` historical `request_timeout_secs` is NOT floored here.
+        // The floor lives at the single consumption point
+        // ([`crate::mdds::macros::effective_deadline`]) so the gRPC hang guard
+        // holds even for callers who never run `validate` — the connect paths
+        // and the SDK bindings pass unvalidated config snapshots. Flooring only
+        // here would leave those paths exposed.
         if !flatfiles_bounds::MAX_ATTEMPTS.contains(&self.flatfiles.max_attempts) {
             return Err(Error::config_out_of_range(
                 "flatfiles.max_attempts",
@@ -2013,27 +2006,6 @@ mod tests {
             .expect("historical window sizes are clamped");
         assert_eq!(config.historical.window_size_kb, 1_024);
         assert_eq!(config.historical.connection_window_size_kb, 64);
-    }
-
-    #[test]
-    fn validate_floors_zero_request_timeout_to_default() {
-        // A `0` default deadline would opt every deadline-less request out of
-        // the gRPC hang guard; validation floors it back to the production
-        // default so a silent-but-live server cannot hang the client forever.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.request_timeout_secs = 0;
-        let config = config.validate().expect("zero request timeout is floored");
-        assert_eq!(
-            config.historical.request_timeout_secs,
-            HistoricalConfig::production_defaults().request_timeout_secs,
-        );
-        // A non-zero caller value is preserved untouched.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.request_timeout_secs = 42;
-        let config = config
-            .validate()
-            .expect("non-zero request timeout is preserved");
-        assert_eq!(config.historical.request_timeout_secs, 42);
     }
 
     #[test]

--- a/thetadatadx-rs/src/mdds/client.rs
+++ b/thetadatadx-rs/src/mdds/client.rs
@@ -237,6 +237,25 @@ impl HistoricalClient {
         &self.config
     }
 
+    /// Deterministically tear the historical client down.
+    ///
+    /// The historical client owns only the `Arc`-backed gRPC [`ChannelPool`] —
+    /// a set of idle HTTP/2 connections with no worker thread and no streaming
+    /// state machine — so there is nothing to signal or join here: the pool's
+    /// connections are released when the last client handle is dropped (RAII).
+    /// This method exists so the historical surface matches the unified
+    /// [`crate::Client::close`] across every binding (`close()` /
+    /// context-manager exit / destructor); the deterministic point of release
+    /// is the binding dropping its owning handle on `close`. Idempotent.
+    ///
+    /// [`ChannelPool`]: crate::grpc::ChannelPool
+    pub fn close(&self) {
+        // No streaming dispatcher and no owned worker thread: the channel pool
+        // releases on handle drop. Kept as an explicit no-op so the base/
+        // historical lifecycle surface is uniform across bindings rather than
+        // silently absent on the historical-only path.
+    }
+
     /// Return the session UUID. Reads through the shared session token
     /// so the value reflects any mid-session refresh.
     pub async fn session_uuid(&self) -> String {

--- a/thetadatadx-rs/src/mdds/client.rs
+++ b/thetadatadx-rs/src/mdds/client.rs
@@ -239,7 +239,7 @@ impl HistoricalClient {
 
     /// Deterministically tear the historical client down.
     ///
-    /// The historical client owns only the `Arc`-backed gRPC [`ChannelPool`] —
+    /// The historical client owns only the `Arc`-backed gRPC channel pool —
     /// a set of idle HTTP/2 connections with no worker thread and no streaming
     /// state machine — so there is nothing to signal or join here: the pool's
     /// connections are released when the last client handle is dropped (RAII).
@@ -247,8 +247,6 @@ impl HistoricalClient {
     /// [`crate::Client::close`] across every binding (`close()` /
     /// context-manager exit / destructor); the deterministic point of release
     /// is the binding dropping its owning handle on `close`. Idempotent.
-    ///
-    /// [`ChannelPool`]: crate::grpc::ChannelPool
     pub fn close(&self) {
         // No streaming dispatcher and no owned worker thread: the channel pool
         // releases on handle drop. Kept as an explicit no-op so the base/

--- a/thetadatadx-rs/src/mdds/macros.rs
+++ b/thetadatadx-rs/src/mdds/macros.rs
@@ -43,8 +43,15 @@
 /// fall back to the configured
 /// [`crate::config::HistoricalConfig::request_timeout_secs`] default so a
 /// server holding the stream open without sending chunks cannot hang the
-/// request indefinitely. A configured default of `0` disables the
-/// fallback.
+/// request indefinitely.
+///
+/// A configured default of `0` does NOT disable the fallback: it is floored to
+/// the production default here — the single
+/// point every historical request routes through — so the gRPC hang guard
+/// holds regardless of whether [`crate::config::DirectConfig::validate`] ran
+/// on the config (the connect paths and the SDK bindings pass unvalidated
+/// snapshots). The only way to run a request with no deadline is the explicit
+/// per-call `with_deadline(Duration::ZERO)` opt-out above.
 pub(crate) fn effective_deadline(
     explicit: Option<std::time::Duration>,
     default_secs: u64,
@@ -54,7 +61,17 @@ pub(crate) fn effective_deadline(
         // deadline" rather than a zero-length timeout that fires at once.
         Some(d) if d.is_zero() => None,
         Some(d) => Some(d),
-        None => (default_secs > 0).then(|| std::time::Duration::from_secs(default_secs)),
+        // Unset: fall back to the configured default, flooring a `0` (which
+        // would otherwise disable the guard) to the terminal-safe default so a
+        // silent-but-live server cannot hang a deadline-less request forever.
+        None => {
+            let secs = if default_secs == 0 {
+                crate::config::DEFAULT_REQUEST_TIMEOUT_SECS
+            } else {
+                default_secs
+            };
+            Some(std::time::Duration::from_secs(secs))
+        }
     }
 }
 
@@ -1239,13 +1256,20 @@ mod effective_deadline_tests {
         );
     }
 
-    /// `with_deadline(Duration::ZERO)` normalizes to `None` at the
-    /// builder, opting the request out of any deadline. A configured
-    /// default of `0` must NOT silently re-impose one on that request,
-    /// so a `0` default leaves the explicit opt-out intact.
+    /// A configured default of `0` is FLOORED to the production default
+    /// rather than disabling the guard: a deadline-less request must never be
+    /// left unbounded just because the config carried a `0` (validated or
+    /// not). This is the single consumption-point floor — the only way to run
+    /// a request with no deadline is the explicit `with_deadline(Duration::ZERO)`
+    /// opt-out (covered separately), NOT a `0` in the config.
     #[test]
-    fn zero_default_disables_the_fallback() {
-        assert_eq!(effective_deadline(None, 0), None);
+    fn zero_default_is_floored_to_the_production_default() {
+        assert_eq!(
+            effective_deadline(None, 0),
+            Some(Duration::from_secs(
+                crate::config::DEFAULT_REQUEST_TIMEOUT_SECS
+            )),
+        );
     }
 
     /// The production default seeds a positive per-request deadline, so

--- a/thetadatadx-ts/__tests__/base_client_lifecycle.test.mjs
+++ b/thetadatadx-ts/__tests__/base_client_lifecycle.test.mjs
@@ -72,8 +72,9 @@ describe('base-client lifecycle surface', () => {
       close() { calls.push('close'); },
     };
     await mod.Client.prototype[Symbol.asyncDispose].call(fake);
-    // Streaming surface present → stop + drain, never the close() fallback.
-    assert.deepEqual(calls, ['stopStreaming', ['awaitDrain', 5000]]);
+    // Streaming surface present → drain first (stop + awaitDrain), THEN the
+    // deterministic close() so the registered callback is released back to V8.
+    assert.deepEqual(calls, ['stopStreaming', ['awaitDrain', 5000], 'close']);
   });
 
   it('[Symbol.asyncDispose] warns (does not throw) when the drain times out', async () => {

--- a/thetadatadx-ts/__tests__/base_client_lifecycle.test.mjs
+++ b/thetadatadx-ts/__tests__/base_client_lifecycle.test.mjs
@@ -1,0 +1,108 @@
+// Base-client lifecycle tests (issue #1069): the deterministic `close()`
+// plus the TC39 `[Symbol.dispose]` / `[Symbol.asyncDispose]` disposers that
+// `using` / `await using` invoke on scope exit.
+//
+// Pins that:
+//   * `Client` and `HistoricalClient` expose `close()` (napi-generated) and
+//     the two disposer symbols (patched on at require time);
+//   * the sync disposer routes through `close()`;
+//   * the async disposer on the unified client pairs `stopStreaming()` with
+//     `awaitDrain(5000)` and warns (never throws) on drain timeout;
+//   * the async disposer on the historical-only surface (no `.stream`) falls
+//     back to `close()`.
+//
+// Runs without a live FPSS handshake: the disposer bodies read `this.stream`
+// / `this.close`, so they are invoked against in-memory fakes via `.call()`,
+// keeping the test unit-scoped and credential-free. The native binding is
+// loaded only to confirm the methods are wired onto the real prototypes.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const wrapperImportPath = '../streaming-session.js';
+
+let mod;
+try {
+  const imported = await import(wrapperImportPath);
+  mod = imported.default ?? imported;
+} catch {
+  console.error('FAIL: native addon not built; run `npm run build` first');
+  process.exit(1);
+}
+
+describe('base-client lifecycle surface', () => {
+  it('Client exposes close() and both disposer symbols', () => {
+    assert.equal(typeof mod.Client, 'function');
+    assert.equal(typeof mod.Client.prototype.close, 'function', 'Client.close()');
+    assert.equal(
+      typeof mod.Client.prototype[Symbol.dispose],
+      'function',
+      'Client[Symbol.dispose]',
+    );
+    assert.equal(
+      typeof mod.Client.prototype[Symbol.asyncDispose],
+      'function',
+      'Client[Symbol.asyncDispose]',
+    );
+  });
+
+  it('HistoricalClient exposes close() and both disposer symbols', () => {
+    assert.equal(typeof mod.HistoricalClient, 'function');
+    assert.equal(typeof mod.HistoricalClient.prototype.close, 'function');
+    assert.equal(typeof mod.HistoricalClient.prototype[Symbol.dispose], 'function');
+    assert.equal(typeof mod.HistoricalClient.prototype[Symbol.asyncDispose], 'function');
+  });
+
+  it('[Symbol.dispose] routes through close()', () => {
+    let closed = 0;
+    const fake = { close() { closed += 1; } };
+    mod.Client.prototype[Symbol.dispose].call(fake);
+    assert.equal(closed, 1, 'sync dispose must call close() exactly once');
+  });
+
+  it('[Symbol.asyncDispose] pairs stopStreaming with awaitDrain on the unified client', async () => {
+    const calls = [];
+    const fake = {
+      stream: {
+        stopStreaming() { calls.push('stopStreaming'); },
+        async awaitDrain(timeoutMs) {
+          calls.push(['awaitDrain', timeoutMs]);
+          return true;
+        },
+      },
+      close() { calls.push('close'); },
+    };
+    await mod.Client.prototype[Symbol.asyncDispose].call(fake);
+    // Streaming surface present → stop + drain, never the close() fallback.
+    assert.deepEqual(calls, ['stopStreaming', ['awaitDrain', 5000]]);
+  });
+
+  it('[Symbol.asyncDispose] warns (does not throw) when the drain times out', async () => {
+    const fake = {
+      stream: {
+        stopStreaming() {},
+        async awaitDrain() { return false; },
+      },
+      close() {},
+    };
+    const originalWarn = console.warn;
+    const warned = [];
+    console.warn = (msg) => warned.push(msg);
+    try {
+      await mod.Client.prototype[Symbol.asyncDispose].call(fake);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.equal(warned.length, 1, 'exactly one warning on drain timeout');
+    assert.match(warned[0], /drain timed out/);
+    assert.match(warned[0], /5000ms/);
+  });
+
+  it('[Symbol.asyncDispose] falls back to close() with no streaming surface', async () => {
+    let closed = 0;
+    // Historical-only shape: no `.stream`. The async disposer must not throw
+    // reaching for `stopStreaming`; it closes instead.
+    const fake = { stream: undefined, close() { closed += 1; } };
+    await mod.HistoricalClient.prototype[Symbol.asyncDispose].call(fake);
+    assert.equal(closed, 1, 'historical async dispose must call close() exactly once');
+  });
+});

--- a/thetadatadx-ts/__tests__/mdds_client.test.mjs
+++ b/thetadatadx-ts/__tests__/mdds_client.test.mjs
@@ -105,9 +105,12 @@ describe('HistoricalClient carries the historical surface', () => {
     // client-level member that lives on the unified `Client` itself, not on
     // its `client.historical` view, so it is mirrored onto `HistoricalClient`
     // directly and pinned against the unified `Client` in its own block
-    // above. Exclude both so this comparison pins the generated data-fetch
-    // surface.
-    const LIFECYCLE = new Set(['connect', 'connectFromFile', 'flatFileToPath']);
+    // above. `close` is a client-lifecycle method (deterministic teardown)
+    // that lives on the standalone `HistoricalClient` but not on the
+    // `client.historical` sub-view — you close the owning `Client`, not its
+    // view — so it is likewise excluded. Exclude all so this comparison pins
+    // the generated data-fetch surface.
+    const LIFECYCLE = new Set(['connect', 'connectFromFile', 'flatFileToPath', 'close']);
     // Every data-fetch method the MDDS-only client exposes must also exist
     // on the unified client's `client.historical` view — the historical
     // surface is generated identically onto both, so the MDDS set is a

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -77,6 +77,22 @@ export declare class Client {
    * `async` for the same reason as [`Client::connect`].
    */
   static connectWith(options: ClientConnectOptions): Promise<Client>
+  /**
+   * Deterministically close the client.
+   *
+   * Stops streaming if it is live (idempotent) and releases the registered
+   * callback back to V8. The historical gRPC channel pool releases when the
+   * last handle to this client is dropped. Safe to call more than once and
+   * safe on a client that only ran historical queries.
+   *
+   * This is the recommended teardown. Prefer the `using` declaration
+   * (`using client = connect(...)`) so `close()` runs on scope exit through
+   * `[Symbol.dispose]`; for a full streaming-drain barrier use the
+   * `[Symbol.asyncDispose]` pairing (`stopStreaming()` + `awaitDrain`) the
+   * context-managed session exposes. `close()` performs the stop; the core
+   * dispatcher join is detached so this never blocks the JS thread.
+   */
+  close(): void
   /** FLATFILES namespace handle. Cheap — shares the underlying client connection. */
   get flatFiles(): FlatFilesNamespace
   /**
@@ -808,6 +824,17 @@ export declare class HistoricalClient {
    * `async` for the same reason as [`HistoricalClient::connect`].
    */
   static connectFromFile(path: string, config?: Config | undefined | null): Promise<HistoricalClient>
+  /**
+   * Deterministically close the historical client.
+   *
+   * The historical-only surface never opens streaming, so there is no
+   * dispatcher to drain; the gRPC channel pool releases when the last handle
+   * to this client is dropped. Provided so the historical surface matches the
+   * unified `Client` lifecycle across every binding. Idempotent. Prefer the
+   * `using` declaration (`using c = await HistoricalClient.connect(...)`) so
+   * `close()` runs on scope exit through `[Symbol.dispose]`.
+   */
+  close(): void
   /**
    * List all available stock ticker symbols.
    *

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -89,8 +89,15 @@ export declare class Client {
    * (`using client = connect(...)`) so `close()` runs on scope exit through
    * `[Symbol.dispose]`; for a full streaming-drain barrier use the
    * `[Symbol.asyncDispose]` pairing (`stopStreaming()` + `awaitDrain`) the
-   * context-managed session exposes. `close()` performs the stop; the core
-   * dispatcher join is detached so this never blocks the JS thread.
+   * context-managed session exposes.
+   *
+   * `close()` retires the streaming dispatcher synchronously on the calling
+   * thread, so it can block briefly while the dispatcher drains its
+   * in-flight events. The non-blocking detach (a teardown that returns
+   * immediately and finishes on a helper thread) applies only to the
+   * implicit `Drop` path, which must not block a thread that may hold a
+   * runtime lock the dispatcher re-enters. Callers wanting a non-blocking
+   * release let the handle drop instead of calling `close()`.
    */
   close(): void
   /** FLATFILES namespace handle. Cheap — shares the underlying client connection. */

--- a/thetadatadx-ts/src/lib.rs
+++ b/thetadatadx-ts/src/lib.rs
@@ -964,6 +964,26 @@ impl Client {
             callback: Arc::new(Mutex::new(None)),
         })
     }
+
+    /// Deterministically close the client.
+    ///
+    /// Stops streaming if it is live (idempotent) and releases the registered
+    /// callback back to V8. The historical gRPC channel pool releases when the
+    /// last handle to this client is dropped. Safe to call more than once and
+    /// safe on a client that only ran historical queries.
+    ///
+    /// This is the recommended teardown. Prefer the `using` declaration
+    /// (`using client = connect(...)`) so `close()` runs on scope exit through
+    /// `[Symbol.dispose]`; for a full streaming-drain barrier use the
+    /// `[Symbol.asyncDispose]` pairing (`stopStreaming()` + `awaitDrain`) the
+    /// context-managed session exposes. `close()` performs the stop; the core
+    /// dispatcher join is detached so this never blocks the JS thread.
+    #[napi]
+    pub fn close(&self) {
+        self.client.stream().stop_streaming();
+        let mut guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = None;
+    }
 }
 
 #[napi]
@@ -1187,6 +1207,22 @@ impl HistoricalClient {
     ) -> napi::Result<HistoricalClient> {
         let client = connect_historical_from_file_core(path, config_or_production(config)).await?;
         Ok(HistoricalClient { client })
+    }
+
+    /// Deterministically close the historical client.
+    ///
+    /// The historical-only surface never opens streaming, so there is no
+    /// dispatcher to drain; the gRPC channel pool releases when the last handle
+    /// to this client is dropped. Provided so the historical surface matches the
+    /// unified `Client` lifecycle across every binding. Idempotent. Prefer the
+    /// `using` declaration (`using c = await HistoricalClient.connect(...)`) so
+    /// `close()` runs on scope exit through `[Symbol.dispose]`.
+    #[napi]
+    pub fn close(&self) {
+        // No streaming dispatcher on the historical-only surface; the channel
+        // pool releases on handle drop. Kept explicit so the lifecycle surface
+        // is uniform across bindings.
+        self.client.close();
     }
 }
 

--- a/thetadatadx-ts/src/lib.rs
+++ b/thetadatadx-ts/src/lib.rs
@@ -976,8 +976,15 @@ impl Client {
     /// (`using client = connect(...)`) so `close()` runs on scope exit through
     /// `[Symbol.dispose]`; for a full streaming-drain barrier use the
     /// `[Symbol.asyncDispose]` pairing (`stopStreaming()` + `awaitDrain`) the
-    /// context-managed session exposes. `close()` performs the stop; the core
-    /// dispatcher join is detached so this never blocks the JS thread.
+    /// context-managed session exposes.
+    ///
+    /// `close()` retires the streaming dispatcher synchronously on the calling
+    /// thread, so it can block briefly while the dispatcher drains its
+    /// in-flight events. The non-blocking detach (a teardown that returns
+    /// immediately and finishes on a helper thread) applies only to the
+    /// implicit `Drop` path, which must not block a thread that may hold a
+    /// runtime lock the dispatcher re-enters. Callers wanting a non-blocking
+    /// release let the handle drop instead of calling `close()`.
     #[napi]
     pub fn close(&self) {
         self.client.stream().stop_streaming();

--- a/thetadatadx-ts/streaming-session.d.ts
+++ b/thetadatadx-ts/streaming-session.d.ts
@@ -15,7 +15,7 @@
 
 /* eslint-disable */
 
-import type { Client, StreamView, StreamEvent, ContractRef } from './index';
+import type { Client, HistoricalClient, StreamView, StreamEvent, ContractRef } from './index';
 
 export * from './index';
 
@@ -122,6 +122,38 @@ declare module './index' {
      * normally so any error from the body is not masked.
      */
     streaming(callback: StreamEventCallback): Promise<StreamingSession>;
+
+    /**
+     * TC39 explicit resource management: `using client = connect(...)` calls
+     * this on synchronous scope exit. Runs {@link Client.close} — stops
+     * streaming if live and releases the callback. For a streaming-drain
+     * barrier before release, use `await using` ({@link Client[Symbol.asyncDispose]})
+     * or the context-managed session.
+     */
+    [Symbol.dispose](): void;
+
+    /**
+     * TC39 explicit resource management: `await using client = ...` calls this
+     * on scope exit. Stops streaming and awaits the drain barrier so the
+     * consumer thread has finished firing the registered callback before the
+     * JS closure is released. Drain timeouts emit `console.warn` rather than
+     * throwing, so an error from the `using` body is not masked.
+     */
+    [Symbol.asyncDispose](): Promise<void>;
+  }
+
+  interface HistoricalClient {
+    /**
+     * TC39 explicit resource management: `using client = await
+     * HistoricalClient.connect(...)` calls this on scope exit. Runs
+     * {@link HistoricalClient.close}. The historical-only surface has no
+     * streaming to drain, so the sync and async disposers are equivalent.
+     */
+    [Symbol.dispose](): void;
+
+    /** Async counterpart of {@link HistoricalClient[Symbol.dispose]}; no
+     * streaming drain on the historical-only surface. */
+    [Symbol.asyncDispose](): Promise<void>;
   }
 
   interface StreamView {

--- a/thetadatadx-ts/streaming-session.js
+++ b/thetadatadx-ts/streaming-session.js
@@ -407,20 +407,26 @@ for (const Klass of [native.Client, native.HistoricalClient]) {
   if (typeof Klass.prototype[Symbol.asyncDispose] !== 'function') {
     Klass.prototype[Symbol.asyncDispose] = async function asyncDispose() {
       // `stream` exists only on the unified `Client`; the historical-only
-      // client has no streaming surface, so fall back to `close()` there.
+      // client has no streaming surface, so `close()` alone is the teardown.
       const stream = this.stream;
-      if (!stream) {
-        this.close();
-        return;
+      if (stream) {
+        // Await the drain barrier first so the consumer thread has finished
+        // firing the registered callback before the JS closure is released;
+        // warn (never throw) on timeout to match the context-managed session.
+        stream.stopStreaming();
+        const drained = await stream.awaitDrain(EXIT_DRAIN_TIMEOUT_MS);
+        if (!drained) {
+          console.warn(
+            `Client close drain timed out after ${EXIT_DRAIN_TIMEOUT_MS}ms; ` +
+              'the streaming consumer callback may still be firing.',
+          );
+        }
       }
-      stream.stopStreaming();
-      const drained = await stream.awaitDrain(EXIT_DRAIN_TIMEOUT_MS);
-      if (!drained) {
-        console.warn(
-          `Client close drain timed out after ${EXIT_DRAIN_TIMEOUT_MS}ms; ` +
-            'the streaming consumer callback may still be firing.',
-        );
-      }
+      // Always run the deterministic close: it releases the registered
+      // callback back to V8 and is the single teardown the sync disposer also
+      // routes through. Skipping it would leak the callback reference on the
+      // `await using` path. Idempotent after the stop above.
+      this.close();
     };
   }
 }

--- a/thetadatadx-ts/streaming-session.js
+++ b/thetadatadx-ts/streaming-session.js
@@ -389,6 +389,42 @@ if (
   };
 }
 
+// TC39 explicit resource management on the base clients. `close()` is the
+// napi-generated deterministic teardown; these computed-symbol members cannot
+// be emitted by napi-rs (it names only identifier methods), so they are patched
+// on here — the same wrapper-side pattern as `streaming()` and the
+// `StreamingSession` disposers. `[Symbol.dispose]` backs `using client = ...`
+// (sync scope exit); `[Symbol.asyncDispose]` backs `await using client = ...`
+// and additionally awaits the streaming drain barrier so a callback closure is
+// safe to release, warning (never throwing) on timeout to match the session.
+for (const Klass of [native.Client, native.HistoricalClient]) {
+  if (!Klass) continue;
+  if (typeof Klass.prototype[Symbol.dispose] !== 'function') {
+    Klass.prototype[Symbol.dispose] = function dispose() {
+      this.close();
+    };
+  }
+  if (typeof Klass.prototype[Symbol.asyncDispose] !== 'function') {
+    Klass.prototype[Symbol.asyncDispose] = async function asyncDispose() {
+      // `stream` exists only on the unified `Client`; the historical-only
+      // client has no streaming surface, so fall back to `close()` there.
+      const stream = this.stream;
+      if (!stream) {
+        this.close();
+        return;
+      }
+      stream.stopStreaming();
+      const drained = await stream.awaitDrain(EXIT_DRAIN_TIMEOUT_MS);
+      if (!drained) {
+        console.warn(
+          `Client close drain timed out after ${EXIT_DRAIN_TIMEOUT_MS}ms; ` +
+            'the streaming consumer callback may still be firing.',
+        );
+      }
+    };
+  }
+}
+
 
 // Re-cast typed errors on every native entrypoint — instance method,
 // static factory, or free function. The Rust binding tags every


### PR DESCRIPTION
Closes #1069.

## Problem

The base and historical clients had no explicit shutdown: no `close()`, no context-manager, no deterministic teardown, while the streaming surfaces did. On Python, dropping a client that had started streaming without first calling `stop_streaming()` could deadlock. The drop runs with the GIL held, the core teardown joins the dispatcher thread, and the dispatcher needs the GIL to finish an in-flight callback.

## Fix

The client drop now detaches the dispatcher join onto a helper thread, so the drop returns immediately, releases the GIL, and the dispatcher drains cleanly. A start-streaming-then-drop path no longer hangs.

Adds a deterministic `close()` plus idiomatic context-manager / RAII on the base and historical clients across all four bindings: Python `close()` with `__enter__`/`__exit__` and `__aenter__`/`__aexit__`, TypeScript `close()` with `[Symbol.dispose]`/`[Symbol.asyncDispose]`, C++ `close()`, and Rust `close()`. `close()` releases the connection deterministically and, when streaming is active, pairs `stop_streaming()`.

A `request_timeout_secs` of `0` is now floored to the default rather than disabling the historical request timeout. The per-call zero-duration opt-out is unchanged.

## Tests

Core, Python, and TypeScript suites pass, including a test that a start-streaming-then-drop path completes without deadlock and that `close()` is idempotent and safe after streaming. Cross-binding parity is clean with no C-ABI symbol changes.