### PR TITLE
fix(client)!: close() releases the client and rejects further use

### DIFF
--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -2214,6 +2214,13 @@ CLIENT_REVERSE_ORPHAN_EXEMPT_MEMBERS: frozenset[str] = frozenset(
         # harvests. Not exposed to Python, so it carries no cross-binding
         # contract and is enrolled by the public `close` row instead.
         "closeImpl",
+        # Private closed-guard accessor resolving the live core handle (or a
+        # "client is closed" error) behind every vended surface; a plain
+        # (non-`#[pymethods]`) `impl Client` helper the collector harvests. Not
+        # exposed to Python — the TypeScript twin (`clientHandle`) is likewise a
+        # plain `impl` helper the napi collector never sees — so it carries no
+        # cross-binding contract.
+        "clientArc",
     }
 )
 

--- a/thetadatadx-cpp/tests/lifecycle.cpp
+++ b/thetadatadx-cpp/tests/lifecycle.cpp
@@ -213,3 +213,27 @@ TEST_CASE("close() is idempotent and safe before destruction", "[lifecycle][live
     REQUIRE_NOTHROW(historical.close());
     REQUIRE_NOTHROW(historical.close());
 }
+
+TEST_CASE("close() releases the handle deterministically", "[lifecycle][live]") {
+    const auto creds_path = env_or_empty("THETADATADX_LIVE_CREDS");
+    if (creds_path.empty()) {
+        SKIP("THETADATADX_LIVE_CREDS not set");
+    }
+    auto creds = thetadatadx::Credentials::from_file(creds_path);
+    auto config = thetadatadx::Config::production();
+
+    // Cross-binding parity anchor (the Python / TypeScript bindings match this):
+    // close() RELEASES the client handle, so the client is unusable afterward.
+    // The public raw-handle accessor going null is the deterministic-release
+    // proof — the historical gRPC channel pool is freed at close, not at some
+    // later GC. `HistoricalClient` releases through the same `handle_.reset()`
+    // path (its handle accessor is private, so the idempotent-close case above
+    // is its observable pin).
+    auto client = thetadatadx::Client::connect(creds, config);
+    REQUIRE(client.get() != nullptr);
+    client.close();
+    REQUIRE(client.get() == nullptr);
+    // Idempotent after release: the accessor stays null, no double-free.
+    client.close();
+    REQUIRE(client.get() == nullptr);
+}

--- a/thetadatadx-py/src/flatfile_methods.rs
+++ b/thetadatadx-py/src/flatfile_methods.rs
@@ -325,10 +325,10 @@ impl crate::Client {
     /// `flat_files = client.flat_files` in user code is identical to
     /// calling `client.flat_files.option_eod(...)` inline.
     #[getter]
-    fn flat_files(&self) -> FlatFilesNamespace {
-        FlatFilesNamespace {
-            client: Arc::clone(&self.client),
-        }
+    fn flat_files(&self) -> PyResult<FlatFilesNamespace> {
+        Ok(FlatFilesNamespace {
+            client: self.client_arc()?,
+        })
     }
 
     /// Pull a flat-file blob and write the requested format directly to
@@ -353,7 +353,7 @@ impl crate::Client {
         let sec = parse_flatfile_sec_type(sec_type)?;
         let req = parse_flatfile_req_type(req_type)?;
         let fmt = parse_flatfile_format(format)?;
-        let client = Arc::clone(&self.client);
+        let client = self.client_arc()?;
         let date_owned = date.to_string();
         let path_owned = std::path::PathBuf::from(path);
         let final_path = run_blocking(py, async move {
@@ -383,7 +383,7 @@ impl crate::Client {
         let sec = parse_flatfile_sec_type(sec_type)?;
         let req = parse_flatfile_req_type(req_type)?;
         let fmt = parse_flatfile_format(format)?;
-        let client = Arc::clone(&self.client);
+        let client = self.client_arc()?;
         let date_owned = date.to_string();
         let path_owned = std::path::PathBuf::from(path);
         spawn_awaitable(

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -678,29 +678,29 @@ fn resolve_direct_config(
 struct Client {
     /// The underlying Rust unified client (Deref to HistoricalClient for historical).
     ///
-    /// Wrapped in `Arc<>` so the per-endpoint fluent builder pyclasses
-    /// emitted by the generator (`<Endpoint>Builder`) can clone a cheap
-    /// handle into the awaitable returned by `*_async()` terminals. The
-    /// inner `thetadatadx::Client` is not `Clone` — its
-    /// streaming mutex and subscription-tier state forbid it — so the
-    /// builder cannot hold the value directly without Arc ref-counting.
+    /// Held as `Option` behind a `Mutex` so `close()` can DETERMINISTICALLY
+    /// RELEASE the handle: closing takes the `Arc<Client>` out of the slot and
+    /// drops it, so the historical gRPC channel pool is freed once the last
+    /// co-owning surface (a `HistoricalView` / `StreamView` / builder /
+    /// flat-files namespace vended before close) is also gone — matching the
+    /// C++ wrapper, where `close()` resets the handle. A closed slot (`None`)
+    /// makes every access via [`Client::client_arc`] raise "client is closed",
+    /// so the client is UNUSABLE after close and a second close is a no-op.
     ///
-    /// Shutdown contract: when the pyclass auto-drops while the GIL is
-    /// held, the final `Arc::drop` may trigger the core
-    /// `Client::Drop` chain, which joins the streaming dispatcher
-    /// thread that itself re-acquires the GIL via `Python::attach`.
-    /// Holding the GIL across that join would deadlock. Callers MUST
-    /// invoke `stop_streaming()` (the generated method uses `py.detach`
-    /// around the teardown so the dispatcher exits cleanly) before
-    /// letting the pyclass fall out of scope. The `with client.streaming(cb)`
-    /// context manager pairs `start_streaming(cb)` with
+    /// The inner `thetadatadx::Client` is not `Clone` — its streaming mutex and
+    /// subscription-tier state forbid it — so surfaces co-own a cheap
+    /// `Arc<Client>` clone (survivng past a parent close, exactly as the C++
+    /// `Historical` / `Stream` views co-own the `shared_ptr`).
+    ///
+    /// Deadlock-safe drop: the core `Client::Drop` runs the DETACHED streaming
+    /// quiesce (never a GIL-reacquiring join), so dropping the taken `Arc` on
+    /// the calling thread — even with the GIL held — cannot deadlock.
+    /// `close()` still stops streaming and drains synchronously (GIL released)
+    /// before the drop. The `with client.streaming(cb)` context manager
+    /// pairs `start_streaming(cb)` with
     /// `stop_streaming() + await_drain(5000)` on exit to enforce this
-    /// ordering automatically. The fully-shared `Arc<>` (cloned into
-    /// every fluent builder pyclass) cannot enforce the contract at the
-    /// `Drop` site without restructuring every accessor, so the
-    /// invariant is enforced by documentation plus the explicit
-    /// `stop_streaming(py)` path.
-    client: std::sync::Arc<thetadatadx::Client>,
+    /// ordering automatically.
+    client: std::sync::Mutex<Option<std::sync::Arc<thetadatadx::Client>>>,
     /// User-registered Python callable that receives every streaming
     /// event after `start_streaming(callback)` succeeds. The dispatcher's
     /// drain thread acquires the GIL via `Python::attach` to invoke
@@ -735,9 +735,27 @@ impl Client {
             thetadatadx::Client::connect(&creds, direct_config).await
         })?;
         Ok(Self {
-            client: std::sync::Arc::new(client),
+            client: std::sync::Mutex::new(Some(std::sync::Arc::new(client))),
             callback: Arc::new(Mutex::new(None)),
         })
+    }
+
+    /// The live core client handle, or a "client is closed" error.
+    ///
+    /// Every surface the client vends (`historical` / `stream` / `flat_files`)
+    /// resolves the handle through here, so once `close()` has taken it the
+    /// client is uniformly unusable. Returns a cheap `Arc` clone the caller
+    /// co-owns.
+    pub(crate) fn client_arc(&self) -> PyResult<Arc<thetadatadx::Client>> {
+        self.client
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "client is closed; construct a new client to make further calls",
+                )
+            })
     }
 }
 
@@ -915,7 +933,15 @@ impl Client {
     // one place to audit.
 
     fn __repr__(&self) -> String {
-        let streaming = if self.client.stream().is_streaming() {
+        let Some(client) = self
+            .client
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+        else {
+            return "Client(closed)".to_string();
+        };
+        let streaming = if client.stream().is_streaming() {
             "streaming=connected"
         } else {
             "streaming=none"
@@ -930,10 +956,10 @@ impl Client {
     /// storing `hist = client.historical` is identical to calling
     /// `client.historical.<endpoint>(...)` inline.
     #[getter]
-    fn historical(&self) -> HistoricalView {
-        HistoricalView {
-            client: Arc::clone(&self.client),
-        }
+    fn historical(&self) -> PyResult<HistoricalView> {
+        Ok(HistoricalView {
+            client: self.client_arc()?,
+        })
     }
 
     /// Real-time-streaming sub-namespace: `client.stream.subscribe(...)`,
@@ -943,11 +969,11 @@ impl Client {
     /// parent's callback slot, so the streaming lifecycle observed through
     /// the view is the same one the unified client manages.
     #[getter]
-    fn stream(&self) -> StreamView {
-        StreamView {
-            client: Arc::clone(&self.client),
+    fn stream(&self) -> PyResult<StreamView> {
+        Ok(StreamView {
+            client: self.client_arc()?,
             callback: Arc::clone(&self.callback),
-        }
+        })
     }
 
     /// Deterministically close the client.
@@ -1020,19 +1046,32 @@ impl Client {
     /// Mirrors the `StreamingSession` context-manager exit and the C ABI
     /// `thetadatadx_client_free` contract: stop streaming, wait on the
     /// post-stop drain barrier so the consumer thread has finished firing the
-    /// callback (making the callback closure safe to release), then drop the
-    /// stored callback handle. The GIL is released across both the stop and the
-    /// drain so the dispatcher's `Python::attach` can make progress; nothing
-    /// here blocks the interpreter.
+    /// callback (making the callback closure safe to release), then RELEASE the
+    /// core client handle and drop the stored callback. The GIL is released
+    /// across both the stop and the drain so the dispatcher's `Python::attach`
+    /// can make progress; nothing here blocks the interpreter.
+    ///
+    /// Idempotent: the handle is taken out of its slot up front, so a second
+    /// close finds `None` and returns immediately. Dropping the taken `Arc`
+    /// releases the historical gRPC channel pool once no vended surface still
+    /// co-owns it, and runs the core `Client::Drop` (the DETACHED streaming
+    /// quiesce, never a GIL-reacquiring join) — safe to drop here even with the
+    /// GIL held.
     pub(crate) fn close_impl(&self, py: Python<'_>) -> PyResult<()> {
+        // Take the handle out of the slot. Idempotent: a second close finds
+        // `None`. Holding the `Arc` in a local means the release (drop) happens
+        // at the end of this function, AFTER the synchronous stop + drain below.
+        let Some(client) = self.client.lock().unwrap_or_else(|e| e.into_inner()).take() else {
+            return Ok(());
+        };
         // Only a live streaming session has anything to drain. Snapshot that
         // BEFORE stopping so we do not wait on a barrier that will never arm on
         // a historical-only client (whose `prev_drained` slot stays empty).
-        let was_streaming = self.client.stream().is_streaming();
+        let was_streaming = client.stream().is_streaming();
         let drained = py.detach(|| {
-            self.client.close();
+            client.close();
             if was_streaming {
-                self.client
+                client
                     .stream()
                     .await_drain(std::time::Duration::from_millis(
                         streaming_session::EXIT_DRAIN_TIMEOUT_MS,
@@ -1522,7 +1561,7 @@ impl AsyncClient {
             async move { thetadatadx::Client::connect(&inner_creds, direct_config).await },
             |py, client| {
                 let wrapped = Client {
-                    client: std::sync::Arc::new(client),
+                    client: std::sync::Mutex::new(Some(std::sync::Arc::new(client))),
                     callback: Arc::new(Mutex::new(None)),
                 };
                 let inner = Py::new(py, wrapped)?;

--- a/thetadatadx-py/src/streaming_session.rs
+++ b/thetadatadx-py/src/streaming_session.rs
@@ -57,7 +57,9 @@ impl StreamableHandle {
     /// `StreamView` surface, so the `Unified` arm dispatches through it.
     pub(crate) fn start_streaming(&self, py: Python<'_>, callback: Py<PyAny>) -> PyResult<()> {
         match self {
-            Self::Unified(handle) => handle.borrow(py).stream().start_streaming(py, callback),
+            // `stream()` raises if the client has been closed, so entering a
+            // session on a closed client surfaces the closed error here.
+            Self::Unified(handle) => handle.borrow(py).stream()?.start_streaming(py, callback),
             Self::Fpss(handle) => handle.borrow(py).start_streaming(py, callback),
         }
     }
@@ -65,7 +67,13 @@ impl StreamableHandle {
     /// Invoke `stop_streaming()` through the typed enum.
     pub(crate) fn stop_streaming(&self, py: Python<'_>) {
         match self {
-            Self::Unified(handle) => handle.borrow(py).stream().stop_streaming(py),
+            // A closed client has no streaming session to stop — treat the
+            // teardown as a vacuous no-op rather than raising on `__exit__`.
+            Self::Unified(handle) => {
+                if let Ok(stream) = handle.borrow(py).stream() {
+                    stream.stop_streaming(py);
+                }
+            }
             Self::Fpss(handle) => handle.borrow(py).stop_streaming(py),
         }
     }
@@ -76,7 +84,11 @@ impl StreamableHandle {
     /// wait.
     pub(crate) fn await_drain(&self, py: Python<'_>, timeout_ms: u64) -> bool {
         match self {
-            Self::Unified(handle) => handle.borrow(py).stream().await_drain(py, timeout_ms),
+            // A closed client has no consumer to drain — vacuously satisfied.
+            Self::Unified(handle) => handle
+                .borrow(py)
+                .stream()
+                .map_or(true, |stream| stream.await_drain(py, timeout_ms)),
             Self::Fpss(handle) => handle.borrow(py).await_drain(py, timeout_ms),
         }
     }
@@ -250,7 +262,7 @@ impl crate::Client {
     /// Backs the `session_uuid` entry on `AsyncClient`'s
     /// `__getattr__` allowlist so that proxy resolves to a working call.
     fn session_uuid(&self, py: Python<'_>) -> pyo3::PyResult<String> {
-        let inner = self.client.clone();
+        let inner = self.client_arc()?;
         crate::run_blocking(py, async move { Ok(inner.session_uuid().await) })
     }
 
@@ -268,7 +280,15 @@ impl crate::Client {
     /// Mirrors the upstream
     /// [`thetadatadx::Client::subscription_info`] shape.
     fn subscription_info(&self) -> Vec<(String, String)> {
-        let info = self.client.subscription_info();
+        // A closed client holds no live auth payload; report `Unknown` per
+        // asset class rather than raising from a plain diagnostic getter.
+        let Ok(client) = self.client_arc() else {
+            return ["stock", "options", "indices", "interest_rate"]
+                .into_iter()
+                .map(|asset| (asset.to_string(), "Unknown".to_string()))
+                .collect();
+        };
+        let info = client.subscription_info();
         vec![
             ("stock".to_string(), info.stock),
             ("options".to_string(), info.options),

--- a/thetadatadx-py/tests/test_context_manager.py
+++ b/thetadatadx-py/tests/test_context_manager.py
@@ -283,6 +283,67 @@ def test_close_is_idempotent_and_safe_after_streaming(client) -> None:
     client.close()
 
 
+def test_close_releases_and_makes_client_unusable() -> None:
+    """Offline source pin (#1071 follow-up): `close()` must RELEASE the core
+    client handle, not merely stop streaming, and every vended surface must
+    resolve the handle through the closed-guard so a closed client is unusable.
+
+    Asserted against the generated / hand-written source so a regression that
+    reverts `close()` back to a stop-only teardown (leaving the client usable
+    and the gRPC pool pinned) fails even without live credentials. The
+    behavioural proof lives in the live-gated tests below.
+    """
+    from pathlib import Path
+
+    here = Path(__file__).resolve().parent
+    src_root = None
+    for candidate in [here, *here.parents]:
+        target = candidate / "src"
+        if target.is_dir() and (target / "lib.rs").is_file():
+            src_root = target
+            break
+    assert src_root is not None, "could not locate thetadatadx-py/src"
+
+    lib = (src_root / "lib.rs").read_text()
+    # The handle is held behind an Option so close() can take it.
+    assert (
+        "client: std::sync::Mutex<Option<std::sync::Arc<thetadatadx::Client>>>" in lib
+    ), "the unified Client must hold its handle as an Option so close() can release it"
+    # close_impl takes the handle out of its slot (deterministic release) and the
+    # accessor raises once it is gone (unusable after close).
+    assert ".take()" in lib, "close_impl must take() the handle out to release it"
+    assert "client is closed" in lib, (
+        "the closed-guard must raise a clear 'client is closed' error"
+    )
+
+
+def test_close_makes_client_unusable(client) -> None:
+    """After `close()` every surface accessor raises a clear closed error, so a
+    subsequent historical or streaming call cannot reach the network. Live-gated
+    because the constructor needs a real handshake.
+    """
+    client.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = client.historical
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = client.stream
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = client.flat_files
+    # Idempotent: a second close on the released client is a no-op.
+    client.close()
+
+
+def test_close_releases_via_context_manager(client) -> None:
+    """The `with Client(...)` exit runs the REAL close (release), not just a
+    stop-streaming: inside the block the client is usable, and after the block a
+    surface accessor raises the closed error. Live-gated.
+    """
+    with client as bound:
+        assert bound.historical is not None
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = client.stream
+
+
 def test_direct_start_streaming_then_drop_does_not_deadlock() -> None:
     """The forgetful path is deadlock-safe (issue 1).
 

--- a/thetadatadx-py/tests/test_standalone_clients.py
+++ b/thetadatadx-py/tests/test_standalone_clients.py
@@ -188,6 +188,27 @@ def test_mdds_client_blocks_fpss_attrs() -> None:
             getattr(client, name)
 
 
+def test_mdds_client_close_releases_and_is_unusable() -> None:
+    """`HistoricalClient.close()` RELEASES the underlying handle and makes the
+    client unusable: a subsequent historical call raises a clear closed error,
+    and a second close is a no-op. Live-gated because construction needs the
+    gRPC handshake.
+    """
+    mod = _import_module()
+    if not _live_creds_path():
+        pytest.skip("THETADATADX_LIVE_CREDS unset -- skip live HistoricalClient close check")
+
+    creds = mod.Credentials.from_file(_live_creds_path())
+    mdds = mod.HistoricalClient(creds, mod.Config.production())
+    mdds.close()
+    # A historical call after close reaches the closed-guard on the wrapped
+    # unified client (raised before any network round-trip).
+    with pytest.raises(RuntimeError, match="closed"):
+        mdds.stock_history_eod("AAPL", "20240101", "20240301")
+    # Idempotent.
+    mdds.close()
+
+
 def test_mdds_client_block_list_offline() -> None:
     """Offline coverage of the full ``BLOCKED_FPSS_METHODS`` inventory.
 

--- a/thetadatadx-rs/build_support_bin/endpoints/sdk_render/typescript.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/sdk_render/typescript.rs
@@ -49,10 +49,13 @@ use super::super::sdk_helpers::{
     to_camel_case, to_pascal_case, ts_class_name, ts_class_vec_converter, write_timeout_call,
 };
 
-/// napi classes that carry the historical endpoint surface. Both wrap an
-/// `Arc<thetadatadx::Client>` field named `client`, so the
-/// generated method bodies (which all reference `self.client`) compile
-/// unchanged against either receiver.
+/// napi classes that carry the historical endpoint surface. Both expose a
+/// `client_handle(&self) -> napi::Result<Arc<thetadatadx::Client>>` accessor,
+/// so the generated method bodies (which resolve the handle via
+/// `self.client_handle()?`) compile unchanged against either receiver.
+/// `HistoricalView` co-owns its `Arc` (always `Ok`, surviving a parent
+/// `Client::close`); `HistoricalClient` holds the handle behind an `Option` and
+/// rejects with "client is closed" once its own `close()` has released it.
 ///
 /// `Client` is the unified handle (historical + FPSS
 /// streaming); `HistoricalClient` is the standalone historical-only handle
@@ -97,9 +100,10 @@ pub(super) fn render_typescript_historical_methods(endpoints: &[GeneratedEndpoin
 
 /// Emit a single `#[napi] impl <ClassName> { ... }` block carrying every
 /// historical endpoint method (and its server-stream companion). The
-/// method bodies reference `self.client`, so the block compiles against any
-/// napi class that exposes an `Arc<thetadatadx::Client>` field
-/// named `client`. Parameterising over the class name lets the generator
+/// method bodies resolve the client via `self.client_handle()?`, so the block
+/// compiles against any napi class that exposes a
+/// `client_handle(&self) -> napi::Result<Arc<thetadatadx::Client>>` accessor.
+/// Parameterising over the class name lets the generator
 /// project the identical surface onto the unified `Client` and
 /// the standalone `HistoricalClient` without duplicating the per-endpoint
 /// rendering.
@@ -250,7 +254,7 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     // `'static` borrow source: the request builder borrows the client,
     // and that borrow must outlive the V8 stack frame the Promise
     // detaches from.
-    out.push_str("        let client = self.client.clone();\n");
+    out.push_str("        let client = self.client_handle()?;\n");
 
     let has_symbols = method_params
         .iter()
@@ -482,7 +486,7 @@ fn render_typescript_endpoint_stream_method(endpoint: &GeneratedEndpoint) -> Str
     out.push_str("            Some(ms) => Some(validate_timeout_ms(ms)?),\n");
     out.push_str("            None => None,\n");
     out.push_str("        };\n");
-    out.push_str("        let client = self.client.clone();\n");
+    out.push_str("        let client = self.client_handle()?;\n");
 
     let has_symbols = method_params
         .iter()

--- a/thetadatadx-ts/__tests__/close_releases.test.mjs
+++ b/thetadatadx-ts/__tests__/close_releases.test.mjs
@@ -1,0 +1,101 @@
+// `close()` deterministic-release lifecycle tests (#1071 follow-up).
+//
+// Pins the contract that `close()` RELEASES the core client handle (not just
+// stops streaming), so a closed client is unusable: every surface getter
+// (`historical` / `stream` / `flatFiles`) throws a clear "client is closed"
+// error, and a second close is a no-op. Also pins that the explicit-resource
+// disposers (`Symbol.dispose` / `Symbol.asyncDispose`) route through the real
+// `close()` and tolerate an already-closed client.
+//
+// The disposer-shape tests run offline against crafted receivers; the
+// behavioural close-then-use tests are gated on THETADATADX_TEST_CREDS because
+// constructing a `Client` needs a live handshake.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// The wrapper patches the disposers onto the native `Client` /
+// `HistoricalClient` prototypes at import time and re-exports the native
+// classes, so importing it is enough to exercise both.
+let mod;
+try {
+  const imported = await import('../streaming-session.js');
+  mod = imported.default ?? imported;
+} catch {
+  console.error('FAIL: native addon not built; run `npm run build` first');
+  process.exit(1);
+}
+
+describe('base-client disposers route through close()', () => {
+  it('Symbol.dispose calls close()', () => {
+    const disposer = mod.Client.prototype[Symbol.dispose];
+    assert.equal(typeof disposer, 'function', 'Client must define [Symbol.dispose]');
+    let closed = 0;
+    disposer.call({ close() { closed++; } });
+    assert.equal(closed, 1, 'the sync disposer must invoke the real close()');
+  });
+
+  it('Symbol.asyncDispose still closes an already-closed client (stream getter throws)', async () => {
+    const disposer = mod.Client.prototype[Symbol.asyncDispose];
+    assert.equal(typeof disposer, 'function', 'Client must define [Symbol.asyncDispose]');
+    let closed = 0;
+    const alreadyClosed = {
+      // A closed client throws "client is closed" from the `stream` getter.
+      get stream() { throw new Error('client is closed'); },
+      close() { closed++; },
+    };
+    // Must not reject: the disposer treats a throwing `stream` getter as
+    // nothing-to-drain and still runs close().
+    await disposer.call(alreadyClosed);
+    assert.equal(closed, 1, 'asyncDispose must still run close() on a closed client');
+  });
+
+  it('Symbol.asyncDispose drains then closes a live client', async () => {
+    const disposer = mod.Client.prototype[Symbol.asyncDispose];
+    const order = [];
+    const live = {
+      get stream() {
+        return {
+          stopStreaming() { order.push('stopStreaming'); },
+          async awaitDrain() { order.push('awaitDrain'); return true; },
+        };
+      },
+      close() { order.push('close'); },
+    };
+    await disposer.call(live);
+    assert.deepEqual(order, ['stopStreaming', 'awaitDrain', 'close']);
+  });
+});
+
+describe('close() releases the handle and makes the client unusable', () => {
+  it('unified Client: surface getters throw after close (live)', async () => {
+    const credsPath = process.env.THETADATADX_TEST_CREDS;
+    if (!credsPath) {
+      console.log('SKIP: set THETADATADX_TEST_CREDS=/path/to/creds.txt to enable this live test');
+      return;
+    }
+    const client = await mod.Client.connectFromFile(credsPath);
+    client.close();
+    assert.throws(() => client.historical, /closed/, 'historical must throw after close');
+    assert.throws(() => client.stream, /closed/, 'stream must throw after close');
+    assert.throws(() => client.flatFiles, /closed/, 'flatFiles must throw after close');
+    // Idempotent.
+    assert.doesNotThrow(() => client.close());
+  });
+
+  it('standalone HistoricalClient: endpoint call rejects after close (live)', async () => {
+    const credsPath = process.env.THETADATADX_TEST_CREDS;
+    if (!credsPath) {
+      console.log('SKIP: set THETADATADX_TEST_CREDS=/path/to/creds.txt to enable this live test');
+      return;
+    }
+    const hist = await mod.HistoricalClient.connectFromFile(credsPath);
+    hist.close();
+    await assert.rejects(
+      hist.stockHistoryEOD('AAPL', '20240101', '20240301'),
+      /closed/,
+      'a historical call after close must reject with the closed error',
+    );
+    assert.doesNotThrow(() => hist.close());
+  });
+});

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -80,10 +80,14 @@ export declare class Client {
   /**
    * Deterministically close the client.
    *
-   * Stops streaming if it is live (idempotent) and releases the registered
-   * callback back to V8. The historical gRPC channel pool releases when the
-   * last handle to this client is dropped. Safe to call more than once and
-   * safe on a client that only ran historical queries.
+   * Stops streaming if it is live (idempotent), RELEASES the core client
+   * handle, and releases the registered callback back to V8. Taking the
+   * handle out of its slot and dropping it frees the historical gRPC channel
+   * pool once no vended surface still co-owns it, and makes the client
+   * UNUSABLE — every subsequent `historical` / `stream` / `flatFiles` access
+   * rejects with "client is closed". Safe to call more than once (a second
+   * close finds an empty slot and is a no-op) and safe on a client that only
+   * ran historical queries.
    *
    * This is the recommended teardown. Prefer the `using` declaration
    * (`using client = connect(...)`) so `close()` runs on scope exit through
@@ -93,11 +97,10 @@ export declare class Client {
    *
    * `close()` retires the streaming dispatcher synchronously on the calling
    * thread, so it can block briefly while the dispatcher drains its
-   * in-flight events. The non-blocking detach (a teardown that returns
-   * immediately and finishes on a helper thread) applies only to the
-   * implicit `Drop` path, which must not block a thread that may hold a
-   * runtime lock the dispatcher re-enters. Callers wanting a non-blocking
-   * release let the handle drop instead of calling `close()`.
+   * in-flight events. Dropping the taken handle runs the core `Client::Drop`
+   * (the detached streaming quiesce), which returns immediately and finishes
+   * on a helper thread. Callers wanting a non-blocking release let the handle
+   * drop instead of calling `close()`.
    */
   close(): void
   /** FLATFILES namespace handle. Cheap — shares the underlying client connection. */
@@ -835,9 +838,11 @@ export declare class HistoricalClient {
    * Deterministically close the historical client.
    *
    * The historical-only surface never opens streaming, so there is no
-   * dispatcher to drain; the gRPC channel pool releases when the last handle
-   * to this client is dropped. Provided so the historical surface matches the
-   * unified `Client` lifecycle across every binding. Idempotent. Prefer the
+   * dispatcher to drain; closing takes the core client handle out of its slot
+   * and drops it, RELEASING the gRPC channel pool once no vended surface still
+   * co-owns it and making the client UNUSABLE (every endpoint call rejects
+   * with "client is closed"). Matches the unified `Client` lifecycle across
+   * every binding. Idempotent — a second close finds an empty slot. Prefer the
    * `using` declaration (`using c = await HistoricalClient.connect(...)`) so
    * `close()` runs on scope exit through `[Symbol.dispose]`.
    */

--- a/thetadatadx-ts/src/_generated/historical_methods.rs
+++ b/thetadatadx-ts/src/_generated/historical_methods.rs
@@ -1489,7 +1489,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().stock_list_symbols();
             if let Some(ms) = timeout_ms {
@@ -1519,7 +1519,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().stock_list_dates(&request_type, &symbol);
             if let Some(ms) = timeout_ms {
@@ -1554,7 +1554,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -1595,7 +1595,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -1636,7 +1636,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -1677,7 +1677,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -1715,7 +1715,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
@@ -1744,7 +1744,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let callback = std::sync::Arc::new(callback);
@@ -1786,7 +1786,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -1837,7 +1837,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -1900,7 +1900,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -1947,7 +1947,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -2009,7 +2009,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -2060,7 +2060,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -2124,7 +2124,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -2175,7 +2175,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -2243,7 +2243,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -2278,7 +2278,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -2328,7 +2328,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -2363,7 +2363,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -2400,7 +2400,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_symbols();
             if let Some(ms) = timeout_ms {
@@ -2436,7 +2436,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_dates(&request_type, &symbol, expiration.as_str());
@@ -2467,7 +2467,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_expirations(&symbol);
             if let Some(ms) = timeout_ms {
@@ -2498,7 +2498,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_strikes(&symbol, expiration.as_str());
@@ -2533,7 +2533,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let symbol = options.symbol;
         let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
@@ -2568,7 +2568,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let symbol = options.symbol;
         let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
@@ -2613,7 +2613,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -2666,7 +2666,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -2715,7 +2715,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -2769,7 +2769,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -2821,7 +2821,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -2879,7 +2879,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -2959,7 +2959,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -3039,7 +3039,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -3119,7 +3119,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -3199,7 +3199,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -3280,7 +3280,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -3327,7 +3327,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -3388,7 +3388,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3449,7 +3449,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3525,7 +3525,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3586,7 +3586,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3662,7 +3662,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3727,7 +3727,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3808,7 +3808,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3873,7 +3873,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -3950,7 +3950,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4003,7 +4003,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4072,7 +4072,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -4139,7 +4139,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -4223,7 +4223,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4300,7 +4300,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4394,7 +4394,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4471,7 +4471,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4566,7 +4566,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4643,7 +4643,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4737,7 +4737,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4814,7 +4814,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4909,7 +4909,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -4986,7 +4986,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5080,7 +5080,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5157,7 +5157,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5252,7 +5252,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5329,7 +5329,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5423,7 +5423,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5500,7 +5500,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5594,7 +5594,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5671,7 +5671,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5764,7 +5764,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5841,7 +5841,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -5933,7 +5933,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -5982,7 +5982,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -6042,7 +6042,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -6091,7 +6091,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -6141,7 +6141,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().index_list_symbols();
             if let Some(ms) = timeout_ms {
@@ -6170,7 +6170,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().index_list_dates(&symbol);
             if let Some(ms) = timeout_ms {
@@ -6200,7 +6200,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
         let ticks = spawn_endpoint_task(async move {
@@ -6233,7 +6233,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
         let ticks = spawn_endpoint_task(async move {
@@ -6266,7 +6266,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
         let ticks = spawn_endpoint_task(async move {
@@ -6300,7 +6300,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
@@ -6329,7 +6329,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let callback = std::sync::Arc::new(callback);
@@ -6371,7 +6371,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -6412,7 +6412,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -6466,7 +6466,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -6513,7 +6513,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -6569,7 +6569,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -6600,7 +6600,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -6635,7 +6635,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let ticks = spawn_endpoint_task(async move {
             let mut request = client.historical().calendar_open_today();
             if let Some(ms) = timeout_ms {
@@ -6664,7 +6664,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let ticks = spawn_endpoint_task(async move {
             let mut request = client.historical().calendar_on_date(date.as_str());
@@ -6694,7 +6694,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let ticks = spawn_endpoint_task(async move {
             let mut request = client.historical().calendar_year(&year);
             if let Some(ms) = timeout_ms {
@@ -6726,7 +6726,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
@@ -6755,7 +6755,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let callback = std::sync::Arc::new(callback);
@@ -6794,7 +6794,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -6839,7 +6839,7 @@ impl HistoricalView {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -6890,7 +6890,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().stock_list_symbols();
             if let Some(ms) = timeout_ms {
@@ -6920,7 +6920,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().stock_list_dates(&request_type, &symbol);
             if let Some(ms) = timeout_ms {
@@ -6955,7 +6955,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -6996,7 +6996,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -7037,7 +7037,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -7078,7 +7078,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
         let min_time = normalize_optional_time(options.min_time);
@@ -7116,7 +7116,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
@@ -7145,7 +7145,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let callback = std::sync::Arc::new(callback);
@@ -7187,7 +7187,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -7238,7 +7238,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -7301,7 +7301,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -7348,7 +7348,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -7410,7 +7410,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -7461,7 +7461,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -7525,7 +7525,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -7576,7 +7576,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
         let end_time = normalize_optional_time(options.end_time);
@@ -7644,7 +7644,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -7679,7 +7679,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -7729,7 +7729,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -7764,7 +7764,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -7801,7 +7801,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_symbols();
             if let Some(ms) = timeout_ms {
@@ -7837,7 +7837,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_dates(&request_type, &symbol, expiration.as_str());
@@ -7868,7 +7868,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_expirations(&symbol);
             if let Some(ms) = timeout_ms {
@@ -7899,7 +7899,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         spawn_endpoint_task(async move {
             let call = client.historical().option_list_strikes(&symbol, expiration.as_str());
@@ -7934,7 +7934,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let symbol = options.symbol;
         let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
@@ -7969,7 +7969,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let symbol = options.symbol;
         let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
@@ -8014,7 +8014,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8067,7 +8067,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8116,7 +8116,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8170,7 +8170,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8222,7 +8222,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8280,7 +8280,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8360,7 +8360,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8440,7 +8440,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8520,7 +8520,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8600,7 +8600,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let strike = options.strike;
         let right = options.right;
@@ -8681,7 +8681,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -8728,7 +8728,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -8789,7 +8789,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -8850,7 +8850,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -8926,7 +8926,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -8987,7 +8987,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9063,7 +9063,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9128,7 +9128,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9209,7 +9209,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9274,7 +9274,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9351,7 +9351,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9404,7 +9404,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9473,7 +9473,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -9540,7 +9540,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -9624,7 +9624,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9701,7 +9701,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9795,7 +9795,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9872,7 +9872,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -9967,7 +9967,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10044,7 +10044,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10138,7 +10138,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10215,7 +10215,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10310,7 +10310,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10387,7 +10387,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10481,7 +10481,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10558,7 +10558,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10653,7 +10653,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10730,7 +10730,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10824,7 +10824,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10901,7 +10901,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -10995,7 +10995,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -11072,7 +11072,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -11165,7 +11165,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -11242,7 +11242,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
         let strike = options.strike;
@@ -11334,7 +11334,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -11383,7 +11383,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -11443,7 +11443,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -11492,7 +11492,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -11542,7 +11542,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().index_list_symbols();
             if let Some(ms) = timeout_ms {
@@ -11571,7 +11571,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         spawn_endpoint_task(async move {
             let call = client.historical().index_list_dates(&symbol);
             if let Some(ms) = timeout_ms {
@@ -11601,7 +11601,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
         let ticks = spawn_endpoint_task(async move {
@@ -11634,7 +11634,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
         let ticks = spawn_endpoint_task(async move {
@@ -11667,7 +11667,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
         let ticks = spawn_endpoint_task(async move {
@@ -11701,7 +11701,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
@@ -11730,7 +11730,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let callback = std::sync::Arc::new(callback);
@@ -11772,7 +11772,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -11813,7 +11813,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -11867,7 +11867,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -11914,7 +11914,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let interval = options.interval;
         let start_time = normalize_optional_time(options.start_time);
@@ -11970,7 +11970,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -12001,7 +12001,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
@@ -12036,7 +12036,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let ticks = spawn_endpoint_task(async move {
             let mut request = client.historical().calendar_open_today();
             if let Some(ms) = timeout_ms {
@@ -12065,7 +12065,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let date = normalize_date(date);
         let ticks = spawn_endpoint_task(async move {
             let mut request = client.historical().calendar_on_date(date.as_str());
@@ -12095,7 +12095,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let ticks = spawn_endpoint_task(async move {
             let mut request = client.historical().calendar_year(&year);
             if let Some(ms) = timeout_ms {
@@ -12127,7 +12127,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
@@ -12156,7 +12156,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let callback = std::sync::Arc::new(callback);
@@ -12195,7 +12195,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;
@@ -12240,7 +12240,7 @@ impl HistoricalClient {
             Some(ms) => Some(validate_timeout_ms(ms)?),
             None => None,
         };
-        let client = self.client.clone();
+        let client = self.client_handle()?;
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let interval = options.interval;

--- a/thetadatadx-ts/src/flatfile_methods.rs
+++ b/thetadatadx-ts/src/flatfile_methods.rs
@@ -260,10 +260,10 @@ use crate::{Client, HistoricalClient};
 impl Client {
     /// FLATFILES namespace handle. Cheap — shares the underlying client connection.
     #[napi(getter, js_name = "flatFiles")]
-    pub fn flat_files(&self) -> FlatFilesNamespace {
-        FlatFilesNamespace {
-            client: Arc::clone(&self.client),
-        }
+    pub fn flat_files(&self) -> napi::Result<FlatFilesNamespace> {
+        Ok(FlatFilesNamespace {
+            client: self.client_handle()?,
+        })
     }
 
     /// Pull a flat-file blob and write the requested format to `path`.
@@ -278,7 +278,15 @@ impl Client {
         path: String,
         format: Option<String>,
     ) -> napi::Result<String> {
-        flat_file_to_path_impl(&self.client, sec_type, req_type, date, path, format).await
+        flat_file_to_path_impl(
+            &self.client_handle()?,
+            sec_type,
+            req_type,
+            date,
+            path,
+            format,
+        )
+        .await
     }
 }
 
@@ -290,10 +298,10 @@ impl HistoricalClient {
     /// The historical-only client opens the same data channel as the unified
     /// client, so the full flat-file surface is reachable here unchanged.
     #[napi(getter, js_name = "flatFiles")]
-    pub fn flat_files(&self) -> FlatFilesNamespace {
-        FlatFilesNamespace {
-            client: Arc::clone(&self.client),
-        }
+    pub fn flat_files(&self) -> napi::Result<FlatFilesNamespace> {
+        Ok(FlatFilesNamespace {
+            client: self.client_handle()?,
+        })
     }
 
     /// Pull a flat-file blob and write the requested format to `path`.
@@ -308,6 +316,14 @@ impl HistoricalClient {
         path: String,
         format: Option<String>,
     ) -> napi::Result<String> {
-        flat_file_to_path_impl(&self.client, sec_type, req_type, date, path, format).await
+        flat_file_to_path_impl(
+            &self.client_handle()?,
+            sec_type,
+            req_type,
+            date,
+            path,
+            format,
+        )
+        .await
     }
 }

--- a/thetadatadx-ts/src/lib.rs
+++ b/thetadatadx-ts/src/lib.rs
@@ -780,13 +780,20 @@ pub(crate) type TsfnCallback = napi::threadsafe_function::ThreadsafeFunction<
 
 #[napi]
 pub struct Client {
-    /// Wrapped in `Arc` so async napi methods (e.g. `awaitDrain`) can
-    /// clone a cheap handle into a `tokio::task::spawn_blocking` future
-    /// without violating the `Send + 'static` bound. The inner
-    /// `thetadatadx::Client` is not `Clone` -- its streaming mutex and
-    /// subscription-tier state forbid that -- so the outer `Arc` is the
-    /// only way to hand a borrow off the napi main thread.
-    client: Arc<thetadatadx::Client>,
+    /// Held as `Option` behind a `Mutex` so `close()` can DETERMINISTICALLY
+    /// RELEASE the handle: closing takes the `Arc<Client>` out of the slot and
+    /// drops it, freeing the historical gRPC channel pool once the last
+    /// co-owning surface (a `HistoricalView` / `StreamView` vended before
+    /// close) is also gone — matching the C++ wrapper, where `close()` resets
+    /// the handle. A closed slot (`None`) makes every access via
+    /// [`Client::client_handle`] reject with "client is closed", so the client
+    /// is UNUSABLE after close and a second close is a no-op.
+    ///
+    /// The inner `thetadatadx::Client` is not `Clone` -- its streaming mutex
+    /// and subscription-tier state forbid that -- so surfaces co-own a cheap
+    /// `Arc<Client>` clone (surviving past a parent close, exactly as the C++
+    /// `Historical` / `Stream` views co-own the `shared_ptr`).
+    client: Mutex<Option<Arc<thetadatadx::Client>>>,
     /// Stored JS callback registered via `startStreaming(callback)`.
     /// `None` until the first registration; persisted across
     /// `reconnect()` so the reconnect path can re-attach the same JS
@@ -825,6 +832,19 @@ pub struct HistoricalView {
     client: Arc<thetadatadx::Client>,
 }
 
+impl HistoricalView {
+    /// The core client handle for the generated endpoint bodies.
+    ///
+    /// The view co-owns its `Arc<Client>`, so it stays usable even after the
+    /// parent `Client` closes — matching the C++ `Historical` view, which
+    /// co-owns the `shared_ptr`. Infallible; the `napi::Result` signature is
+    /// shared with `HistoricalClient::client_handle` so the identical generated
+    /// bodies compile against either receiver.
+    pub(crate) fn client_handle(&self) -> napi::Result<Arc<thetadatadx::Client>> {
+        Ok(Arc::clone(&self.client))
+    }
+}
+
 /// User-facing real-time-streaming sub-namespace returned by the
 /// `client.stream` getter.
 ///
@@ -845,10 +865,10 @@ impl Client {
     /// Returns a fresh [`HistoricalView`] that shares the underlying
     /// client connection. No auth round-trip, no streaming-state mutation.
     #[napi(getter)]
-    pub fn historical(&self) -> HistoricalView {
-        HistoricalView {
-            client: Arc::clone(&self.client),
-        }
+    pub fn historical(&self) -> napi::Result<HistoricalView> {
+        Ok(HistoricalView {
+            client: self.client_handle()?,
+        })
     }
 
     /// Real-time-streaming sub-namespace: `client.stream.subscribe(...)`,
@@ -858,11 +878,29 @@ impl Client {
     /// parent's callback slot, so the streaming lifecycle observed through
     /// the view is the one the unified client manages.
     #[napi(getter)]
-    pub fn stream(&self) -> StreamView {
-        StreamView {
-            client: Arc::clone(&self.client),
+    pub fn stream(&self) -> napi::Result<StreamView> {
+        Ok(StreamView {
+            client: self.client_handle()?,
             callback: Arc::clone(&self.callback),
-        }
+        })
+    }
+
+    /// The live core client handle, or a "client is closed" error.
+    ///
+    /// Every surface the client vends (`historical` / `stream` / `flatFiles`)
+    /// resolves the handle through here, so once `close()` has taken it the
+    /// client is uniformly unusable. Returns a cheap `Arc` clone the caller
+    /// co-owns.
+    pub(crate) fn client_handle(&self) -> napi::Result<Arc<thetadatadx::Client>> {
+        self.client
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .ok_or_else(|| {
+                napi::Error::from_reason(
+                    "client is closed; construct a new client to make further calls",
+                )
+            })
     }
 }
 
@@ -907,7 +945,7 @@ impl Client {
             .map_err(|e| napi::Error::from_reason(format!("connect task failed to complete: {e}")))?
             .map_err(to_napi_err)?;
         Ok(Client {
-            client: Arc::new(client),
+            client: Mutex::new(Some(Arc::new(client))),
             callback: Arc::new(Mutex::new(None)),
         })
     }
@@ -924,7 +962,7 @@ impl Client {
     pub async fn connect_from_file(path: String, config: Option<&Config>) -> napi::Result<Client> {
         let client = connect_historical_from_file_core(path, config_or_production(config)).await?;
         Ok(Client {
-            client,
+            client: Mutex::new(Some(client)),
             callback: Arc::new(Mutex::new(None)),
         })
     }
@@ -960,17 +998,21 @@ impl Client {
             .map_err(|e| napi::Error::from_reason(format!("connect task failed to complete: {e}")))?
             .map_err(to_napi_err)?;
         Ok(Client {
-            client: Arc::new(client),
+            client: Mutex::new(Some(Arc::new(client))),
             callback: Arc::new(Mutex::new(None)),
         })
     }
 
     /// Deterministically close the client.
     ///
-    /// Stops streaming if it is live (idempotent) and releases the registered
-    /// callback back to V8. The historical gRPC channel pool releases when the
-    /// last handle to this client is dropped. Safe to call more than once and
-    /// safe on a client that only ran historical queries.
+    /// Stops streaming if it is live (idempotent), RELEASES the core client
+    /// handle, and releases the registered callback back to V8. Taking the
+    /// handle out of its slot and dropping it frees the historical gRPC channel
+    /// pool once no vended surface still co-owns it, and makes the client
+    /// UNUSABLE — every subsequent `historical` / `stream` / `flatFiles` access
+    /// rejects with "client is closed". Safe to call more than once (a second
+    /// close finds an empty slot and is a no-op) and safe on a client that only
+    /// ran historical queries.
     ///
     /// This is the recommended teardown. Prefer the `using` declaration
     /// (`using client = connect(...)`) so `close()` runs on scope exit through
@@ -980,14 +1022,20 @@ impl Client {
     ///
     /// `close()` retires the streaming dispatcher synchronously on the calling
     /// thread, so it can block briefly while the dispatcher drains its
-    /// in-flight events. The non-blocking detach (a teardown that returns
-    /// immediately and finishes on a helper thread) applies only to the
-    /// implicit `Drop` path, which must not block a thread that may hold a
-    /// runtime lock the dispatcher re-enters. Callers wanting a non-blocking
-    /// release let the handle drop instead of calling `close()`.
+    /// in-flight events. Dropping the taken handle runs the core `Client::Drop`
+    /// (the detached streaming quiesce), which returns immediately and finishes
+    /// on a helper thread. Callers wanting a non-blocking release let the handle
+    /// drop instead of calling `close()`.
     #[napi]
     pub fn close(&self) {
-        self.client.stream().stop_streaming();
+        // Take the handle: idempotent. A second close finds `None`.
+        let Some(client) = self.client.lock().unwrap_or_else(|e| e.into_inner()).take() else {
+            return;
+        };
+        // Stop streaming synchronously on the calling thread, then release the
+        // stored callback. Dropping `client` at scope end frees the pool and
+        // runs the detached core `Drop`.
+        client.stream().stop_streaming();
         let mut guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
         *guard = None;
     }
@@ -1151,15 +1199,31 @@ impl StreamView {
 /// ```
 #[napi]
 pub struct HistoricalClient {
-    /// Wrapped in `Arc` so the generated async endpoint methods can
-    /// clone a cheap `'static` handle into the worker future, exactly
-    /// like the unified client's `client` field. The generated method
-    /// bodies reference `self.client`, so the historical impl block the
-    /// codegen projects onto this class compiles unchanged. This client
-    /// holds the same `thetadatadx::Client` core but never
-    /// reaches its streaming methods — no streaming TLS slot is opened for a
-    /// session that lives entirely through `HistoricalClient`.
-    client: Arc<thetadatadx::Client>,
+    /// Held as `Option` behind a `Mutex` (like the unified `Client`) so
+    /// `close()` DETERMINISTICALLY RELEASES the handle: closing takes the
+    /// `Arc<Client>` out and drops it, freeing the historical gRPC channel pool,
+    /// and makes the client UNUSABLE — the generated endpoint bodies resolve the
+    /// handle through [`HistoricalClient::client_handle`], which rejects with
+    /// "client is closed" once the slot is empty. A second close is a no-op.
+    client: Mutex<Option<Arc<thetadatadx::Client>>>,
+}
+
+impl HistoricalClient {
+    /// The live core client handle for the generated endpoint bodies, or a
+    /// "client is closed" error. Shares its signature with
+    /// [`HistoricalView::client_handle`] so the identical generated bodies
+    /// compile against either receiver.
+    pub(crate) fn client_handle(&self) -> napi::Result<Arc<thetadatadx::Client>> {
+        self.client
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .ok_or_else(|| {
+                napi::Error::from_reason(
+                    "client is closed; construct a new client to make further calls",
+                )
+            })
+    }
 }
 
 #[napi]
@@ -1197,7 +1261,7 @@ impl HistoricalClient {
             .map_err(|e| napi::Error::from_reason(format!("connect task failed to complete: {e}")))?
             .map_err(to_napi_err)?;
         Ok(HistoricalClient {
-            client: Arc::new(client),
+            client: Mutex::new(Some(Arc::new(client))),
         })
     }
 
@@ -1213,23 +1277,27 @@ impl HistoricalClient {
         config: Option<&Config>,
     ) -> napi::Result<HistoricalClient> {
         let client = connect_historical_from_file_core(path, config_or_production(config)).await?;
-        Ok(HistoricalClient { client })
+        Ok(HistoricalClient {
+            client: Mutex::new(Some(client)),
+        })
     }
 
     /// Deterministically close the historical client.
     ///
     /// The historical-only surface never opens streaming, so there is no
-    /// dispatcher to drain; the gRPC channel pool releases when the last handle
-    /// to this client is dropped. Provided so the historical surface matches the
-    /// unified `Client` lifecycle across every binding. Idempotent. Prefer the
+    /// dispatcher to drain; closing takes the core client handle out of its slot
+    /// and drops it, RELEASING the gRPC channel pool once no vended surface still
+    /// co-owns it and making the client UNUSABLE (every endpoint call rejects
+    /// with "client is closed"). Matches the unified `Client` lifecycle across
+    /// every binding. Idempotent — a second close finds an empty slot. Prefer the
     /// `using` declaration (`using c = await HistoricalClient.connect(...)`) so
     /// `close()` runs on scope exit through `[Symbol.dispose]`.
     #[napi]
     pub fn close(&self) {
-        // No streaming dispatcher on the historical-only surface; the channel
-        // pool releases on handle drop. Kept explicit so the lifecycle surface
-        // is uniform across bindings.
-        self.client.close();
+        // Take the handle out of its slot and drop it (idempotent). Dropping the
+        // last co-owning `Arc` frees the channel pool and runs the detached core
+        // `Drop`. A historical-only client has no streaming dispatcher to stop.
+        let _ = self.client.lock().unwrap_or_else(|e| e.into_inner()).take();
     }
 }
 

--- a/thetadatadx-ts/streaming-session.js
+++ b/thetadatadx-ts/streaming-session.js
@@ -408,7 +408,15 @@ for (const Klass of [native.Client, native.HistoricalClient]) {
     Klass.prototype[Symbol.asyncDispose] = async function asyncDispose() {
       // `stream` exists only on the unified `Client`; the historical-only
       // client has no streaming surface, so `close()` alone is the teardown.
-      const stream = this.stream;
+      // An already-closed client throws on the `stream` getter ("client is
+      // closed"); treat that as nothing-to-drain so disposing a closed client
+      // stays a no-op rather than rejecting.
+      let stream;
+      try {
+        stream = this.stream;
+      } catch {
+        stream = undefined;
+      }
       if (stream) {
         // Await the drain barrier first so the consumer thread has finished
         // firing the registered callback before the JS closure is released;


### PR DESCRIPTION
Follow-up to #1071. `close()` and the context-managers (`__exit__`, `Symbol.dispose`, `Symbol.asyncDispose`) in Python and TypeScript previously only stopped streaming and retained the client handle, so the historical connection pool was never released and the client stayed usable after close. C++ already reset its handle; this brings Python and TypeScript to the same contract.

The handle is now held as an `Option` behind a mutex. `close()` takes it (idempotent — a second close is a no-op), stops and drains streaming synchronously with the GIL released, then drops it so the connection pool is released. Any surface access after close returns a clear "client is closed" error. Views or builders vended before close keep the pool alive until they drop, matching the C++ shared-handle semantics.

The deadlock-safe drop path is preserved: close still drains with the GIL released, and the core drop runs the detached teardown rather than a GIL-reacquiring join.

Breaking: a closed client now rejects further calls instead of silently continuing.

## Tests

Added closed-surface-rejects, idempotent-close, and context-manager-releases tests across Python, TypeScript, and C++. Full suites pass; C-ABI and cross-binding parity clean; no method-surface change.