### PR TITLE
feat(historical)!: emit the wire symbol column on option and index endpoints

### DIFF
--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -898,28 +898,28 @@ ThetaDataDxColumnPresence thetadatadx_trade_quote_ticks_present_columns(const ch
  * borrowed (still owned by the caller). Returns an Arrow IPC byte buffer the
  * caller MUST free with thetadatadx_arrow_bytes_free, or (data=NULL, len=0) on
  * error with thetadatadx_last_error() set. */
-ThetaDataDxArrowBytes thetadatadx_eod_ticks_to_arrow_ipc_projected(const ThetaDataDxEodTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_ohlc_ticks_to_arrow_ipc_projected(const ThetaDataDxOhlcTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_quote_ticks_to_arrow_ipc_projected(const ThetaDataDxQuoteTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_greeks_all_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksAllTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_greeks_eod_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksEodTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_greeks_first_order_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksFirstOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_greeks_second_order_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksSecondOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_greeks_third_order_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksThirdOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_greeks_all_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksAllTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_greeks_first_order_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksFirstOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_greeks_second_order_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksSecondOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_greeks_third_order_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksThirdOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksImpliedVolatilityTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_iv_ticks_to_arrow_ipc_projected(const ThetaDataDxIvTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_price_ticks_to_arrow_ipc_projected(const ThetaDataDxPriceTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_index_price_at_time_ticks_to_arrow_ipc_projected(const ThetaDataDxIndexPriceAtTimeTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_open_interest_ticks_to_arrow_ipc_projected(const ThetaDataDxOpenInterestTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_market_value_ticks_to_arrow_ipc_projected(const ThetaDataDxMarketValueTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_calendar_days_to_arrow_ipc_projected(const ThetaDataDxCalendarDay* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_interest_rate_ticks_to_arrow_ipc_projected(const ThetaDataDxInterestRateTick* rows, size_t len, ThetaDataDxColumnPresence presence);
-ThetaDataDxArrowBytes thetadatadx_trade_quote_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeQuoteTick* rows, size_t len, ThetaDataDxColumnPresence presence);
+ThetaDataDxArrowBytes thetadatadx_eod_ticks_to_arrow_ipc_projected(const ThetaDataDxEodTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_ohlc_ticks_to_arrow_ipc_projected(const ThetaDataDxOhlcTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_quote_ticks_to_arrow_ipc_projected(const ThetaDataDxQuoteTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_greeks_all_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksAllTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_greeks_eod_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksEodTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_greeks_first_order_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksFirstOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_greeks_second_order_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksSecondOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_greeks_third_order_ticks_to_arrow_ipc_projected(const ThetaDataDxGreeksThirdOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_greeks_all_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksAllTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_greeks_first_order_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksFirstOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_greeks_second_order_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksSecondOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_greeks_third_order_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksThirdOrderTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeGreeksImpliedVolatilityTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_iv_ticks_to_arrow_ipc_projected(const ThetaDataDxIvTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_price_ticks_to_arrow_ipc_projected(const ThetaDataDxPriceTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_index_price_at_time_ticks_to_arrow_ipc_projected(const ThetaDataDxIndexPriceAtTimeTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_open_interest_ticks_to_arrow_ipc_projected(const ThetaDataDxOpenInterestTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_market_value_ticks_to_arrow_ipc_projected(const ThetaDataDxMarketValueTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_calendar_days_to_arrow_ipc_projected(const ThetaDataDxCalendarDay* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_interest_rate_ticks_to_arrow_ipc_projected(const ThetaDataDxInterestRateTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
+ThetaDataDxArrowBytes thetadatadx_trade_quote_ticks_to_arrow_ipc_projected(const ThetaDataDxTradeQuoteTick* rows, size_t len, ThetaDataDxColumnPresence presence, const char* symbol);
 
 /* ── Streaming Arrow RecordBatch reader (pull-based) ── */
 

--- a/thetadatadx-cpp/include/tick_arrow_ipc.hpp.inc
+++ b/thetadatadx-cpp/include/tick_arrow_ipc.hpp.inc
@@ -56,10 +56,12 @@ inline std::vector<uint8_t> tick_to_arrow_ipc(const std::vector<Tick>& rows, CFn
 }
 /// Serialise a typed history-row vector as a PROJECTED Arrow IPC stream —
 /// only the columns named in `presence` — by forwarding to its `_projected`
-/// C ABI serialiser. Same error / empty-stream contract as `tick_to_arrow_ipc`.
+/// C ABI serialiser. `symbol` is the response's constant root, broadcast as
+/// the leading column (empty -> omitted). Same error / empty-stream contract
+/// as `tick_to_arrow_ipc`.
 template <typename Tick, typename CFn>
-inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, CFn c_fn) {
-    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw());
+inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, const std::string& symbol, CFn c_fn) {
+    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw(), symbol.empty() ? nullptr : symbol.c_str());
     if (raw.data == nullptr) {
         throw_last_ffi_error();
     }
@@ -91,10 +93,12 @@ inline ColumnPresence calendar_days_present_columns(const std::vector<std::strin
 /// Serialise a `CalendarDay` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> calendar_days_to_arrow_ipc_projected(const std::vector<CalendarDay>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_calendar_days_to_arrow_ipc_projected);
+inline std::vector<uint8_t> calendar_days_to_arrow_ipc_projected(const std::vector<CalendarDay>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_calendar_days_to_arrow_ipc_projected);
 }
 
 /// Serialise a `EodTick` history result as Arrow IPC stream bytes,
@@ -119,10 +123,12 @@ inline ColumnPresence eod_ticks_present_columns(const std::vector<std::string>& 
 /// Serialise a `EodTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> eod_ticks_to_arrow_ipc_projected(const std::vector<EodTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_eod_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> eod_ticks_to_arrow_ipc_projected(const std::vector<EodTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_eod_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `GreeksAllTick` history result as Arrow IPC stream bytes,
@@ -147,10 +153,12 @@ inline ColumnPresence greeks_all_ticks_present_columns(const std::vector<std::st
 /// Serialise a `GreeksAllTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_all_ticks_to_arrow_ipc_projected(const std::vector<GreeksAllTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_greeks_all_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> greeks_all_ticks_to_arrow_ipc_projected(const std::vector<GreeksAllTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_all_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `GreeksEodTick` history result as Arrow IPC stream bytes,
@@ -175,10 +183,12 @@ inline ColumnPresence greeks_eod_ticks_present_columns(const std::vector<std::st
 /// Serialise a `GreeksEodTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_eod_ticks_to_arrow_ipc_projected(const std::vector<GreeksEodTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_greeks_eod_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> greeks_eod_ticks_to_arrow_ipc_projected(const std::vector<GreeksEodTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_eod_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `GreeksFirstOrderTick` history result as Arrow IPC stream bytes,
@@ -203,10 +213,12 @@ inline ColumnPresence greeks_first_order_ticks_present_columns(const std::vector
 /// Serialise a `GreeksFirstOrderTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksFirstOrderTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_greeks_first_order_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksFirstOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_first_order_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `GreeksSecondOrderTick` history result as Arrow IPC stream bytes,
@@ -231,10 +243,12 @@ inline ColumnPresence greeks_second_order_ticks_present_columns(const std::vecto
 /// Serialise a `GreeksSecondOrderTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksSecondOrderTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_greeks_second_order_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksSecondOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_second_order_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `GreeksThirdOrderTick` history result as Arrow IPC stream bytes,
@@ -259,10 +273,12 @@ inline ColumnPresence greeks_third_order_ticks_present_columns(const std::vector
 /// Serialise a `GreeksThirdOrderTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksThirdOrderTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_greeks_third_order_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksThirdOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_third_order_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `IndexPriceAtTimeTick` history result as Arrow IPC stream bytes,
@@ -287,10 +303,12 @@ inline ColumnPresence index_price_at_time_ticks_present_columns(const std::vecto
 /// Serialise a `IndexPriceAtTimeTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> index_price_at_time_ticks_to_arrow_ipc_projected(const std::vector<IndexPriceAtTimeTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_index_price_at_time_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> index_price_at_time_ticks_to_arrow_ipc_projected(const std::vector<IndexPriceAtTimeTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_index_price_at_time_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `InterestRateTick` history result as Arrow IPC stream bytes,
@@ -315,10 +333,12 @@ inline ColumnPresence interest_rate_ticks_present_columns(const std::vector<std:
 /// Serialise a `InterestRateTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> interest_rate_ticks_to_arrow_ipc_projected(const std::vector<InterestRateTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_interest_rate_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> interest_rate_ticks_to_arrow_ipc_projected(const std::vector<InterestRateTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_interest_rate_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `IvTick` history result as Arrow IPC stream bytes,
@@ -343,10 +363,12 @@ inline ColumnPresence iv_ticks_present_columns(const std::vector<std::string>& h
 /// Serialise a `IvTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> iv_ticks_to_arrow_ipc_projected(const std::vector<IvTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_iv_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> iv_ticks_to_arrow_ipc_projected(const std::vector<IvTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_iv_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `MarketValueTick` history result as Arrow IPC stream bytes,
@@ -371,10 +393,12 @@ inline ColumnPresence market_value_ticks_present_columns(const std::vector<std::
 /// Serialise a `MarketValueTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> market_value_ticks_to_arrow_ipc_projected(const std::vector<MarketValueTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_market_value_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> market_value_ticks_to_arrow_ipc_projected(const std::vector<MarketValueTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_market_value_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `OhlcTick` history result as Arrow IPC stream bytes,
@@ -399,10 +423,12 @@ inline ColumnPresence ohlc_ticks_present_columns(const std::vector<std::string>&
 /// Serialise a `OhlcTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> ohlc_ticks_to_arrow_ipc_projected(const std::vector<OhlcTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_ohlc_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> ohlc_ticks_to_arrow_ipc_projected(const std::vector<OhlcTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_ohlc_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `OpenInterestTick` history result as Arrow IPC stream bytes,
@@ -427,10 +453,12 @@ inline ColumnPresence open_interest_ticks_present_columns(const std::vector<std:
 /// Serialise a `OpenInterestTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> open_interest_ticks_to_arrow_ipc_projected(const std::vector<OpenInterestTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_open_interest_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> open_interest_ticks_to_arrow_ipc_projected(const std::vector<OpenInterestTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_open_interest_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `PriceTick` history result as Arrow IPC stream bytes,
@@ -455,10 +483,12 @@ inline ColumnPresence price_ticks_present_columns(const std::vector<std::string>
 /// Serialise a `PriceTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> price_ticks_to_arrow_ipc_projected(const std::vector<PriceTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_price_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> price_ticks_to_arrow_ipc_projected(const std::vector<PriceTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_price_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `QuoteTick` history result as Arrow IPC stream bytes,
@@ -483,10 +513,12 @@ inline ColumnPresence quote_ticks_present_columns(const std::vector<std::string>
 /// Serialise a `QuoteTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> quote_ticks_to_arrow_ipc_projected(const std::vector<QuoteTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_quote_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> quote_ticks_to_arrow_ipc_projected(const std::vector<QuoteTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_quote_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeGreeksAllTick` history result as Arrow IPC stream bytes,
@@ -511,10 +543,12 @@ inline ColumnPresence trade_greeks_all_ticks_present_columns(const std::vector<s
 /// Serialise a `TradeGreeksAllTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_all_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksAllTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_greeks_all_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_greeks_all_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksAllTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_all_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeGreeksFirstOrderTick` history result as Arrow IPC stream bytes,
@@ -539,10 +573,12 @@ inline ColumnPresence trade_greeks_first_order_ticks_present_columns(const std::
 /// Serialise a `TradeGreeksFirstOrderTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksFirstOrderTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_greeks_first_order_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksFirstOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_first_order_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeGreeksImpliedVolatilityTick` history result as Arrow IPC stream bytes,
@@ -567,10 +603,12 @@ inline ColumnPresence trade_greeks_implied_volatility_ticks_present_columns(cons
 /// Serialise a `TradeGreeksImpliedVolatilityTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksImpliedVolatilityTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksImpliedVolatilityTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeGreeksSecondOrderTick` history result as Arrow IPC stream bytes,
@@ -595,10 +633,12 @@ inline ColumnPresence trade_greeks_second_order_ticks_present_columns(const std:
 /// Serialise a `TradeGreeksSecondOrderTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksSecondOrderTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_greeks_second_order_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksSecondOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_second_order_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeGreeksThirdOrderTick` history result as Arrow IPC stream bytes,
@@ -623,10 +663,12 @@ inline ColumnPresence trade_greeks_third_order_ticks_present_columns(const std::
 /// Serialise a `TradeGreeksThirdOrderTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksThirdOrderTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_greeks_third_order_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksThirdOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_third_order_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeQuoteTick` history result as Arrow IPC stream bytes,
@@ -651,10 +693,12 @@ inline ColumnPresence trade_quote_ticks_present_columns(const std::vector<std::s
 /// Serialise a `TradeQuoteTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_quote_ticks_to_arrow_ipc_projected(const std::vector<TradeQuoteTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_quote_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_quote_ticks_to_arrow_ipc_projected(const std::vector<TradeQuoteTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_quote_ticks_to_arrow_ipc_projected);
 }
 
 /// Serialise a `TradeTick` history result as Arrow IPC stream bytes,
@@ -679,9 +723,11 @@ inline ColumnPresence trade_ticks_present_columns(const std::vector<std::string>
 /// Serialise a `TradeTick` history result as a PROJECTED Arrow IPC stream —
 /// only the columns `presence` names (from the matching
 /// `_present_columns`), the terminal-exact output Python's
-/// `<TickName>List.to_arrow()` gives on a decode result. Throws
+/// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
+/// response's constant root, broadcast as the leading column
+/// (option/index carry it, stock does not; empty -> omitted). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_ticks_to_arrow_ipc_projected(const std::vector<TradeTick>& rows, const ColumnPresence& presence) {
-    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_trade_ticks_to_arrow_ipc_projected);
+inline std::vector<uint8_t> trade_ticks_to_arrow_ipc_projected(const std::vector<TradeTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_ticks_to_arrow_ipc_projected);
 }
 

--- a/thetadatadx-cpp/include/tick_arrow_ipc.hpp.inc
+++ b/thetadatadx-cpp/include/tick_arrow_ipc.hpp.inc
@@ -57,11 +57,11 @@ inline std::vector<uint8_t> tick_to_arrow_ipc(const std::vector<Tick>& rows, CFn
 /// Serialise a typed history-row vector as a PROJECTED Arrow IPC stream —
 /// only the columns named in `presence` — by forwarding to its `_projected`
 /// C ABI serialiser. `symbol` is the response's constant root, broadcast as
-/// the leading column (empty -> omitted). Same error / empty-stream contract
-/// as `tick_to_arrow_ipc`.
+/// the leading column; `nullptr` omits it (an empty string stays a valid
+/// value). Same error / empty-stream contract as `tick_to_arrow_ipc`.
 template <typename Tick, typename CFn>
-inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, const std::string& symbol, CFn c_fn) {
-    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw(), symbol.empty() ? nullptr : symbol.c_str());
+inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, const char* symbol, CFn c_fn) {
+    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw(), symbol);
     if (raw.data == nullptr) {
         throw_last_ffi_error();
     }
@@ -95,9 +95,9 @@ inline ColumnPresence calendar_days_present_columns(const std::vector<std::strin
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> calendar_days_to_arrow_ipc_projected(const std::vector<CalendarDay>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> calendar_days_to_arrow_ipc_projected(const std::vector<CalendarDay>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_calendar_days_to_arrow_ipc_projected);
 }
 
@@ -125,9 +125,9 @@ inline ColumnPresence eod_ticks_present_columns(const std::vector<std::string>& 
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> eod_ticks_to_arrow_ipc_projected(const std::vector<EodTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> eod_ticks_to_arrow_ipc_projected(const std::vector<EodTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_eod_ticks_to_arrow_ipc_projected);
 }
 
@@ -155,9 +155,9 @@ inline ColumnPresence greeks_all_ticks_present_columns(const std::vector<std::st
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_all_ticks_to_arrow_ipc_projected(const std::vector<GreeksAllTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> greeks_all_ticks_to_arrow_ipc_projected(const std::vector<GreeksAllTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_all_ticks_to_arrow_ipc_projected);
 }
 
@@ -185,9 +185,9 @@ inline ColumnPresence greeks_eod_ticks_present_columns(const std::vector<std::st
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_eod_ticks_to_arrow_ipc_projected(const std::vector<GreeksEodTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> greeks_eod_ticks_to_arrow_ipc_projected(const std::vector<GreeksEodTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_eod_ticks_to_arrow_ipc_projected);
 }
 
@@ -215,9 +215,9 @@ inline ColumnPresence greeks_first_order_ticks_present_columns(const std::vector
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksFirstOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksFirstOrderTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_first_order_ticks_to_arrow_ipc_projected);
 }
 
@@ -245,9 +245,9 @@ inline ColumnPresence greeks_second_order_ticks_present_columns(const std::vecto
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksSecondOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksSecondOrderTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_second_order_ticks_to_arrow_ipc_projected);
 }
 
@@ -275,9 +275,9 @@ inline ColumnPresence greeks_third_order_ticks_present_columns(const std::vector
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksThirdOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<GreeksThirdOrderTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_greeks_third_order_ticks_to_arrow_ipc_projected);
 }
 
@@ -305,9 +305,9 @@ inline ColumnPresence index_price_at_time_ticks_present_columns(const std::vecto
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> index_price_at_time_ticks_to_arrow_ipc_projected(const std::vector<IndexPriceAtTimeTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> index_price_at_time_ticks_to_arrow_ipc_projected(const std::vector<IndexPriceAtTimeTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_index_price_at_time_ticks_to_arrow_ipc_projected);
 }
 
@@ -335,9 +335,9 @@ inline ColumnPresence interest_rate_ticks_present_columns(const std::vector<std:
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> interest_rate_ticks_to_arrow_ipc_projected(const std::vector<InterestRateTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> interest_rate_ticks_to_arrow_ipc_projected(const std::vector<InterestRateTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_interest_rate_ticks_to_arrow_ipc_projected);
 }
 
@@ -365,9 +365,9 @@ inline ColumnPresence iv_ticks_present_columns(const std::vector<std::string>& h
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> iv_ticks_to_arrow_ipc_projected(const std::vector<IvTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> iv_ticks_to_arrow_ipc_projected(const std::vector<IvTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_iv_ticks_to_arrow_ipc_projected);
 }
 
@@ -395,9 +395,9 @@ inline ColumnPresence market_value_ticks_present_columns(const std::vector<std::
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> market_value_ticks_to_arrow_ipc_projected(const std::vector<MarketValueTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> market_value_ticks_to_arrow_ipc_projected(const std::vector<MarketValueTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_market_value_ticks_to_arrow_ipc_projected);
 }
 
@@ -425,9 +425,9 @@ inline ColumnPresence ohlc_ticks_present_columns(const std::vector<std::string>&
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> ohlc_ticks_to_arrow_ipc_projected(const std::vector<OhlcTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> ohlc_ticks_to_arrow_ipc_projected(const std::vector<OhlcTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_ohlc_ticks_to_arrow_ipc_projected);
 }
 
@@ -455,9 +455,9 @@ inline ColumnPresence open_interest_ticks_present_columns(const std::vector<std:
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> open_interest_ticks_to_arrow_ipc_projected(const std::vector<OpenInterestTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> open_interest_ticks_to_arrow_ipc_projected(const std::vector<OpenInterestTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_open_interest_ticks_to_arrow_ipc_projected);
 }
 
@@ -485,9 +485,9 @@ inline ColumnPresence price_ticks_present_columns(const std::vector<std::string>
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> price_ticks_to_arrow_ipc_projected(const std::vector<PriceTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> price_ticks_to_arrow_ipc_projected(const std::vector<PriceTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_price_ticks_to_arrow_ipc_projected);
 }
 
@@ -515,9 +515,9 @@ inline ColumnPresence quote_ticks_present_columns(const std::vector<std::string>
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> quote_ticks_to_arrow_ipc_projected(const std::vector<QuoteTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> quote_ticks_to_arrow_ipc_projected(const std::vector<QuoteTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_quote_ticks_to_arrow_ipc_projected);
 }
 
@@ -545,9 +545,9 @@ inline ColumnPresence trade_greeks_all_ticks_present_columns(const std::vector<s
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_all_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksAllTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_greeks_all_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksAllTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_all_ticks_to_arrow_ipc_projected);
 }
 
@@ -575,9 +575,9 @@ inline ColumnPresence trade_greeks_first_order_ticks_present_columns(const std::
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksFirstOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_greeks_first_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksFirstOrderTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_first_order_ticks_to_arrow_ipc_projected);
 }
 
@@ -605,9 +605,9 @@ inline ColumnPresence trade_greeks_implied_volatility_ticks_present_columns(cons
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksImpliedVolatilityTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksImpliedVolatilityTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_implied_volatility_ticks_to_arrow_ipc_projected);
 }
 
@@ -635,9 +635,9 @@ inline ColumnPresence trade_greeks_second_order_ticks_present_columns(const std:
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksSecondOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_greeks_second_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksSecondOrderTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_second_order_ticks_to_arrow_ipc_projected);
 }
 
@@ -665,9 +665,9 @@ inline ColumnPresence trade_greeks_third_order_ticks_present_columns(const std::
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksThirdOrderTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_greeks_third_order_ticks_to_arrow_ipc_projected(const std::vector<TradeGreeksThirdOrderTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_greeks_third_order_ticks_to_arrow_ipc_projected);
 }
 
@@ -695,9 +695,9 @@ inline ColumnPresence trade_quote_ticks_present_columns(const std::vector<std::s
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_quote_ticks_to_arrow_ipc_projected(const std::vector<TradeQuoteTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_quote_ticks_to_arrow_ipc_projected(const std::vector<TradeQuoteTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_quote_ticks_to_arrow_ipc_projected);
 }
 
@@ -725,9 +725,9 @@ inline ColumnPresence trade_ticks_present_columns(const std::vector<std::string>
 /// `_present_columns`), the terminal-exact output Python's
 /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the
 /// response's constant root, broadcast as the leading column
-/// (option/index carry it, stock does not; empty -> omitted). Throws
+/// (option/index carry it, stock does not; `nullptr` omits it). Throws
 /// `thetadatadx::Error` on failure; the returned vector owns its memory.
-inline std::vector<uint8_t> trade_ticks_to_arrow_ipc_projected(const std::vector<TradeTick>& rows, const ColumnPresence& presence, const std::string& symbol = {}) {
+inline std::vector<uint8_t> trade_ticks_to_arrow_ipc_projected(const std::vector<TradeTick>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {
     return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_trade_ticks_to_arrow_ipc_projected);
 }
 

--- a/thetadatadx-ffi/src/types.rs
+++ b/thetadatadx-ffi/src/types.rs
@@ -745,14 +745,19 @@ macro_rules! tick_array_to_arrow_ipc_projected {
                 let Some(mut columns) = (unsafe { presence.to_presence() }) else {
                     return ThetaDataDxArrowBytes::EMPTY;
                 };
-                // SAFETY: `symbol` is the caller's optional NUL-terminated
-                // string; `cstr_to_str` validates non-null + UTF-8.
-                match unsafe { crate::error::cstr_to_str(symbol) } {
-                    Ok(Some(s)) => columns = columns.with_symbol(s),
-                    Ok(None) => {}
-                    Err(e) => {
-                        crate::error::set_error(&format!("symbol is not UTF-8: {e}"));
-                        return ThetaDataDxArrowBytes::EMPTY;
+                // Ignore the broadcast `symbol` when the tick already owns a
+                // per-row `symbol` column (OptionContract) so the projected
+                // schema never carries a duplicate `symbol`.
+                if !columns.contains("symbol") {
+                    // SAFETY: `symbol` is the caller's optional NUL-terminated
+                    // string; `cstr_to_str` validates non-null + UTF-8.
+                    match unsafe { crate::error::cstr_to_str(symbol) } {
+                        Ok(Some(s)) => columns = columns.with_symbol(s),
+                        Ok(None) => {}
+                        Err(e) => {
+                            crate::error::set_error(&format!("symbol is not UTF-8: {e}"));
+                            return ThetaDataDxArrowBytes::EMPTY;
+                        }
                     }
                 }
                 let slice: &[$tick] = if len == 0 {

--- a/thetadatadx-ffi/src/types.rs
+++ b/thetadatadx-ffi/src/types.rs
@@ -545,9 +545,11 @@ pub unsafe extern "C" fn thetadatadx_arrow_bytes_free(bytes: ThetaDataDxArrowByt
 //  * `thetadatadx_<tick>_present_columns(headers, len)` runs the SAME
 //    `WireColumns::present_columns` the buffered path uses — the decode-fed
 //    producer, given a response's wire header names.
-//  * `thetadatadx_<tick>_ticks_to_arrow_ipc_projected(rows, len, presence)`
+//  * `thetadatadx_<tick>_ticks_to_arrow_ipc_projected(rows, len, presence, symbol)`
 //    serialises the rows through `TicksArrowExt::to_arrow_projected`, so the
-//    IPC stream omits exactly the columns the wire omitted.
+//    IPC stream omits exactly the columns the wire omitted and broadcasts the
+//    response's constant `symbol` (root) as the leading column when non-null
+//    (option/index carry it, stock does not).
 //
 // The all-present `thetadatadx_<tick>_ticks_to_arrow_ipc` terminal is
 // unchanged — a hand-built row vector a caller assembled itself never touched
@@ -716,6 +718,11 @@ macro_rules! tick_array_to_arrow_ipc_projected {
         /// may be null only when `len` is 0. Caller MUST free the result with
         /// `thetadatadx_arrow_bytes_free`.
         ///
+        /// `symbol` is the response's constant root value, broadcast as the
+        /// leading `symbol` column (option/index responses carry it, stock does
+        /// not); pass null to omit it. `symbol` must be a NUL-terminated C string
+        /// valid for the call when non-null.
+        ///
         /// # Safety
         /// `rows` must point to `len` initialised `$tick` values valid for the
         /// call; `presence` must be a valid [`ThetaDataDxColumnPresence`] (its
@@ -726,6 +733,7 @@ macro_rules! tick_array_to_arrow_ipc_projected {
             rows: *const $tick,
             len: usize,
             presence: ThetaDataDxColumnPresence,
+            symbol: *const c_char,
         ) -> ThetaDataDxArrowBytes {
             ffi_boundary!(ThetaDataDxArrowBytes::EMPTY, {
                 if rows.is_null() && len != 0 {
@@ -734,9 +742,19 @@ macro_rules! tick_array_to_arrow_ipc_projected {
                 }
                 // SAFETY: `presence` is the caller's carrier; `to_presence`
                 // validates each name pointer before use.
-                let Some(columns) = (unsafe { presence.to_presence() }) else {
+                let Some(mut columns) = (unsafe { presence.to_presence() }) else {
                     return ThetaDataDxArrowBytes::EMPTY;
                 };
+                // SAFETY: `symbol` is the caller's optional NUL-terminated
+                // string; `cstr_to_str` validates non-null + UTF-8.
+                match unsafe { crate::error::cstr_to_str(symbol) } {
+                    Ok(Some(s)) => columns = columns.with_symbol(s),
+                    Ok(None) => {}
+                    Err(e) => {
+                        crate::error::set_error(&format!("symbol is not UTF-8: {e}"));
+                        return ThetaDataDxArrowBytes::EMPTY;
+                    }
+                }
                 let slice: &[$tick] = if len == 0 {
                     &[]
                 } else {

--- a/thetadatadx-ffi/tests/arrow_ipc_projected.rs
+++ b/thetadatadx-ffi/tests/arrow_ipc_projected.rs
@@ -169,7 +169,7 @@ fn decode_fed_projected_export_omits_flags_and_contract_id() {
     let cols = ipc_columns(&bytes);
     // SAFETY: `bytes` came from the terminal; freed exactly once.
     unsafe { thetadatadx_arrow_bytes_free(bytes) };
-    // SAFETY: free the original carrier exactly once (the copy was never freed).
+    // SAFETY: free the no-symbol/no-flags presence carrier once; the projected serializer borrowed (copied) it, so the original is still ours to free.
     unsafe { thetadatadx_column_presence_free(presence) };
 
     // The projected frame is exactly the wire's columns, in schema order.
@@ -243,7 +243,7 @@ fn projected_export_broadcasts_symbol_as_leading_column() {
     let cols = ipc_columns(&bytes);
     // SAFETY: `bytes` came from the terminal; freed exactly once.
     unsafe { thetadatadx_arrow_bytes_free(bytes) };
-    // SAFETY: free the original carrier exactly once (the copy was never freed).
+    // SAFETY: free the presence carrier that held the broadcast `symbol` once; the serializer copied it, so this frees the original, not the copy.
     unsafe { thetadatadx_column_presence_free(presence) };
 
     assert_eq!(
@@ -336,7 +336,7 @@ fn empty_presence_projects_to_zero_columns_with_row_count() {
     let (cols, num_rows) = ipc_columns_and_rows(&bytes);
     // SAFETY: `bytes` came from the terminal; freed exactly once.
     unsafe { thetadatadx_arrow_bytes_free(bytes) };
-    // SAFETY: free the original carrier exactly once (the copy was never freed).
+    // SAFETY: free the empty-presence carrier once; the serializer copied it, so the original is freed here exactly once.
     unsafe { thetadatadx_column_presence_free(presence) };
 
     assert!(

--- a/thetadatadx-ffi/tests/arrow_ipc_projected.rs
+++ b/thetadatadx-ffi/tests/arrow_ipc_projected.rs
@@ -159,7 +159,12 @@ fn decode_fed_projected_export_omits_flags_and_contract_id() {
     // SAFETY: `rows` is a live slice; `carrier_copy` aliases the still-owned
     // `presence` names, valid for the call. The terminal only reads it.
     let bytes = unsafe {
-        thetadatadx_trade_ticks_to_arrow_ipc_projected(rows.as_ptr(), rows.len(), carrier_copy)
+        thetadatadx_trade_ticks_to_arrow_ipc_projected(
+            rows.as_ptr(),
+            rows.len(),
+            carrier_copy,
+            std::ptr::null(),
+        )
     };
     let cols = ipc_columns(&bytes);
     // SAFETY: `bytes` came from the terminal; freed exactly once.
@@ -199,6 +204,57 @@ fn decode_fed_projected_export_omits_flags_and_contract_id() {
             "projected export leaked the wire-absent column `{absent}`"
         );
     }
+}
+
+#[test]
+fn projected_export_broadcasts_symbol_as_leading_column() {
+    // An option-trade response carries a constant `symbol` (root). Passing it
+    // to the projected terminal must prepend a `symbol` Utf8 column, first in
+    // schema order, valued on every row.
+    let rows = sample_rows();
+    let option_headers: &[&str] = &[
+        "symbol",
+        "expiration",
+        "strike",
+        "right",
+        "ms_of_day",
+        "sequence",
+        "condition",
+        "size",
+        "exchange",
+        "price",
+    ];
+    let presence = presence_from_headers(option_headers);
+    let carrier_copy = ThetaDataDxColumnPresence {
+        names: presence.names,
+        len: presence.len,
+    };
+    let symbol = CString::new("SPY").unwrap();
+    // SAFETY: `rows` is a live slice; `carrier_copy` aliases the still-owned
+    // `presence`; `symbol` is a live C string for the call.
+    let bytes = unsafe {
+        thetadatadx_trade_ticks_to_arrow_ipc_projected(
+            rows.as_ptr(),
+            rows.len(),
+            carrier_copy,
+            symbol.as_ptr(),
+        )
+    };
+    let cols = ipc_columns(&bytes);
+    // SAFETY: `bytes` came from the terminal; freed exactly once.
+    unsafe { thetadatadx_arrow_bytes_free(bytes) };
+    // SAFETY: free the original carrier exactly once (the copy was never freed).
+    unsafe { thetadatadx_column_presence_free(presence) };
+
+    assert_eq!(
+        cols.first().map(String::as_str),
+        Some("symbol"),
+        "symbol must be the leading projected column; got {cols:?}"
+    );
+    assert!(
+        cols.contains(&"expiration".to_string()),
+        "option projection keeps the contract-id trio; got {cols:?}"
+    );
 }
 
 #[test]
@@ -270,7 +326,12 @@ fn empty_presence_projects_to_zero_columns_with_row_count() {
     // SAFETY: `rows` is a live slice; `carrier_copy` aliases the still-owned
     // empty carrier. The terminal only reads it.
     let bytes = unsafe {
-        thetadatadx_trade_ticks_to_arrow_ipc_projected(rows.as_ptr(), rows.len(), carrier_copy)
+        thetadatadx_trade_ticks_to_arrow_ipc_projected(
+            rows.as_ptr(),
+            rows.len(),
+            carrier_copy,
+            std::ptr::null(),
+        )
     };
     let (cols, num_rows) = ipc_columns_and_rows(&bytes);
     // SAFETY: `bytes` came from the terminal; freed exactly once.

--- a/thetadatadx-py/src/_generated/tick_arrow.rs
+++ b/thetadatadx-py/src/_generated/tick_arrow.rs
@@ -3081,10 +3081,6 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
-        if let Some(sym) = present.symbol() {
-            fields.push(Field::new("symbol", DataType::Utf8, false));
-            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
-        }
         if has_symbol {
             fields.push(Field::new("symbol", DataType::Utf8, false));
             columns.push(Arc::new(StringArray::from(col_symbol)) as ArrayRef);

--- a/thetadatadx-py/src/_generated/tick_arrow.rs
+++ b/thetadatadx-py/src/_generated/tick_arrow.rs
@@ -554,6 +554,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_date {
             fields.push(Field::new("date", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_date)) as ArrayRef);
@@ -731,6 +735,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_created_ms_of_day {
             fields.push(Field::new("created_ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_created_ms_of_day)) as ArrayRef);
@@ -1034,6 +1042,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -1453,6 +1465,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -1764,6 +1780,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -1965,6 +1985,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2156,6 +2180,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2319,6 +2347,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2412,6 +2444,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_date {
             fields.push(Field::new("date", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_date)) as ArrayRef);
@@ -2541,6 +2577,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2682,6 +2722,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2823,6 +2867,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2944,6 +2992,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3029,6 +3081,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_symbol {
             fields.push(Field::new("symbol", DataType::Utf8, false));
             columns.push(Arc::new(StringArray::from(col_symbol)) as ArrayRef);
@@ -3100,6 +3156,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3233,6 +3293,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3554,6 +3618,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3887,6 +3955,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4128,6 +4200,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4375,6 +4451,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4636,6 +4716,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4923,6 +5007,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -5176,6 +5264,10 @@ pub(crate) mod slice_arrow {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);

--- a/thetadatadx-rs/build_support_bin/ticks/cpp.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/cpp.rs
@@ -142,14 +142,16 @@ pub(super) fn render_cpp_tick_arrow_ipc(schema: &Schema) -> String {
     out.push_str(
         "/// Serialise a typed history-row vector as a PROJECTED Arrow IPC stream —\n\
          /// only the columns named in `presence` — by forwarding to its `_projected`\n\
-         /// C ABI serialiser. Same error / empty-stream contract as `tick_to_arrow_ipc`.\n",
+         /// C ABI serialiser. `symbol` is the response's constant root, broadcast as\n\
+         /// the leading column (empty -> omitted). Same error / empty-stream contract\n\
+         /// as `tick_to_arrow_ipc`.\n",
     );
     out.push_str("template <typename Tick, typename CFn>\n");
     out.push_str(
-        "inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, CFn c_fn) {\n",
+        "inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, const std::string& symbol, CFn c_fn) {\n",
     );
     out.push_str(
-        "    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw());\n",
+        "    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw(), symbol.empty() ? nullptr : symbol.c_str());\n",
     );
     out.push_str("    if (raw.data == nullptr) {\n");
     out.push_str("        throw_last_ffi_error();\n");
@@ -229,17 +231,19 @@ pub(super) fn render_cpp_tick_arrow_ipc(schema: &Schema) -> String {
         out.push_str(
             "/// only the columns `presence` names (from the matching\n\
              /// `_present_columns`), the terminal-exact output Python's\n\
-             /// `<TickName>List.to_arrow()` gives on a decode result. Throws\n\
+             /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the\n\
+             /// response's constant root, broadcast as the leading column\n\
+             /// (option/index carry it, stock does not; empty -> omitted). Throws\n\
              /// `thetadatadx::Error` on failure; the returned vector owns its memory.\n",
         );
         writeln!(
             out,
-            "inline std::vector<uint8_t> {snake}_to_arrow_ipc_projected(const std::vector<{type_name}>& rows, const ColumnPresence& presence) {{"
+            "inline std::vector<uint8_t> {snake}_to_arrow_ipc_projected(const std::vector<{type_name}>& rows, const ColumnPresence& presence, const std::string& symbol = {{}}) {{"
         )
         .unwrap();
         writeln!(
             out,
-            "    return detail::tick_to_arrow_ipc_projected(rows, presence, thetadatadx_{snake}_to_arrow_ipc_projected);"
+            "    return detail::tick_to_arrow_ipc_projected(rows, presence, symbol, thetadatadx_{snake}_to_arrow_ipc_projected);"
         )
         .unwrap();
         out.push_str("}\n\n");

--- a/thetadatadx-rs/build_support_bin/ticks/cpp.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/cpp.rs
@@ -143,15 +143,15 @@ pub(super) fn render_cpp_tick_arrow_ipc(schema: &Schema) -> String {
         "/// Serialise a typed history-row vector as a PROJECTED Arrow IPC stream —\n\
          /// only the columns named in `presence` — by forwarding to its `_projected`\n\
          /// C ABI serialiser. `symbol` is the response's constant root, broadcast as\n\
-         /// the leading column (empty -> omitted). Same error / empty-stream contract\n\
-         /// as `tick_to_arrow_ipc`.\n",
+         /// the leading column; `nullptr` omits it (an empty string stays a valid\n\
+         /// value). Same error / empty-stream contract as `tick_to_arrow_ipc`.\n",
     );
     out.push_str("template <typename Tick, typename CFn>\n");
     out.push_str(
-        "inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, const std::string& symbol, CFn c_fn) {\n",
+        "inline std::vector<uint8_t> tick_to_arrow_ipc_projected(const std::vector<Tick>& rows, const ColumnPresence& presence, const char* symbol, CFn c_fn) {\n",
     );
     out.push_str(
-        "    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw(), symbol.empty() ? nullptr : symbol.c_str());\n",
+        "    ThetaDataDxArrowBytes raw = c_fn(rows.data(), rows.size(), presence.raw(), symbol);\n",
     );
     out.push_str("    if (raw.data == nullptr) {\n");
     out.push_str("        throw_last_ffi_error();\n");
@@ -233,12 +233,12 @@ pub(super) fn render_cpp_tick_arrow_ipc(schema: &Schema) -> String {
              /// `_present_columns`), the terminal-exact output Python's\n\
              /// `<TickName>List.to_arrow()` gives on a decode result. `symbol` is the\n\
              /// response's constant root, broadcast as the leading column\n\
-             /// (option/index carry it, stock does not; empty -> omitted). Throws\n\
+             /// (option/index carry it, stock does not; `nullptr` omits it). Throws\n\
              /// `thetadatadx::Error` on failure; the returned vector owns its memory.\n",
         );
         writeln!(
             out,
-            "inline std::vector<uint8_t> {snake}_to_arrow_ipc_projected(const std::vector<{type_name}>& rows, const ColumnPresence& presence, const std::string& symbol = {{}}) {{"
+            "inline std::vector<uint8_t> {snake}_to_arrow_ipc_projected(const std::vector<{type_name}>& rows, const ColumnPresence& presence, const char* symbol = nullptr) {{"
         )
         .unwrap();
         writeln!(

--- a/thetadatadx-rs/build_support_bin/ticks/python_arrow.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/python_arrow.rs
@@ -478,6 +478,13 @@ fn render_python_slice_reader_projected(type_name: &str, def: &TickTypeDef) -> S
     out.push_str("    }\n");
     out.push_str("    let mut fields: Vec<Field> = Vec::new();\n");
     out.push_str("    let mut columns: Vec<ArrayRef> = Vec::new();\n");
+    // Leading `symbol` (root) column, broadcast from the response constant —
+    // option/index endpoints carry it, stock does not. First in schema order,
+    // mirroring the Rust `to_arrow_projected` builder.
+    out.push_str("    if let Some(sym) = present.symbol() {\n");
+    out.push_str("        fields.push(Field::new(\"symbol\", DataType::Utf8, false));\n");
+    out.push_str("        columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);\n");
+    out.push_str("    }\n");
     for c in &cols {
         writeln!(out, "    if has_{name} {{", name = c.name).unwrap();
         writeln!(

--- a/thetadatadx-rs/build_support_bin/ticks/python_arrow.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/python_arrow.rs
@@ -480,11 +480,17 @@ fn render_python_slice_reader_projected(type_name: &str, def: &TickTypeDef) -> S
     out.push_str("    let mut columns: Vec<ArrayRef> = Vec::new();\n");
     // Leading `symbol` (root) column, broadcast from the response constant —
     // option/index endpoints carry it, stock does not. First in schema order,
-    // mirroring the Rust `to_arrow_projected` builder.
-    out.push_str("    if let Some(sym) = present.symbol() {\n");
-    out.push_str("        fields.push(Field::new(\"symbol\", DataType::Utf8, false));\n");
-    out.push_str("        columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);\n");
-    out.push_str("    }\n");
+    // mirroring the Rust `to_arrow_projected` builder. Skipped when the tick
+    // already owns a per-row `symbol` column (OptionContract) to avoid a
+    // duplicate field.
+    if !def.columns.iter().any(|c| c.field == "symbol") {
+        out.push_str("    if let Some(sym) = present.symbol() {\n");
+        out.push_str("        fields.push(Field::new(\"symbol\", DataType::Utf8, false));\n");
+        out.push_str(
+            "        columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);\n",
+        );
+        out.push_str("    }\n");
+    }
     for c in &cols {
         writeln!(out, "    if has_{name} {{", name = c.name).unwrap();
         writeln!(

--- a/thetadatadx-rs/build_support_bin/ticks/rust_frames.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/rust_frames.rs
@@ -101,6 +101,14 @@ struct EmitColumn {
     nullable: bool,
 }
 
+/// `true` when the tick's own schema carries a `symbol` column (OptionContract
+/// — the `option_list_contracts` per-row underlying). Such a type must NOT also
+/// get the broadcast response-root `symbol` prepend, or the projected schema
+/// would carry two `symbol` fields.
+pub(super) fn tick_has_symbol_column(def: &TickTypeDef) -> bool {
+    def.columns.iter().any(|c| c.field == "symbol")
+}
+
 /// The ordered emittable columns for a tick type: its schema columns,
 /// then the contract-identity trio when `contract_id = true`, then the
 /// `QuoteTick.midpoint` derived tail. Mirrors the column order the Python
@@ -168,6 +176,7 @@ fn emit_columns(type_name: &str, def: &TickTypeDef) -> Vec<EmitColumn> {
 
 fn render_arrow_impl(type_name: &str, def: &TickTypeDef) -> String {
     let cols = emit_columns(type_name, def);
+    let has_symbol_field = tick_has_symbol_column(def);
     let mut out = String::new();
 
     out.push_str("#[cfg(feature = \"arrow\")]\n");
@@ -282,13 +291,16 @@ fn render_arrow_impl(type_name: &str, def: &TickTypeDef) -> String {
     out.push_str("        let mut columns: Vec<ArrayRef> = Vec::new();\n");
     // Leading `symbol` (root) column, broadcast from the response constant —
     // option/index endpoints carry it, stock does not. First in schema order
-    // to match the wire header layout.
-    out.push_str("        if let Some(sym) = present.symbol() {\n");
-    out.push_str("            fields.push(Field::new(\"symbol\", DataType::Utf8, false));\n");
-    out.push_str(
-        "            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);\n",
-    );
-    out.push_str("        }\n");
+    // to match the wire header layout. Skipped for tick types that already own
+    // a per-row `symbol` column (OptionContract) so the schema has no duplicate.
+    if !has_symbol_field {
+        out.push_str("        if let Some(sym) = present.symbol() {\n");
+        out.push_str("            fields.push(Field::new(\"symbol\", DataType::Utf8, false));\n");
+        out.push_str(
+            "            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);\n",
+        );
+        out.push_str("        }\n");
+    }
     for c in &cols {
         writeln!(out, "        if has_{name} {{", name = c.name).unwrap();
         writeln!(
@@ -329,6 +341,7 @@ fn render_arrow_impl(type_name: &str, def: &TickTypeDef) -> String {
 
 fn render_polars_impl(type_name: &str, def: &TickTypeDef) -> String {
     let cols = emit_columns(type_name, def);
+    let has_symbol_field = tick_has_symbol_column(def);
     let mut out = String::new();
 
     out.push_str("#[cfg(feature = \"polars\")]\n");
@@ -422,12 +435,15 @@ fn render_polars_impl(type_name: &str, def: &TickTypeDef) -> String {
     out.push_str("        }\n");
     out.push_str("        let mut series: Vec<polars::prelude::Column> = Vec::new();\n");
     // Leading `symbol` (root) column, broadcast from the response constant —
-    // first in schema order to match the Arrow builder and the wire.
-    out.push_str("        if let Some(sym) = present.symbol() {\n");
-    out.push_str(
-        "            series.push(Series::new(PlSmallStr::from_static(\"symbol\"), vec![sym.to_string(); n]).into());\n",
-    );
-    out.push_str("        }\n");
+    // first in schema order to match the Arrow builder and the wire. Skipped
+    // when the tick already owns a per-row `symbol` column (OptionContract).
+    if !has_symbol_field {
+        out.push_str("        if let Some(sym) = present.symbol() {\n");
+        out.push_str(
+            "            series.push(Series::new(PlSmallStr::from_static(\"symbol\"), vec![sym.to_string(); n]).into());\n",
+        );
+        out.push_str("        }\n");
+    }
     for c in &cols {
         writeln!(out, "        if has_{name} {{", name = c.name).unwrap();
         writeln!(

--- a/thetadatadx-rs/build_support_bin/ticks/rust_frames.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/rust_frames.rs
@@ -280,6 +280,15 @@ fn render_arrow_impl(type_name: &str, def: &TickTypeDef) -> String {
     out.push_str("        }\n");
     out.push_str("        let mut fields: Vec<Field> = Vec::new();\n");
     out.push_str("        let mut columns: Vec<ArrayRef> = Vec::new();\n");
+    // Leading `symbol` (root) column, broadcast from the response constant —
+    // option/index endpoints carry it, stock does not. First in schema order
+    // to match the wire header layout.
+    out.push_str("        if let Some(sym) = present.symbol() {\n");
+    out.push_str("            fields.push(Field::new(\"symbol\", DataType::Utf8, false));\n");
+    out.push_str(
+        "            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);\n",
+    );
+    out.push_str("        }\n");
     for c in &cols {
         writeln!(out, "        if has_{name} {{", name = c.name).unwrap();
         writeln!(
@@ -412,6 +421,13 @@ fn render_polars_impl(type_name: &str, def: &TickTypeDef) -> String {
     }
     out.push_str("        }\n");
     out.push_str("        let mut series: Vec<polars::prelude::Column> = Vec::new();\n");
+    // Leading `symbol` (root) column, broadcast from the response constant —
+    // first in schema order to match the Arrow builder and the wire.
+    out.push_str("        if let Some(sym) = present.symbol() {\n");
+    out.push_str(
+        "            series.push(Series::new(PlSmallStr::from_static(\"symbol\"), vec![sym.to_string(); n]).into());\n",
+    );
+    out.push_str("        }\n");
     for c in &cols {
         writeln!(out, "        if has_{name} {{", name = c.name).unwrap();
         writeln!(

--- a/thetadatadx-rs/src/columns.rs
+++ b/thetadatadx-rs/src/columns.rs
@@ -36,6 +36,14 @@ pub struct ColumnPresence {
     /// Present schema-column names in schema order. Small (≤ ~24 entries),
     /// so a linear scan in [`Self::contains`] beats a hashed set.
     names: Vec<Box<str>>,
+    /// The response's `symbol` (root) header value, when the wire carried
+    /// one. Option + index historical endpoints send a `symbol` column
+    /// constant across the response (the queried underlying); stock
+    /// endpoints do not. It is not a tick-struct field (the flat POD ticks
+    /// hold no per-row `String`), so it rides here once and the projected
+    /// builders broadcast it as the first Arrow/Polars column. `None` for
+    /// stock responses and every hand-built / streaming frame.
+    symbol: Option<Box<str>>,
 }
 
 impl ColumnPresence {
@@ -52,7 +60,25 @@ impl ColumnPresence {
     {
         Self {
             names: names.into_iter().map(Into::into).collect(),
+            symbol: None,
         }
+    }
+
+    /// Attach the response's constant `symbol` (root) value, so the projected
+    /// builders emit it as the leading broadcast column. The decode seam calls
+    /// this once per response after reading the wire `symbol`/`root` header;
+    /// binding decode seams reconstruct it the same way.
+    #[must_use]
+    pub fn with_symbol<S: Into<Box<str>>>(mut self, symbol: S) -> Self {
+        self.symbol = Some(symbol.into());
+        self
+    }
+
+    /// The response's constant `symbol` (root), when the wire carried one.
+    /// `None` for stock responses and hand-built / streaming frames.
+    #[must_use]
+    pub fn symbol(&self) -> Option<&str> {
+        self.symbol.as_deref()
     }
 
     /// `true` when the response carried the column `name` (a schema field

--- a/thetadatadx-rs/src/frames/generated.rs
+++ b/thetadatadx-rs/src/frames/generated.rs
@@ -74,6 +74,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::CalendarDay] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_date {
             fields.push(Field::new("date", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_date)) as ArrayRef);
@@ -146,6 +150,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::CalendarDay] {
             if has_status { col_status.push(t.status.as_str().to_string()); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_date {
             series.push(Series::new(PlSmallStr::from_static("date"), col_date).into());
         }
@@ -327,6 +334,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::EodTick] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_created_ms_of_day {
             fields.push(Field::new("created_ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_created_ms_of_day)) as ArrayRef);
@@ -549,6 +560,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::EodTick] {
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_created_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("created_ms_of_day"), col_created_ms_of_day).into());
         }
@@ -852,6 +866,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::GreeksAllTick] 
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -1184,6 +1202,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::GreeksAllTick]
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -1604,6 +1625,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::GreeksEodTick] 
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2056,6 +2081,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::GreeksEodTick]
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -2330,6 +2358,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::GreeksFirstOrde
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2522,6 +2554,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::GreeksFirstOrd
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -2711,6 +2746,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::GreeksSecondOrd
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -2893,6 +2932,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::GreeksSecondOr
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -3072,6 +3114,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::GreeksThirdOrde
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3244,6 +3290,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::GreeksThirdOrd
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -3392,6 +3441,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::IndexPriceAtTim
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3524,6 +3577,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::IndexPriceAtTi
             if has_date { col_date.push(t.date); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -3597,6 +3653,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::InterestRateTic
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_date {
             fields.push(Field::new("date", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_date)) as ArrayRef);
@@ -3639,6 +3699,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::InterestRateTi
             if has_rate { col_rate.push(t.rate); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_date {
             series.push(Series::new(PlSmallStr::from_static("date"), col_date).into());
         }
@@ -3769,6 +3832,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::IvTick] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -3931,6 +3998,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::IvTick] {
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -4055,6 +4125,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::MarketValueTick
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4157,6 +4231,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::MarketValueTic
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -4291,6 +4368,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::OhlcTick] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4433,6 +4514,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::OhlcTick] {
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -4537,6 +4621,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::OpenInterestTic
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4619,6 +4707,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::OpenInterestTi
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -4691,6 +4782,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::OptionContract]
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_symbol {
             fields.push(Field::new("symbol", DataType::Utf8, false));
             columns.push(Arc::new(StringArray::from(col_symbol)) as ArrayRef);
@@ -4753,6 +4848,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::OptionContract
             if has_right { col_right.push(if t.right == '\0' { String::new() } else { t.right.to_string() }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_symbol {
             series.push(Series::new(PlSmallStr::from_static("symbol"), col_symbol).into());
         }
@@ -4812,6 +4910,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::PriceTick] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -4864,6 +4966,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::PriceTick] {
             if has_date { col_date.push(t.date); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -4997,6 +5102,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::QuoteTick] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -5159,6 +5268,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::QuoteTick] {
             if has_midpoint { col_midpoint.push(t.midpoint); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -5493,6 +5605,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeGreeksAllT
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -5895,6 +6011,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeGreeksAll
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -6203,6 +6322,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeGreeksFirs
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -6465,6 +6588,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeGreeksFir
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -6689,6 +6815,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeGreeksImpl
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -6891,6 +7021,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeGreeksImp
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -7132,6 +7265,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeGreeksSeco
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -7384,6 +7521,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeGreeksSec
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -7633,6 +7773,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeGreeksThir
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -7875,6 +8019,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeGreeksThi
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -8156,6 +8303,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeQuoteTick]
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -8448,6 +8599,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeQuoteTick
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }
@@ -8681,6 +8835,10 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::TradeTick] {
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            fields.push(Field::new("symbol", DataType::Utf8, false));
+            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
+        }
         if has_ms_of_day {
             fields.push(Field::new("ms_of_day", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef);
@@ -8883,6 +9041,9 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::TradeTick] {
             if has_right { col_right.push(if t.right == '\0' { None } else { Some(t.right.to_string()) }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
+        if let Some(sym) = present.symbol() {
+            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
+        }
         if has_ms_of_day {
             series.push(Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into());
         }

--- a/thetadatadx-rs/src/frames/generated.rs
+++ b/thetadatadx-rs/src/frames/generated.rs
@@ -4782,10 +4782,6 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::OptionContract]
         }
         let mut fields: Vec<Field> = Vec::new();
         let mut columns: Vec<ArrayRef> = Vec::new();
-        if let Some(sym) = present.symbol() {
-            fields.push(Field::new("symbol", DataType::Utf8, false));
-            columns.push(Arc::new(StringArray::from(vec![sym; n])) as ArrayRef);
-        }
         if has_symbol {
             fields.push(Field::new("symbol", DataType::Utf8, false));
             columns.push(Arc::new(StringArray::from(col_symbol)) as ArrayRef);
@@ -4848,9 +4844,6 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::OptionContract
             if has_right { col_right.push(if t.right == '\0' { String::new() } else { t.right.to_string() }); }
         }
         let mut series: Vec<polars::prelude::Column> = Vec::new();
-        if let Some(sym) = present.symbol() {
-            series.push(Series::new(PlSmallStr::from_static("symbol"), vec![sym.to_string(); n]).into());
-        }
         if has_symbol {
             series.push(Series::new(PlSmallStr::from_static("symbol"), col_symbol).into());
         }

--- a/thetadatadx-rs/src/mdds/decode/extract.rs
+++ b/thetadatadx-rs/src/mdds/decode/extract.rs
@@ -215,6 +215,30 @@ pub fn extract_price_column(
         .collect()
 }
 
+/// The response's constant `symbol` (root) value, when the wire carried a
+/// `symbol`/`root` header — the option + index historical endpoints do, stock
+/// does not. Returns `None` when the header is absent (so the projected frame
+/// gains no `symbol` column on stock responses), else the value read from the
+/// first data row. `symbol` is constant across a wildcard response (only
+/// `expiration`/`strike`/`right` vary), so one read broadcasts to every row;
+/// an empty string stands in for a header-present-but-rowless response so the
+/// column set stays keyed on the header, matching the per-column projection.
+pub(crate) fn response_symbol(table: &proto::DataTable) -> Option<Box<str>> {
+    let header_refs: Vec<&str> = table.headers.iter().map(String::as_str).collect();
+    let col_idx = find_header(&header_refs, "root")?;
+    let value = table
+        .data_table
+        .first()
+        .and_then(|row| row.values.get(col_idx))
+        .and_then(|dv| dv.data_type.as_ref())
+        .and_then(|dt| match dt {
+            proto::data_value::DataType::Text(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    Some(value.into())
+}
+
 /// Sort list-endpoint values ascending for the public `list_*` returns.
 ///
 /// Numeric-aware: when every value parses as a finite `f64` (strikes,
@@ -334,6 +358,70 @@ mod tests {
             "numeric list-endpoint cells must coerce to their decimal \
              string, not drop to None"
         );
+    }
+
+    /// `response_symbol` reads the response's constant root from the first
+    /// row, resolving the schema-side `root` against the wire's `symbol`
+    /// header via the shared alias table.
+    #[test]
+    fn response_symbol_reads_root_via_symbol_alias() {
+        let table = proto::DataTable {
+            headers: vec!["symbol".to_string(), "price".to_string()],
+            data_table: vec![
+                proto::DataValueList {
+                    values: vec![
+                        proto::DataValue {
+                            data_type: Some(proto::data_value::DataType::Text("SPY".into())),
+                        },
+                        proto::DataValue {
+                            data_type: Some(proto::data_value::DataType::Number(1)),
+                        },
+                    ],
+                },
+                proto::DataValueList {
+                    values: vec![
+                        proto::DataValue {
+                            data_type: Some(proto::data_value::DataType::Text("SPY".into())),
+                        },
+                        proto::DataValue {
+                            data_type: Some(proto::data_value::DataType::Number(2)),
+                        },
+                    ],
+                },
+            ],
+        };
+        assert_eq!(response_symbol(&table).as_deref(), Some("SPY"));
+    }
+
+    /// A stock response carries no `symbol`/`root` header, so `response_symbol`
+    /// returns `None` — the projected frame then gains no `symbol` column.
+    #[test]
+    fn response_symbol_absent_header_is_none() {
+        let table = proto::DataTable {
+            headers: vec!["ms_of_day".to_string(), "price".to_string()],
+            data_table: vec![proto::DataValueList {
+                values: vec![
+                    proto::DataValue {
+                        data_type: Some(proto::data_value::DataType::Number(1)),
+                    },
+                    proto::DataValue {
+                        data_type: Some(proto::data_value::DataType::Number(2)),
+                    },
+                ],
+            }],
+        };
+        assert_eq!(response_symbol(&table), None);
+    }
+
+    /// Header present but no data rows -> `Some("")`: the column set stays keyed
+    /// on the header (matching per-column projection), broadcast over zero rows.
+    #[test]
+    fn response_symbol_header_present_no_rows_is_empty() {
+        let table = proto::DataTable {
+            headers: vec!["symbol".to_string()],
+            data_table: Vec::new(),
+        };
+        assert_eq!(response_symbol(&table).as_deref(), Some(""));
     }
 
     /// Empty `DataTable` returns empty Vec without alias resolution —

--- a/thetadatadx-rs/src/mdds/macros.rs
+++ b/thetadatadx-rs/src/mdds/macros.rs
@@ -984,6 +984,13 @@ macro_rules! parsed_endpoint {
                         let columns = <$item as $crate::columns::WireColumns>::present_columns(
                             &present_headers,
                         );
+                        // Carry the response's constant `symbol` (root) so the
+                        // projected frame broadcasts it as the leading column —
+                        // option/index endpoints send it, stock does not.
+                        let columns = match $crate::mdds::decode::extract::response_symbol(&table) {
+                            Some(symbol) => columns.with_symbol(symbol),
+                            None => columns,
+                        };
                         // Surface the wrong-API-for-this-workload
                         // signal exactly once per request, after the buffered
                         // `Vec` materialized — before this point the row count

--- a/thetadatadx-rs/tests/test_column_projection.rs
+++ b/thetadatadx-rs/tests/test_column_projection.rs
@@ -144,6 +144,121 @@ fn option_trade_quote_keeps_contract_id() {
     }
 }
 
+// ── The response's constant `symbol` (root) rides as the leading column ───
+//
+// Option + index endpoints send a `symbol` header constant across the
+// response; the flat POD tick structs can't hold a per-row `String`, so the
+// decode carries it once on the `ColumnPresence` and the projected builders
+// broadcast it as the first column. Stock endpoints send no `symbol` header.
+// These tests drive the same presence the decode seam builds — the wire
+// header set plus the response's root read through the public
+// `extract_text_column` (the alias-aware `root` <- `symbol` lookup).
+
+/// The presence the decode seam builds for `table`: the wire's column set plus
+/// the response's constant `symbol` (root) when the wire carried one.
+fn presence_with_symbol<T: WireColumns>(table: &proto::DataTable) -> ColumnPresence {
+    let present = presence_of::<T>(table);
+    match decode::extract_text_column(table, "root")
+        .into_iter()
+        .flatten()
+        .next()
+    {
+        Some(symbol) => present.with_symbol(symbol),
+        None => present,
+    }
+}
+
+/// The values of the `symbol` column in a projected batch, or `None` when the
+/// batch carries no `symbol` column.
+fn symbol_column(batch: &arrow_array::RecordBatch) -> Option<Vec<String>> {
+    let idx = batch.schema().index_of("symbol").ok()?;
+    use arrow_array::Array as _;
+    let arr = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<arrow_array::StringArray>()
+        .expect("symbol column is Utf8");
+    Some((0..arr.len()).map(|i| arr.value(i).to_string()).collect())
+}
+
+/// An `option_history_trade` response carries a constant `symbol` (root); the
+/// projected frame prepends a `symbol` Utf8 column valued on every row, first
+/// in schema order to match the wire header layout.
+#[test]
+fn option_trade_broadcasts_symbol_as_leading_column() {
+    let table = load_data_table("option_history_trade");
+    let present = presence_with_symbol::<TradeTick>(&table);
+    let ticks: Vec<TradeTick> = decode::parse_trade_ticks(&table).expect("parse_trade_ticks");
+
+    let batch = ticks.as_slice().to_arrow_projected(&present).unwrap();
+    let cols = arrow_columns(&batch);
+    assert_eq!(
+        cols.first().map(String::as_str),
+        Some("symbol"),
+        "symbol must be the leading column; got {cols:?}"
+    );
+    let values = symbol_column(&batch).expect("symbol column present");
+    assert_eq!(values.len(), ticks.len(), "symbol broadcast to every row");
+    assert!(
+        values.iter().all(|v| v == "SPY"),
+        "symbol value must be the queried root on every row; got {values:?}"
+    );
+
+    // Polars agrees on the column set (symbol first).
+    let df = ticks.as_slice().to_polars_projected(&present).unwrap();
+    assert_eq!(
+        polars_columns(&df),
+        cols,
+        "arrow/polars column sets diverge"
+    );
+    assert_eq!(df.height(), ticks.len());
+}
+
+/// A wildcard option `trade_quote` response also broadcasts `symbol` first,
+/// alongside the contract-identity trio that varies per contract.
+#[test]
+fn option_trade_quote_broadcasts_symbol() {
+    let table = load_data_table("option_history_trade_quote");
+    let present = presence_with_symbol::<TradeQuoteTick>(&table);
+    let ticks: Vec<TradeQuoteTick> =
+        decode::parse_trade_quote_ticks(&table).expect("parse_trade_quote_ticks");
+
+    let batch = ticks.as_slice().to_arrow_projected(&present).unwrap();
+    let cols = arrow_columns(&batch);
+    assert_eq!(
+        cols.first().map(String::as_str),
+        Some("symbol"),
+        "got {cols:?}"
+    );
+    let values = symbol_column(&batch).expect("symbol column present");
+    assert!(
+        !values.is_empty() && values.iter().all(|v| v == &values[0]),
+        "symbol constant across a wildcard response; got {values:?}"
+    );
+    // The contract-id trio still rides after the symbol.
+    for cid in ["expiration", "strike", "right"] {
+        assert!(cols.contains(&cid.to_string()), "missing {cid} in {cols:?}");
+    }
+}
+
+/// A stock response carries no `symbol` header — the projected frame gains no
+/// `symbol` column.
+#[test]
+fn stock_trade_quote_has_no_symbol_column() {
+    let table = load_data_table("stock_history_trade_quote");
+    let present = presence_with_symbol::<TradeQuoteTick>(&table);
+    let ticks: Vec<TradeQuoteTick> =
+        decode::parse_trade_quote_ticks(&table).expect("parse_trade_quote_ticks");
+
+    let batch = ticks.as_slice().to_arrow_projected(&present).unwrap();
+    assert!(
+        symbol_column(&batch).is_none(),
+        "stock response must not carry a symbol column; got {:?}",
+        arrow_columns(&batch)
+    );
+    assert!(present.symbol().is_none(), "no symbol on a stock presence");
+}
+
 // ── Symptom 2: equity responses omit the contract-identity trio ───────────
 
 /// A stock EOD response carries no contract-identity trio — the projected

--- a/thetadatadx-rs/tests/test_column_projection.rs
+++ b/thetadatadx-rs/tests/test_column_projection.rs
@@ -241,6 +241,34 @@ fn option_trade_quote_broadcasts_symbol() {
     }
 }
 
+/// `OptionContract` (the `option_list_contracts` tick) already owns a per-row
+/// `symbol` column. Even when the decode attaches a broadcast root, its
+/// projected frame must carry EXACTLY ONE `symbol` column — its per-row one —
+/// not a duplicate broadcast field.
+#[test]
+fn option_contract_projects_exactly_one_symbol_column() {
+    use thetadatadx::OptionContract;
+    // The shape the decode seam builds: the tick's own schema columns present,
+    // plus a broadcast root attached (as it would be off the `symbol` header).
+    let present =
+        ColumnPresence::from_names(["symbol", "expiration", "strike", "right"]).with_symbol("SPY");
+    let empty: Vec<OptionContract> = Vec::new();
+
+    let cols = arrow_columns(&empty.as_slice().to_arrow_projected(&present).unwrap());
+    assert_eq!(
+        cols.iter().filter(|c| c.as_str() == "symbol").count(),
+        1,
+        "OptionContract must carry exactly one (per-row) symbol column; got {cols:?}"
+    );
+    // Polars agrees.
+    let dcols = polars_columns(&empty.as_slice().to_polars_projected(&present).unwrap());
+    assert_eq!(
+        dcols.iter().filter(|c| c.as_str() == "symbol").count(),
+        1,
+        "polars OptionContract must carry exactly one symbol column; got {dcols:?}"
+    );
+}
+
 /// A stock response carries no `symbol` header — the projected frame gains no
 /// `symbol` column.
 #[test]


### PR DESCRIPTION
The MDDS gRPC wire sends a leading `symbol` (root) column on option and index historical endpoints, constant across the response (only expiration/strike/right vary). The SDK dropped it — the flat, fixed-layout tick structs have no `symbol` field. This makes the projected output byte-exact to the server by emitting it.

Because `symbol` is constant per response, it is carried once on the per-response column carrier (`ColumnPresence`, layout unchanged) rather than added to the POD tick, and the projected Arrow/Polars builders broadcast it as the leading column when the wire sent it. Option/index historical output gains a leading `symbol` column; stock (no such header) does not; streaming and hand-built full-schema paths are unchanged.

Breaking: option/index projected Arrow/Polars output gains a new leading column, so positional-schema consumers shift — consistent with the projection change that introduced this path.

## Tests

Capture-backed: `option_history_trade` -> `symbol` is the first column on every row; a wildcard option response -> symbol + the contract-id trio; `stock_history_trade` -> no symbol column. C-ABI + cross-binding parity clean; the projected C symbol gains a nullable `symbol` parameter, header updated.