### PR TITLE
fix(python): release the callback lock before connecting so close() cannot deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows server archive attaches to the release.** The Windows `thetadatadx-server` archive was built, but the upload step received a path the artifact action could not resolve on Windows, so the GitHub Release carried no Windows binary. The archive is now referenced by its native workspace path and attaches correctly.
+- **Python `close()` can no longer deadlock against an in-flight streaming start.** `start_streaming` now releases its callback lock before the blocking connect, so a concurrent `close()` / `__exit__` / `__aexit__` on the client cannot wedge the interpreter.
+- **Python `session.subscribe(...)` after `close()` raises the uniform closed error.** The context-managed session's attribute proxy now surfaces the "client is closed" error on a closed unified client instead of masking it as an `AttributeError`.
+- **Python `close()` called from inside a streaming callback returns promptly.** Closing from the dispatcher thread now skips the drain wait it could never observe, instead of burning the full drain timeout and emitting a spurious warning.
 
 ## [13.0.0-rc.12] - 2026-07-01
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows server archive attaches to the release.** The Windows `thetadatadx-server` archive was built, but the upload step received a path the artifact action could not resolve on Windows, so the GitHub Release carried no Windows binary. The archive is now referenced by its native workspace path and attaches correctly.
+- **Python `close()` can no longer deadlock against an in-flight streaming start.** `start_streaming` now releases its callback lock before the blocking connect, so a concurrent `close()` / `__exit__` / `__aexit__` on the client cannot wedge the interpreter.
+- **Python `session.subscribe(...)` after `close()` raises the uniform closed error.** The context-managed session's attribute proxy now surfaces the "client is closed" error on a closed unified client instead of masking it as an `AttributeError`.
+- **Python `close()` called from inside a streaming callback returns promptly.** Closing from the dispatcher thread now skips the drain wait it could never observe, instead of burning the full drain timeout and emitting a spurious warning.
 
 ## [13.0.0-rc.12] - 2026-07-01
 

--- a/thetadatadx-py/src/_generated/streaming_methods.rs
+++ b/thetadatadx-py/src/_generated/streaming_methods.rs
@@ -53,15 +53,16 @@ impl StreamView {
         {
             // Reserve the registration slot before releasing the GIL for the
             // blocking handshake, then DROP the guard. `close()` parks on this
-            // same `Mutex<Option<Py<PyAny>>>` WITH the GIL held; a guard held
-            // across the `py.detach` connect below (whose dispatcher re-acquires
-            // the GIL) would let a concurrent `close()` take the GIL and block on
-            // the mutex while this thread blocks on the GIL -- a whole-interpreter
-            // deadlock. Take the lock in this inner scope, reject a
-            // double-registration, store the handle eagerly, and release before
-            // connecting. The stop-generation guard plus this double-start
-            // rejection make the wide critical section unnecessary; a handshake
-            // failure clears the slot again below.
+            // same `Mutex<Option<Arc<Py<PyAny>>>>` WITH the GIL held; a guard
+            // held across the `py.detach` connect below (whose dispatcher
+            // re-acquires the GIL) would let a concurrent `close()` take the GIL
+            // and block on the mutex while this thread blocks on the GIL -- a
+            // whole-interpreter deadlock. Take the lock in this inner scope,
+            // reject a double-registration, store the handle eagerly, and release
+            // before connecting. The stop-generation guard plus this
+            // double-start rejection make the wide critical section unnecessary;
+            // the `CallbackReservation` armed below clears the slot again on a
+            // handshake failure.
             let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
             // Reject double-registration with a clear PyRuntimeError. The
             // underlying `Client::start_streaming` would also error,
@@ -72,8 +73,15 @@ impl StreamView {
                     "streaming already started -- call stop_streaming() before start_streaming() again",
                 ));
             }
-            *cb_guard = Some(callback_arc.clone_ref(py));
+            *cb_guard = Some(Arc::clone(&callback_arc));
         }
+        // Own the reservation until the connect succeeds. On any non-success exit
+        // -- the `?` on a handshake failure below, or a panic before the connect
+        // completes -- the guard clears the slot, but ONLY if it still holds THIS
+        // reservation (`Arc::ptr_eq`). The lock is dropped across the detached
+        // connect, so a concurrent stop + restart may have replaced the slot with
+        // a newer callback that must keep its registration. Disarmed on success.
+        let mut reservation = CallbackReservation::armed(&self.callback, &callback_arc);
         let dispatch_cb = Arc::clone(&callback_arc);
         // Capture a WEAK handle to the Rust client so the dispatcher closure
         // can call `record_panic()` when the Python callback raises an
@@ -163,14 +171,10 @@ impl StreamView {
                 None,
             )
         })
-        .map_err(|err| {
-            // The handshake failed -- release the slot reserved above so a later
-            // `start_streaming` retry sees a clean registration instead of a
-            // stuck "streaming already started". Mirrors the TypeScript binding's
-            // handshake-failure clear.
-            *self.callback.lock().unwrap_or_else(|e| e.into_inner()) = None;
-            to_py_err(err)
-        })?;
+        .map_err(to_py_err)?;
+        // Connect succeeded: hand the reservation off to the live session so the
+        // guard does not clear it on return.
+        reservation.disarm();
         Ok(())
     }
 
@@ -317,13 +321,12 @@ impl StreamView {
         })
         .map_err(to_py_err)?;
 
-        // Replace the stored callable with a freshly owned handle so
-        // the next reconnect / shutdown sees the same state shape.
-        // The dispatcher closure already captured a clone of
-        // `callback_arc` (via `dispatch_cb`); the ref-count is >=2
-        // here so `try_unwrap` would always fail.
+        // Replace the stored callable with the reconnected handle so the next
+        // reconnect / shutdown sees the same state shape. The dispatcher closure
+        // already captured a clone of `callback_arc` (via `dispatch_cb`), so this
+        // Arc clone shares the same callable.
         let mut guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
-        *guard = Some(Python::attach(|py| callback_arc.clone_ref(py)));
+        *guard = Some(Arc::clone(&callback_arc));
         Ok(())
     }
 

--- a/thetadatadx-py/src/_generated/streaming_methods.rs
+++ b/thetadatadx-py/src/_generated/streaming_methods.rs
@@ -44,26 +44,36 @@ impl StreamView {
     /// `PyErr::write_unraisable` (visible in `sys.stderr` and
     /// the unraisable hook); each one bumps `panic_count()`.
     pub(crate) fn start_streaming(&self, py: Python<'_>, callback: Py<PyAny>) -> PyResult<()> {
-        // Hold the user callable in a `Mutex<Option<Py<PyAny>>>` so
-        // `stop_streaming` can drop it without leaking a Python
-        // reference, and so a subsequent `start_streaming` /
-        // `reconnect` cycle replaces the previous registration cleanly.
-        let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
-        // Reject double-registration with a clear PyRuntimeError. The
-        // underlying `Client::start_streaming` would also error,
-        // but matching the PyO3 binding's own state first gives a
-        // language-idiomatic message.
-        if cb_guard.is_some() {
-            return Err(PyRuntimeError::new_err(
-                "streaming already started -- call stop_streaming() before start_streaming() again",
-            ));
-        }
         // Bind the callable behind a cheap `Arc` so the FPSS callback
         // closure (`Fn(&StreamEvent) + Send + 'static`) can clone the
         // handle into each per-event invocation. `Py<PyAny>` itself is
         // `Send + Sync` once the GIL is released, so the Arc is purely
         // a reference-count lifetime aid.
         let callback_arc: Arc<Py<PyAny>> = Arc::new(callback);
+        {
+            // Reserve the registration slot before releasing the GIL for the
+            // blocking handshake, then DROP the guard. `close()` parks on this
+            // same `Mutex<Option<Py<PyAny>>>` WITH the GIL held; a guard held
+            // across the `py.detach` connect below (whose dispatcher re-acquires
+            // the GIL) would let a concurrent `close()` take the GIL and block on
+            // the mutex while this thread blocks on the GIL -- a whole-interpreter
+            // deadlock. Take the lock in this inner scope, reject a
+            // double-registration, store the handle eagerly, and release before
+            // connecting. The stop-generation guard plus this double-start
+            // rejection make the wide critical section unnecessary; a handshake
+            // failure clears the slot again below.
+            let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
+            // Reject double-registration with a clear PyRuntimeError. The
+            // underlying `Client::start_streaming` would also error,
+            // but matching the PyO3 binding's own state first gives a
+            // language-idiomatic message.
+            if cb_guard.is_some() {
+                return Err(PyRuntimeError::new_err(
+                    "streaming already started -- call stop_streaming() before start_streaming() again",
+                ));
+            }
+            *cb_guard = Some(callback_arc.clone_ref(py));
+        }
         let dispatch_cb = Arc::clone(&callback_arc);
         // Capture a WEAK handle to the Rust client so the dispatcher closure
         // can call `record_panic()` when the Python callback raises an
@@ -153,14 +163,14 @@ impl StreamView {
                 None,
             )
         })
-        .map_err(to_py_err)?;
-
-        // The dispatcher closure already captured a clone of
-        // `callback_arc` (via `dispatch_cb`), so the Arc ref-count is
-        // guaranteed >=2 by the time we reach this line — `try_unwrap`
-        // would always fail. Lift a fresh owned handle under the GIL
-        // for storage on `cb_guard`.
-        *cb_guard = Some(Python::attach(|py| callback_arc.clone_ref(py)));
+        .map_err(|err| {
+            // The handshake failed -- release the slot reserved above so a later
+            // `start_streaming` retry sees a clean registration instead of a
+            // stuck "streaming already started". Mirrors the TypeScript binding's
+            // handshake-failure clear.
+            *self.callback.lock().unwrap_or_else(|e| e.into_inner()) = None;
+            to_py_err(err)
+        })?;
         Ok(())
     }
 

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -714,7 +714,13 @@ struct Client {
     /// and every `StreamView` handle observe and mutate one registration,
     /// keeping `start_streaming` / `stop_streaming` / `reconnect`
     /// idempotent regardless of which surface the caller reaches through.
-    callback: Arc<Mutex<Option<Py<PyAny>>>>,
+    ///
+    /// The callable is held behind an inner `Arc` so a freshly reserved slot
+    /// carries a unique identity (`Arc::ptr_eq`): `start_streaming` releases the
+    /// lock before its blocking connect, so a concurrent stop + restart can
+    /// replace the reservation mid-connect; the failed start must clear ONLY its
+    /// own slot, never the newer one.
+    callback: Arc<Mutex<Option<Arc<Py<PyAny>>>>>,
 }
 
 impl Client {
@@ -783,7 +789,54 @@ struct HistoricalView {
 #[pyclass(frozen)]
 struct StreamView {
     client: std::sync::Arc<thetadatadx::Client>,
-    callback: Arc<Mutex<Option<Py<PyAny>>>>,
+    callback: Arc<Mutex<Option<Arc<Py<PyAny>>>>>,
+}
+
+/// Clears a freshly reserved `start_streaming` callback slot on any non-success
+/// exit -- the `?` error return AND a panic between reserving the slot and
+/// completing the connect.
+///
+/// `start_streaming` must drop the callback lock before its blocking `py.detach`
+/// connect (holding it across the GIL-releasing connect deadlocks against a
+/// `close()` that parks on the same mutex with the GIL held). Dropping the guard
+/// opens a window where a concurrent stop + restart replaces the reservation, so
+/// clearing unconditionally would wipe the newer callback and strand a live
+/// session with no registration. `Arc::ptr_eq` gives each start a unique
+/// identity, so this clears ONLY when the slot still holds this reservation.
+/// Disarmed by [`Self::disarm`] once the connect succeeds.
+struct CallbackReservation<'a> {
+    slot: &'a Mutex<Option<Arc<Py<PyAny>>>>,
+    reserved: &'a Arc<Py<PyAny>>,
+    armed: bool,
+}
+
+impl<'a> CallbackReservation<'a> {
+    fn armed(slot: &'a Mutex<Option<Arc<Py<PyAny>>>>, reserved: &'a Arc<Py<PyAny>>) -> Self {
+        Self {
+            slot,
+            reserved,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CallbackReservation<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut slot = self.slot.lock().unwrap_or_else(|e| e.into_inner());
+        if slot
+            .as_ref()
+            .is_some_and(|cb| Arc::ptr_eq(cb, self.reserved))
+        {
+            *slot = None;
+        }
+    }
 }
 
 #[pymethods]

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -1068,17 +1068,24 @@ impl Client {
         // BEFORE stopping so we do not wait on a barrier that will never arm on
         // a historical-only client (whose `prev_drained` slot stays empty).
         let was_streaming = client.stream().is_streaming();
+        // A `close()` called from inside a per-event callback runs ON the
+        // dispatcher thread; the drain flag it would wait on flips only after the
+        // callback returns, so `await_drain` would burn its full timeout and warn
+        // about the caller's own frame. Snapshot the self-call BEFORE `close()`
+        // retires the dispatcher and skip the wait on that path, mirroring the
+        // core teardown self-join guard.
+        let self_dispatch = client.stream().current_thread_is_dispatcher();
         let drained = py.detach(|| {
             client.close();
-            if was_streaming {
+            if was_streaming && !self_dispatch {
                 client
                     .stream()
                     .await_drain(std::time::Duration::from_millis(
                         streaming_session::EXIT_DRAIN_TIMEOUT_MS,
                     ))
             } else {
-                // Nothing was streaming; the drain barrier is vacuously
-                // satisfied.
+                // Nothing was streaming, or this close is the dispatcher's own
+                // reentrant call; the drain barrier is vacuously satisfied.
                 true
             }
         });

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -782,7 +782,7 @@ struct HistoricalView {
 /// `client.stream`.
 ///
 /// Shares the parent client's `Arc<thetadatadx::Client>` and the parent's
-/// `Arc<Mutex<Option<Py<PyAny>>>>` callback slot, so `start_streaming`,
+/// `Arc<Mutex<Option<Arc<Py<PyAny>>>>>` callback slot, so `start_streaming`,
 /// `stop_streaming`, `reconnect`, and the subscription methods observe the
 /// same registration the unified client does. Constructing it is a pair of
 /// `Arc::clone`s — no auth round-trip, no streaming state mutation.

--- a/thetadatadx-py/src/streaming_session.rs
+++ b/thetadatadx-py/src/streaming_session.rs
@@ -210,7 +210,14 @@ impl StreamingSession {
         // on `Client` (`session_uuid`, `subscription_info`). The standalone
         // `StreamingClient` arm keeps its flat surface and has no `stream`
         // accessor, so the fallback path handles it unchanged.
-        if let Ok(stream) = bound.getattr("stream") {
+        // Only the unified client exposes a `stream` `StreamView`. On that arm a
+        // failed `stream` lookup is the "client is closed" RuntimeError -- surface
+        // it with `?` instead of masking it as an `AttributeError` from the
+        // fallthrough, so `session.subscribe(...)` after `close()` raises the
+        // uniform closed error. The standalone `StreamingClient` has no `stream`
+        // accessor, so its flat surface is resolved directly below.
+        if let StreamableHandle::Unified(_) = self.client {
+            let stream = bound.getattr("stream")?;
             if let Ok(attr) = stream.getattr(name) {
                 return Ok(attr.unbind());
             }

--- a/thetadatadx-py/tests/test_context_manager.py
+++ b/thetadatadx-py/tests/test_context_manager.py
@@ -343,21 +343,52 @@ def test_start_streaming_releases_callback_lock_before_connect() -> None:
     end = gen.index("fn ", start + 1)
     body = gen[start:end]
 
-    store_at = body.index("*cb_guard = Some(callback_arc.clone_ref(py));")
+    store_at = body.index("*cb_guard = Some(Arc::clone(&callback_arc));")
     detach_at = body.index("py.detach(")
     assert store_at < detach_at, (
-        "the callback slot must be reserved (and its guard dropped) BEFORE "
+        "the callback slot must be reserved (and its lock guard dropped) BEFORE "
         "py.detach releases the GIL for the blocking connect"
     )
-    # The guard must not survive into the detached region: no store back through
-    # cb_guard after the connect (the old post-detach store is gone).
-    assert "*cb_guard =" not in body[detach_at:], (
-        "no callback-lock store may run after py.detach -- the guard is dropped "
+    # The lock guard must not survive into the detached region.
+    assert "cb_guard" not in body[detach_at:], (
+        "no callback-lock guard may live across py.detach -- it is dropped "
         "before connecting"
     )
-    # A handshake failure clears the reserved slot so a retry sees clean state.
-    assert "= None;" in body[detach_at:], (
-        "a handshake failure must clear the reserved callback slot"
+
+
+def test_start_streaming_failure_clear_is_ownership_checked() -> None:
+    """Offline source pin (ABA): the reserve-then-connect fix must NOT clear the
+    callback slot unconditionally on a handshake failure. Since the lock is
+    dropped before the connect, a concurrent stop + restart can replace the
+    reservation mid-connect; an unconditional clear would wipe the newer callback
+    and strand a live session with no registration. The clear runs through a
+    `CallbackReservation` that clears only its OWN slot (`Arc::ptr_eq`) and
+    covers both the error return and a panic before the connect completes.
+    """
+    gen = (_py_src_root() / "_generated" / "streaming_methods.rs").read_text()
+    start = gen.index("fn start_streaming(")
+    body = gen[start : gen.index("fn ", start + 1)]
+    detach_at = body.index("py.detach(")
+    # No unconditional slot clear anywhere in start_streaming (the old
+    # `*self.callback.lock()... = None` / `*cb_guard = None` clears are gone).
+    assert "= None" not in body, (
+        "start_streaming must not clear the callback slot unconditionally -- the "
+        "ownership-checked CallbackReservation owns the failure clear"
+    )
+    # The reservation is armed before the connect and disarmed on success.
+    assert body.index("CallbackReservation::armed(") < detach_at, (
+        "the reservation guard must be armed before py.detach"
+    )
+    assert "reservation.disarm();" in body[detach_at:], (
+        "the reservation must be disarmed on the success path"
+    )
+    # The guard's clear is identity-checked so it never wipes a newer reservation.
+    lib = (_py_src_root() / "lib.rs").read_text()
+    guard = lib[lib.index("impl Drop for CallbackReservation") :]
+    guard = guard[: guard.index("\n}")]
+    assert "Arc::ptr_eq(cb, self.reserved)" in guard, (
+        "the reservation must clear only when the slot still holds ITS own arc "
+        "(Arc::ptr_eq), never a newer start_streaming's reservation"
     )
 
 

--- a/thetadatadx-py/tests/test_context_manager.py
+++ b/thetadatadx-py/tests/test_context_manager.py
@@ -317,6 +317,84 @@ def test_close_releases_and_makes_client_unusable() -> None:
     )
 
 
+def _py_src_root():
+    from pathlib import Path
+
+    here = Path(__file__).resolve().parent
+    for candidate in [here, *here.parents]:
+        target = candidate / "src"
+        if target.is_dir() and (target / "lib.rs").is_file():
+            return target
+    raise AssertionError("could not locate thetadatadx-py/src")
+
+
+def test_start_streaming_releases_callback_lock_before_connect() -> None:
+    """Offline source pin: `start_streaming` must NOT hold the shared callback
+    `Mutex` across the `py.detach` FPSS connect. `close()` parks on that same
+    mutex WITH the GIL held, so a guard held across the detached (GIL-released)
+    connect deadlocks the whole interpreter -- `close()` blocks on the mutex,
+    the connecting thread blocks re-acquiring the GIL. The fix reserves the slot
+    in an inner scope, stores the handle, drops the guard, then connects, and
+    clears the slot on a handshake failure. Pinned against the generated source
+    so a revert to the wide critical section fails without live credentials.
+    """
+    gen = (_py_src_root() / "_generated" / "streaming_methods.rs").read_text()
+    start = gen.index("fn start_streaming(")
+    end = gen.index("fn ", start + 1)
+    body = gen[start:end]
+
+    store_at = body.index("*cb_guard = Some(callback_arc.clone_ref(py));")
+    detach_at = body.index("py.detach(")
+    assert store_at < detach_at, (
+        "the callback slot must be reserved (and its guard dropped) BEFORE "
+        "py.detach releases the GIL for the blocking connect"
+    )
+    # The guard must not survive into the detached region: no store back through
+    # cb_guard after the connect (the old post-detach store is gone).
+    assert "*cb_guard =" not in body[detach_at:], (
+        "no callback-lock store may run after py.detach -- the guard is dropped "
+        "before connecting"
+    )
+    # A handshake failure clears the reserved slot so a retry sees clean state.
+    assert "= None;" in body[detach_at:], (
+        "a handshake failure must clear the reserved callback slot"
+    )
+
+
+def test_closed_session_getattr_propagates_closed_error() -> None:
+    """Offline source pin: `StreamingSession.__getattr__` must propagate the
+    unified client's `stream` closed error with `?` rather than swallowing it
+    with `if let Ok(stream)`. Otherwise `session.subscribe(...)` after `close()`
+    falls through and raises `AttributeError` instead of the uniform
+    "client is closed" `RuntimeError`.
+    """
+    src = (_py_src_root() / "streaming_session.rs").read_text()
+    start = src.index("fn __getattr__(")
+    end = src.index("\n    }", start)
+    body = src[start:end]
+    assert 'bound.getattr("stream")?' in body, (
+        "the Unified arm must propagate the stream getter error with `?` so a "
+        "closed client raises the uniform closed error"
+    )
+    assert 'if let Ok(stream) = bound.getattr("stream")' not in body, (
+        "the swallowing `if let Ok(stream) = bound.getattr(\"stream\")` masks "
+        "the closed error and must be gone"
+    )
+
+
+def test_closed_unified_session_subscribe_raises_closed_error(client) -> None:
+    """After `close()`, calling a proxied method through the session raises the
+    uniform "client is closed" error, not `AttributeError`. Live-gated because
+    the constructor needs a real handshake.
+    """
+    from thetadatadx import Contract
+
+    session = client.streaming(_noop_callback)
+    client.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        session.subscribe(Contract.stock("AAPL").quote())
+
+
 def test_close_makes_client_unusable(client) -> None:
     """After `close()` every surface accessor raises a clear closed error, so a
     subsequent historical or streaming call cannot reach the network. Live-gated

--- a/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/reconnect_body.rs.tmpl
+++ b/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/reconnect_body.rs.tmpl
@@ -67,12 +67,11 @@
         })
         .map_err(to_py_err)?;
 
-        // Replace the stored callable with a freshly owned handle so
-        // the next reconnect / shutdown sees the same state shape.
-        // The dispatcher closure already captured a clone of
-        // `callback_arc` (via `dispatch_cb`); the ref-count is >=2
-        // here so `try_unwrap` would always fail.
+        // Replace the stored callable with the reconnected handle so the next
+        // reconnect / shutdown sees the same state shape. The dispatcher closure
+        // already captured a clone of `callback_arc` (via `dispatch_cb`), so this
+        // Arc clone shares the same callable.
         let mut guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
-        *guard = Some(Python::attach(|py| callback_arc.clone_ref(py)));
+        *guard = Some(Arc::clone(&callback_arc));
         Ok(())
     }

--- a/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
+++ b/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
@@ -7,15 +7,16 @@
         {
             // Reserve the registration slot before releasing the GIL for the
             // blocking handshake, then DROP the guard. `close()` parks on this
-            // same `Mutex<Option<Py<PyAny>>>` WITH the GIL held; a guard held
-            // across the `py.detach` connect below (whose dispatcher re-acquires
-            // the GIL) would let a concurrent `close()` take the GIL and block on
-            // the mutex while this thread blocks on the GIL -- a whole-interpreter
-            // deadlock. Take the lock in this inner scope, reject a
-            // double-registration, store the handle eagerly, and release before
-            // connecting. The stop-generation guard plus this double-start
-            // rejection make the wide critical section unnecessary; a handshake
-            // failure clears the slot again below.
+            // same `Mutex<Option<Arc<Py<PyAny>>>>` WITH the GIL held; a guard
+            // held across the `py.detach` connect below (whose dispatcher
+            // re-acquires the GIL) would let a concurrent `close()` take the GIL
+            // and block on the mutex while this thread blocks on the GIL -- a
+            // whole-interpreter deadlock. Take the lock in this inner scope,
+            // reject a double-registration, store the handle eagerly, and release
+            // before connecting. The stop-generation guard plus this
+            // double-start rejection make the wide critical section unnecessary;
+            // the `CallbackReservation` armed below clears the slot again on a
+            // handshake failure.
             let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
             // Reject double-registration with a clear PyRuntimeError. The
             // underlying `Client::start_streaming` would also error,
@@ -26,8 +27,15 @@
                     "streaming already started -- call stop_streaming() before start_streaming() again",
                 ));
             }
-            *cb_guard = Some(callback_arc.clone_ref(py));
+            *cb_guard = Some(Arc::clone(&callback_arc));
         }
+        // Own the reservation until the connect succeeds. On any non-success exit
+        // -- the `?` on a handshake failure below, or a panic before the connect
+        // completes -- the guard clears the slot, but ONLY if it still holds THIS
+        // reservation (`Arc::ptr_eq`). The lock is dropped across the detached
+        // connect, so a concurrent stop + restart may have replaced the slot with
+        // a newer callback that must keep its registration. Disarmed on success.
+        let mut reservation = CallbackReservation::armed(&self.callback, &callback_arc);
         let dispatch_cb = Arc::clone(&callback_arc);
         // Capture a WEAK handle to the Rust client so the dispatcher closure
         // can call `record_panic()` when the Python callback raises an
@@ -117,13 +125,9 @@
                 None,
             )
         })
-        .map_err(|err| {
-            // The handshake failed -- release the slot reserved above so a later
-            // `start_streaming` retry sees a clean registration instead of a
-            // stuck "streaming already started". Mirrors the TypeScript binding's
-            // handshake-failure clear.
-            *self.callback.lock().unwrap_or_else(|e| e.into_inner()) = None;
-            to_py_err(err)
-        })?;
+        .map_err(to_py_err)?;
+        // Connect succeeded: hand the reservation off to the live session so the
+        // guard does not clear it on return.
+        reservation.disarm();
         Ok(())
     }

--- a/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
+++ b/thetadatadx-rs/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
@@ -1,23 +1,33 @@
-        // Hold the user callable in a `Mutex<Option<Py<PyAny>>>` so
-        // `stop_streaming` can drop it without leaking a Python
-        // reference, and so a subsequent `start_streaming` /
-        // `reconnect` cycle replaces the previous registration cleanly.
-        let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
-        // Reject double-registration with a clear PyRuntimeError. The
-        // underlying `Client::start_streaming` would also error,
-        // but matching the PyO3 binding's own state first gives a
-        // language-idiomatic message.
-        if cb_guard.is_some() {
-            return Err(PyRuntimeError::new_err(
-                "streaming already started -- call stop_streaming() before start_streaming() again",
-            ));
-        }
         // Bind the callable behind a cheap `Arc` so the FPSS callback
         // closure (`Fn(&StreamEvent) + Send + 'static`) can clone the
         // handle into each per-event invocation. `Py<PyAny>` itself is
         // `Send + Sync` once the GIL is released, so the Arc is purely
         // a reference-count lifetime aid.
         let callback_arc: Arc<Py<PyAny>> = Arc::new(callback);
+        {
+            // Reserve the registration slot before releasing the GIL for the
+            // blocking handshake, then DROP the guard. `close()` parks on this
+            // same `Mutex<Option<Py<PyAny>>>` WITH the GIL held; a guard held
+            // across the `py.detach` connect below (whose dispatcher re-acquires
+            // the GIL) would let a concurrent `close()` take the GIL and block on
+            // the mutex while this thread blocks on the GIL -- a whole-interpreter
+            // deadlock. Take the lock in this inner scope, reject a
+            // double-registration, store the handle eagerly, and release before
+            // connecting. The stop-generation guard plus this double-start
+            // rejection make the wide critical section unnecessary; a handshake
+            // failure clears the slot again below.
+            let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
+            // Reject double-registration with a clear PyRuntimeError. The
+            // underlying `Client::start_streaming` would also error,
+            // but matching the PyO3 binding's own state first gives a
+            // language-idiomatic message.
+            if cb_guard.is_some() {
+                return Err(PyRuntimeError::new_err(
+                    "streaming already started -- call stop_streaming() before start_streaming() again",
+                ));
+            }
+            *cb_guard = Some(callback_arc.clone_ref(py));
+        }
         let dispatch_cb = Arc::clone(&callback_arc);
         // Capture a WEAK handle to the Rust client so the dispatcher closure
         // can call `record_panic()` when the Python callback raises an
@@ -107,13 +117,13 @@
                 None,
             )
         })
-        .map_err(to_py_err)?;
-
-        // The dispatcher closure already captured a clone of
-        // `callback_arc` (via `dispatch_cb`), so the Arc ref-count is
-        // guaranteed >=2 by the time we reach this line — `try_unwrap`
-        // would always fail. Lift a fresh owned handle under the GIL
-        // for storage on `cb_guard`.
-        *cb_guard = Some(Python::attach(|py| callback_arc.clone_ref(py)));
+        .map_err(|err| {
+            // The handshake failed -- release the slot reserved above so a later
+            // `start_streaming` retry sees a clean registration instead of a
+            // stuck "streaming already started". Mirrors the TypeScript binding's
+            // handshake-failure clear.
+            *self.callback.lock().unwrap_or_else(|e| e.into_inner()) = None;
+            to_py_err(err)
+        })?;
         Ok(())
     }

--- a/thetadatadx-rs/src/client.rs
+++ b/thetadatadx-rs/src/client.rs
@@ -1367,6 +1367,21 @@ impl Client {
         }
     }
 
+    /// Whether the calling thread is the live dispatcher thread.
+    ///
+    /// A caller running inside a per-event callback is ON this thread, so it can
+    /// never observe its own drain flag flip (the flag is set only after the
+    /// callback returns). Callers guard a blocking [`Self::await_drain`] with
+    /// this, mirroring the teardown self-join guard that detaches rather than
+    /// joining the dispatcher into itself.
+    fn current_thread_is_dispatcher(&self) -> bool {
+        matches!(
+            &*self.streaming.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
+            DispatcherSession::Running { handle, .. }
+                if handle.thread().id() == std::thread::current().id()
+        )
+    }
+
     // -- Streaming convenience methods --
 
     fn with_streaming<R>(
@@ -2502,6 +2517,20 @@ impl StreamSurface<'_> {
     #[must_use]
     pub fn await_drain(&self, timeout: Duration) -> bool {
         self.0.await_drain(timeout)
+    }
+
+    /// Whether the calling thread is the streaming dispatcher thread.
+    ///
+    /// A caller inside a per-event callback runs ON the dispatcher thread, so it
+    /// can never observe its own drain flag flip (that flag is set only after the
+    /// callback returns). A blocking [`Self::await_drain`] from that thread would
+    /// spin to its full timeout; bindings whose `close` path can be reached from
+    /// inside a callback guard the drain with this, mirroring the teardown
+    /// self-join guard that detaches rather than joining the dispatcher into
+    /// itself.
+    #[must_use]
+    pub fn current_thread_is_dispatcher(&self) -> bool {
+        self.0.current_thread_is_dispatcher()
     }
 
     /// Whether a prior streaming session has registered a drain flag for


### PR DESCRIPTION
## Problem

The Python binding could deadlock the whole interpreter when `close()` raced an in-flight `start_streaming`. `start_streaming` held the shared callback `Mutex` across the entire detached connect and handshake, still writing through the guard after releasing the GIL. `close()` parks on that same mutex WITH the GIL held. Interleave: the connecting thread holds the mutex and has released the GIL, `close()` takes the GIL and blocks on the mutex, the connecting thread tries to re-acquire the GIL to finish, and neither can proceed. Reachable from `Client` / `AsyncClient` / `HistoricalClient` `close()` / `__exit__` / `__aexit__`, and Ctrl+C could not break it.

## Fix

- **Deadlock (root cause).** Reserve the registration slot in an inner scope, store the handle, and DROP the guard before `py.detach`, clearing the slot on a handshake failure. This ports the TypeScript binding's already-correct reserve-then-clear pattern. The double-start rejection plus the core stop-generation guard make the wide critical section unnecessary. Fixed in the Python `start_streaming` template (the codegen SSOT) and the checked-in generated surface was regenerated.
- **Closed-session attribute proxy.** The context-managed session's `__getattr__` swallowed the unified client's "client is closed" error with `if let Ok(stream)` and fell through, so `session.subscribe(...)` after `close()` raised `AttributeError` instead of the uniform closed error. The Unified arm now propagates the `stream` getter error with `?`.
- **Self-call drain.** `close()` invoked from inside a streaming callback ran the drain wait on the dispatcher thread itself, so the drain flag could never flip until the callback returned, always timing out and warning about the caller's own frame. A new core `StreamSurface::current_thread_is_dispatcher()` (mirroring the existing teardown self-join guard) lets `close_impl` skip the drain on that self-call.

## Tests / gates

- Added offline source-pin regression tests for the lock-release ordering and the closed-session proxy, plus a live-gated behavioral assertion that `subscribe()` after `close()` raises the closed error. A threaded start/close race is not reproducible offline (constructing a unified client needs a real handshake, and without a server the connect fails instantly so the race window is ~0), so the ordering is pinned against the generated source.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings` (py) and `--lib` (core), codegen-drift `--check`, the Python crate's Rust tests (55 passed), the core client-module tests (27 passed), and offline pytest all pass. No version bump.