### PR TITLE
fix(historical): keep the trading date and per-row symbol in projected frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Projected historical frames keep the trading `date`.** A response whose wire sends one `Timestamp` header split into a time-of-day field and `date` (every EOD and trade/quote/greeks history endpoint) no longer drops `date` from the Arrow / Polars frame, so rows spanning multiple days are distinguishable instead of collapsing to a near-constant time-of-day.
+- **Projected snapshot frames keep the per-row `symbol`.** A multi-symbol snapshot response no longer labels every row with the first row's symbol; the broadcast symbol column is emitted only when the response's `symbol` is provably constant across all rows.
+
 ## [13.0.0-rc.13] - 2026-07-02
 
 ### Added

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Projected historical frames keep the trading `date`.** A response whose wire sends one `Timestamp` header split into a time-of-day field and `date` (every EOD and trade/quote/greeks history endpoint) no longer drops `date` from the Arrow / Polars frame, so rows spanning multiple days are distinguishable instead of collapsing to a near-constant time-of-day.
+- **Projected snapshot frames keep the per-row `symbol`.** A multi-symbol snapshot response no longer labels every row with the first row's symbol; the broadcast symbol column is emitted only when the response's `symbol` is provably constant across all rows.
+
 ## [13.0.0-rc.13] - 2026-07-02
 
 ### Added

--- a/thetadatadx-rs/build_support/ticks/parser.rs
+++ b/thetadatadx-rs/build_support/ticks/parser.rs
@@ -250,51 +250,46 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
 }
 
 /// Emit `impl WireColumns for <Tick>` next to the parser. It resolves the
-/// same schema columns through the same alias-aware `find_header` the
-/// parser uses.
+/// same schema columns through the same alias-aware lookup the parser uses,
+/// via the shared `crate::columns::present_columns_from` helper.
 ///
 /// The contract this produces is the response's *physical wire-column set*,
 /// deduplicated by first-claim — NOT the set of struct fields the parser
-/// filled. The two differ: one physical header can feed more than one
-/// struct field (an alias resolves several schema names to the same wire
-/// spelling), and the parser fills every such field from that one column.
-/// Presence, by contrast, counts each physical header once — claimed by the
-/// first schema column (in schema order) that resolves to it — so a field
-/// the parser did fill can still be absent from presence. The EOD `date`
-/// field is exactly that: the wire sends `created`, the parser fills both
-/// `created`-backed fields, but only the exact match (`created` ->
-/// `created_ms_of_day`) claims the header; the aliased `date` column stays
-/// out of the projected frame even though its struct field carries a value.
+/// filled. One physical header can feed more than one struct field (an alias
+/// resolves several schema names to the same wire spelling), and the parser
+/// fills every such field from that one column. `present_columns_from` counts
+/// each physical header once (first-claim, exact matches before aliases) but
+/// exempts the two derived fields that are not their own physical column:
+/// `date` (the `YYYYMMDD` split of a `Timestamp` header, present whenever it
+/// resolves) and `QuoteTick.midpoint` (computed from `bid` + `ask`, present
+/// whenever both inputs are). The EOD wire sends `created`: the exact match
+/// (`created` -> `created_ms_of_day`) claims the header, and `date` rides the
+/// same column via the exemption instead of being dropped.
 ///
 /// The set names the public schema *field* (e.g. `condition_flags`,
 /// `expiration`) — the name the Arrow / Polars builders key on — not the
 /// wire spelling the alias table resolves.
 fn generate_present_columns(out: &mut String, type_name: &str, def: &TickTypeDef) {
+    let derive_midpoint = type_name == "QuoteTick";
     writeln!(out, "impl crate::columns::WireColumns for {type_name} {{").unwrap();
     out.push_str("    fn present_columns(headers: &[&str]) -> crate::columns::ColumnPresence {\n");
-    out.push_str("        let mut present: Vec<&'static str> = Vec::new();\n");
-    out.push_str("        let mut claimed: Vec<usize> = Vec::new();\n");
+    out.push_str("        const COLS: &[(&str, &str)] = &[\n");
     for col in &def.columns {
         writeln!(
             out,
-            "        if let Some(i) = find_header(headers, \"{name}\") {{ if !claimed.contains(&i) {{ claimed.push(i); present.push(\"{field}\"); }} }}",
+            "            (\"{name}\", \"{field}\"),",
             name = col.name,
             field = col.field,
         )
         .unwrap();
     }
-    // Contract-identity trio: injected under their exact wire names on
-    // wildcard responses, each resolved by exact position (matches the
-    // parser's `_cid_*_idx` lookups). Exact names never collide with the
-    // aliased schema columns above, so no claim check is needed.
-    if def.contract_id {
-        out.push_str(
-            "        if headers.contains(&\"expiration\") { present.push(\"expiration\"); }\n",
-        );
-        out.push_str("        if headers.contains(&\"strike\") { present.push(\"strike\"); }\n");
-        out.push_str("        if headers.contains(&\"right\") { present.push(\"right\"); }\n");
-    }
-    out.push_str("        crate::columns::ColumnPresence::from_names(present)\n");
+    out.push_str("        ];\n");
+    writeln!(
+        out,
+        "        crate::columns::present_columns_from(headers, COLS, {}, {derive_midpoint})",
+        def.contract_id,
+    )
+    .unwrap();
     out.push_str("    }\n\n");
 
     // all_columns(): the full-schema column set (schema columns + the

--- a/thetadatadx-rs/src/columns.rs
+++ b/thetadatadx-rs/src/columns.rs
@@ -106,6 +106,107 @@ impl ColumnPresence {
     }
 }
 
+/// Resolve the present schema-column set for one response from its wire
+/// `headers`, shared by every generated [`WireColumns::present_columns`].
+///
+/// `schema_columns` is the tick's `(wire_name, field)` list in schema order.
+/// Claiming is two-pass so ordering is never a latent invariant: exact
+/// header matches claim first, then aliases claim any remaining header. One
+/// physical header is claimed once (first-claim), so an aliased column never
+/// starves a column that names the header exactly.
+///
+/// Two derived fields are exempt from first-claim because they are not their
+/// own physical column:
+///
+///   * `date` is the `YYYYMMDD` split of a `Timestamp` header — it shares the
+///     physical column with a `*_ms_of_day` field but carries distinct data,
+///     so it is present whenever it resolves. It only claims a header on an
+///     exact standalone `date` column; on the shared-`Timestamp` path the
+///     ms-of-day field owns the claim.
+///   * `midpoint` (`QuoteTick`) is computed at decode from `bid` + `ask` and
+///     is never a wire header, so it is present exactly when both inputs are.
+///
+/// Any wire header no schema column claimed (an upstream rename or a new
+/// column) is logged once so the silent drop is observable.
+#[must_use]
+pub fn present_columns_from(
+    headers: &[&str],
+    schema_columns: &[(&'static str, &'static str)],
+    contract_id: bool,
+    derive_midpoint: bool,
+) -> ColumnPresence {
+    use crate::mdds::decode::headers::find_header;
+
+    let mut claimed = vec![false; headers.len()];
+    let mut present: Vec<&'static str> = Vec::new();
+
+    // Pass 1: exact header matches claim first.
+    for &(wire, field) in schema_columns {
+        if field == "date" {
+            continue;
+        }
+        if let Some(i) = headers.iter().position(|&h| h == wire) {
+            if !claimed[i] {
+                claimed[i] = true;
+                present.push(field);
+            }
+        }
+    }
+    // Pass 2: alias matches claim any header still unclaimed.
+    for &(wire, field) in schema_columns {
+        if field == "date" || headers.contains(&wire) {
+            continue;
+        }
+        if let Some(i) = find_header(headers, wire) {
+            if !claimed[i] {
+                claimed[i] = true;
+                present.push(field);
+            }
+        }
+    }
+    // `date`: present whenever it resolves; claims only an exact standalone
+    // header, never the shared `Timestamp` the ms-of-day field owns.
+    if schema_columns.iter().any(|&(_, f)| f == "date") {
+        if let Some(i) = headers.iter().position(|&h| h == "date") {
+            claimed[i] = true;
+            present.push("date");
+        } else if find_header(headers, "date").is_some() {
+            present.push("date");
+        }
+    }
+    // Contract-identity trio: injected under exact wire names on wildcard
+    // responses; each claims its exact header.
+    if contract_id {
+        for name in ["expiration", "strike", "right"] {
+            if let Some(i) = headers.iter().position(|&h| h == name) {
+                claimed[i] = true;
+                present.push(name);
+            }
+        }
+    }
+    // `midpoint` rides whenever both its inputs do.
+    if derive_midpoint && present.contains(&"bid") && present.contains(&"ask") {
+        present.push("midpoint");
+    }
+    // Observability: a wire header no column claimed is a rename or a new
+    // upstream column silently absent from the frame. Surface it once.
+    let unclaimed: Vec<&str> = headers
+        .iter()
+        .zip(&claimed)
+        .filter_map(|(&h, &c)| (!c).then_some(h))
+        .collect();
+    if !unclaimed.is_empty() {
+        tracing::warn!(
+            target: "thetadatadx::columns",
+            unclaimed = ?unclaimed,
+            headers = ?headers,
+            "response carried wire headers no schema column claimed; they are absent from the projected frame",
+        );
+    }
+
+    ColumnPresence::from_names(present)
+}
+
 /// A tick type that knows which of its schema columns a response's wire
 /// header list actually carried.
 ///
@@ -271,5 +372,64 @@ mod tests {
         let p = ColumnPresence::from_names(["a", "b", "c"]);
         let got: Vec<&str> = p.present_names().collect();
         assert_eq!(got, ["a", "b", "c"]);
+    }
+
+    /// `date` rides the shared `created` Timestamp header: both the ms-of-day
+    /// field and `date` are present even though they resolve to one column.
+    #[test]
+    fn present_date_rides_shared_timestamp() {
+        const COLS: &[(&str, &str)] = &[
+            ("created", "created_ms_of_day"),
+            ("open", "open"),
+            ("date", "date"),
+        ];
+        let p = present_columns_from(&["created", "open"], COLS, false, false);
+        assert!(p.contains("created_ms_of_day"));
+        assert!(p.contains("open"));
+        assert!(
+            p.contains("date"),
+            "date must ride the shared Timestamp column"
+        );
+    }
+
+    /// A real standalone `date` header is present and does not leave the
+    /// header unclaimed (it claims its own exact column).
+    #[test]
+    fn present_date_standalone_header() {
+        const COLS: &[(&str, &str)] = &[("ms_of_day", "ms_of_day"), ("date", "date")];
+        let p = present_columns_from(&["timestamp", "date"], COLS, false, false);
+        assert!(p.contains("ms_of_day"));
+        assert!(p.contains("date"));
+    }
+
+    /// `midpoint` is present exactly when both `bid` and `ask` are.
+    #[test]
+    fn present_midpoint_keys_on_bid_and_ask() {
+        const COLS: &[(&str, &str)] = &[
+            ("ms_of_day", "ms_of_day"),
+            ("bid", "bid"),
+            ("ask", "ask"),
+            ("date", "date"),
+        ];
+        let with = present_columns_from(&["ms_of_day", "bid", "ask", "date"], COLS, false, true);
+        assert!(with.contains("midpoint"));
+
+        let without = present_columns_from(&["ms_of_day", "date"], COLS, false, true);
+        assert!(!without.contains("midpoint"));
+    }
+
+    /// Two-pass claiming: a column that names a header exactly claims it even
+    /// when an alias-matching column is listed first, so ordering is not a
+    /// latent invariant (`root` aliases to `symbol`; the exact `symbol` column
+    /// must own the `symbol` header).
+    #[test]
+    fn present_exact_match_beats_earlier_alias() {
+        const COLS: &[(&str, &str)] = &[("root", "root"), ("symbol", "symbol")];
+        let p = present_columns_from(&["symbol"], COLS, false, false);
+        assert!(
+            p.contains("symbol"),
+            "exact `symbol` column claims the header"
+        );
+        assert!(!p.contains("root"), "the aliased `root` must not steal it");
     }
 }

--- a/thetadatadx-rs/src/columns.rs
+++ b/thetadatadx-rs/src/columns.rs
@@ -172,6 +172,10 @@ pub fn present_columns_from(
         if field == "date" {
             if let Some(i) = find_header(headers, wire) {
                 owner[ci] = Some(i);
+                // Keep `claimed` consistent: `date` feeds a present column, so
+                // its header is claimed (idempotent when a `*_ms_of_day` sibling
+                // already claimed the shared `Timestamp`).
+                claimed[i] = true;
             }
         }
     }

--- a/thetadatadx-rs/src/columns.rs
+++ b/thetadatadx-rs/src/columns.rs
@@ -113,21 +113,21 @@ impl ColumnPresence {
 /// Claiming is two-pass so ordering is never a latent invariant: exact
 /// header matches claim first, then aliases claim any remaining header. One
 /// physical header is claimed once (first-claim), so an aliased column never
-/// starves a column that names the header exactly.
+/// starves a column that names the header exactly. Present columns are
+/// emitted in schema order regardless of which pass claimed them, honouring
+/// the [`ColumnPresence::present_names`] contract.
 ///
-/// Two derived fields are exempt from first-claim because they are not their
-/// own physical column:
+/// Two derived fields are handled specially because they are not their own
+/// physical column:
 ///
-///   * `date` is the `YYYYMMDD` split of a `Timestamp` header — it shares the
-///     physical column with a `*_ms_of_day` field but carries distinct data,
-///     so it is present whenever it resolves. It only claims a header on an
-///     exact standalone `date` column; on the shared-`Timestamp` path the
-///     ms-of-day field owns the claim.
+///   * `date` is resolved after the time fields. When its header is still
+///     unclaimed it is the primary claimant (the interest-rate `created` ->
+///     `date` column) and claims it; when a `*_ms_of_day` field already
+///     claimed the shared `Timestamp` header, `date` is that column's derived
+///     `YYYYMMDD` sibling and rides it without a second claim. Either way it
+///     is present whenever it resolves.
 ///   * `midpoint` (`QuoteTick`) is computed at decode from `bid` + `ask` and
 ///     is never a wire header, so it is present exactly when both inputs are.
-///
-/// Any wire header no schema column claimed (an upstream rename or a new
-/// column) is logged once so the silent drop is observable.
 #[must_use]
 pub fn present_columns_from(
     headers: &[&str],
@@ -138,48 +138,55 @@ pub fn present_columns_from(
     use crate::mdds::decode::headers::find_header;
 
     let mut claimed = vec![false; headers.len()];
-    let mut present: Vec<&'static str> = Vec::new();
+    // Per-column claimed header index; `Some` marks the column present.
+    let mut owner: Vec<Option<usize>> = vec![None; schema_columns.len()];
 
-    // Pass 1: exact header matches claim first.
-    for &(wire, field) in schema_columns {
+    // Pass 1: exact header matches claim first. `date` is deferred (it may be
+    // a derived sibling of a `*_ms_of_day` field on the same header).
+    for (ci, &(wire, field)) in schema_columns.iter().enumerate() {
         if field == "date" {
             continue;
         }
         if let Some(i) = headers.iter().position(|&h| h == wire) {
             if !claimed[i] {
                 claimed[i] = true;
-                present.push(field);
+                owner[ci] = Some(i);
             }
         }
     }
     // Pass 2: alias matches claim any header still unclaimed.
-    for &(wire, field) in schema_columns {
-        if field == "date" || headers.contains(&wire) {
+    for (ci, &(wire, field)) in schema_columns.iter().enumerate() {
+        if field == "date" || owner[ci].is_some() || headers.contains(&wire) {
             continue;
         }
         if let Some(i) = find_header(headers, wire) {
             if !claimed[i] {
                 claimed[i] = true;
-                present.push(field);
+                owner[ci] = Some(i);
             }
         }
     }
-    // `date`: present whenever it resolves; claims only an exact standalone
-    // header, never the shared `Timestamp` the ms-of-day field owns.
-    if schema_columns.iter().any(|&(_, f)| f == "date") {
-        if let Some(i) = headers.iter().position(|&h| h == "date") {
-            claimed[i] = true;
-            present.push("date");
-        } else if find_header(headers, "date").is_some() {
-            present.push("date");
+    // `date`: primary claimant when its header is free, derived sibling when a
+    // time field already claimed the shared `Timestamp` — present either way.
+    for (ci, &(wire, field)) in schema_columns.iter().enumerate() {
+        if field == "date" {
+            if let Some(i) = find_header(headers, wire) {
+                owner[ci] = Some(i);
+            }
         }
     }
+
+    // Emit present columns in schema order.
+    let mut present: Vec<&'static str> = owner
+        .iter()
+        .zip(schema_columns)
+        .filter_map(|(o, &(_, field))| o.map(|_| field))
+        .collect();
     // Contract-identity trio: injected under exact wire names on wildcard
-    // responses; each claims its exact header.
+    // responses.
     if contract_id {
         for name in ["expiration", "strike", "right"] {
-            if let Some(i) = headers.iter().position(|&h| h == name) {
-                claimed[i] = true;
+            if headers.contains(&name) {
                 present.push(name);
             }
         }
@@ -187,21 +194,6 @@ pub fn present_columns_from(
     // `midpoint` rides whenever both its inputs do.
     if derive_midpoint && present.contains(&"bid") && present.contains(&"ask") {
         present.push("midpoint");
-    }
-    // Observability: a wire header no column claimed is a rename or a new
-    // upstream column silently absent from the frame. Surface it once.
-    let unclaimed: Vec<&str> = headers
-        .iter()
-        .zip(&claimed)
-        .filter_map(|(&h, &c)| (!c).then_some(h))
-        .collect();
-    if !unclaimed.is_empty() {
-        tracing::warn!(
-            target: "thetadatadx::columns",
-            unclaimed = ?unclaimed,
-            headers = ?headers,
-            "response carried wire headers no schema column claimed; they are absent from the projected frame",
-        );
     }
 
     ColumnPresence::from_names(present)
@@ -431,5 +423,35 @@ mod tests {
             "exact `symbol` column claims the header"
         );
         assert!(!p.contains("root"), "the aliased `root` must not steal it");
+    }
+
+    /// The interest-rate shape maps wire `created` -> field `date`: `date` is
+    /// the primary claimant of the `created` header (no sibling ms-of-day
+    /// field), so it claims it directly and both fields are present.
+    #[test]
+    fn present_date_is_primary_claimant_when_no_time_sibling() {
+        const COLS: &[(&str, &str)] = &[("created", "date"), ("rate", "rate")];
+        let p = present_columns_from(&["created", "rate"], COLS, false, false);
+        assert!(
+            p.contains("date"),
+            "date claims the `created` header directly"
+        );
+        assert!(p.contains("rate"));
+    }
+
+    /// Present columns are emitted in schema order regardless of which pass
+    /// claimed them (an alias-resolved time field before a later exact field).
+    #[test]
+    fn present_names_follow_schema_order() {
+        const COLS: &[(&str, &str)] = &[
+            ("ms_of_day", "ms_of_day"),
+            ("date", "date"),
+            ("rate", "rate"),
+        ];
+        // `ms_of_day` resolves via alias (pass 2), `rate`/`date` are exact —
+        // yet the order must stay schema order, not claim order.
+        let p = present_columns_from(&["timestamp", "date", "rate"], COLS, false, false);
+        let got: Vec<&str> = p.present_names().collect();
+        assert_eq!(got, ["ms_of_day", "date", "rate"]);
     }
 }

--- a/thetadatadx-rs/src/mdds/decode/extract.rs
+++ b/thetadatadx-rs/src/mdds/decode/extract.rs
@@ -215,28 +215,42 @@ pub fn extract_price_column(
         .collect()
 }
 
-/// The response's constant `symbol` (root) value, when the wire carried a
-/// `symbol`/`root` header — the option + index historical endpoints do, stock
-/// does not. Returns `None` when the header is absent (so the projected frame
-/// gains no `symbol` column on stock responses), else the value read from the
-/// first data row. `symbol` is constant across a wildcard response (only
-/// `expiration`/`strike`/`right` vary), so one read broadcasts to every row;
-/// an empty string stands in for a header-present-but-rowless response so the
+/// The response's constant `symbol` (root) value to broadcast as the leading
+/// projected column, when the wire carried a `symbol`/`root` header — the
+/// option + index single-underlying historical endpoints do, stock does not.
+///
+/// The value is broadcast to every row, so it is only returned when it is
+/// *provably constant*: the whole `symbol` column is scanned and a value is
+/// returned only when every row is the same `Text` cell. A multi-symbol
+/// snapshot response (a per-row-varying `symbol`) or a non-`Text` cell yields
+/// `None`, so the frame keeps its per-row symbol column (or gains none for
+/// the flat POD ticks that hold no per-row symbol) rather than mislabelling
+/// every row with row 0's value.
+///
+/// Returns `None` when the header is absent (stock responses gain no `symbol`
+/// column). A header-present-but-rowless response returns `Some("")` so the
 /// column set stays keyed on the header, matching the per-column projection.
 pub fn response_symbol(table: &proto::DataTable) -> Option<Box<str>> {
     let header_refs: Vec<&str> = table.headers.iter().map(String::as_str).collect();
     let col_idx = find_header(&header_refs, "root")?;
-    let value = table
-        .data_table
-        .first()
-        .and_then(|row| row.values.get(col_idx))
-        .and_then(|dv| dv.data_type.as_ref())
-        .and_then(|dt| match dt {
-            proto::data_value::DataType::Text(s) => Some(s.as_str()),
+    if table.data_table.is_empty() {
+        return Some("".into());
+    }
+    let cell = |row: &proto::DataValueList| -> Option<Box<str>> {
+        match row.values.get(col_idx).and_then(|dv| dv.data_type.as_ref()) {
+            Some(proto::data_value::DataType::Text(s)) => Some(s.as_str().into()),
             _ => None,
-        })
-        .unwrap_or_default();
-    Some(value.into())
+        }
+    };
+    let first = cell(table.data_table.first()?)?;
+    if table.data_table[1..]
+        .iter()
+        .all(|row| cell(row).as_deref() == Some(&*first))
+    {
+        Some(first)
+    } else {
+        None
+    }
 }
 
 /// Sort list-endpoint values ascending for the public `list_*` returns.
@@ -408,6 +422,42 @@ mod tests {
                         data_type: Some(proto::data_value::DataType::Number(2)),
                     },
                 ],
+            }],
+        };
+        assert_eq!(response_symbol(&table), None);
+    }
+
+    /// A multi-symbol snapshot response carries a per-row-varying `symbol`; the
+    /// broadcast is only valid when constant, so a varying column yields `None`
+    /// rather than mislabelling every row with row 0's symbol.
+    #[test]
+    fn response_symbol_varying_column_is_none() {
+        let row = |sym: &str| proto::DataValueList {
+            values: vec![proto::DataValue {
+                data_type: Some(proto::data_value::DataType::Text(sym.into())),
+            }],
+        };
+        let table = proto::DataTable {
+            headers: vec!["symbol".to_string()],
+            data_table: vec![row("AAPL"), row("MSFT")],
+        };
+        assert_eq!(
+            response_symbol(&table),
+            None,
+            "a per-row-varying symbol must not broadcast row 0 to every row",
+        );
+    }
+
+    /// A non-`Text` cell in the symbol column (e.g. a Null row 0) yields `None`
+    /// rather than broadcasting an empty string to every row.
+    #[test]
+    fn response_symbol_non_text_cell_is_none() {
+        let table = proto::DataTable {
+            headers: vec!["symbol".to_string()],
+            data_table: vec![proto::DataValueList {
+                values: vec![proto::DataValue {
+                    data_type: Some(proto::data_value::DataType::Number(0)),
+                }],
             }],
         };
         assert_eq!(response_symbol(&table), None);

--- a/thetadatadx-rs/src/mdds/decode/extract.rs
+++ b/thetadatadx-rs/src/mdds/decode/extract.rs
@@ -236,18 +236,21 @@ pub fn response_symbol(table: &proto::DataTable) -> Option<Box<str>> {
     if table.data_table.is_empty() {
         return Some("".into());
     }
-    let cell = |row: &proto::DataValueList| -> Option<Box<str>> {
+    // Borrow the cell text; box only the single returned value, not per row —
+    // a ~1M-row response would otherwise pay ~1M heap allocations here. A local
+    // fn (not a closure) so the returned `&str` borrows from the `row` argument.
+    fn cell(row: &proto::DataValueList, col_idx: usize) -> Option<&str> {
         match row.values.get(col_idx).and_then(|dv| dv.data_type.as_ref()) {
-            Some(proto::data_value::DataType::Text(s)) => Some(s.as_str().into()),
+            Some(proto::data_value::DataType::Text(s)) => Some(s.as_str()),
             _ => None,
         }
-    };
-    let first = cell(table.data_table.first()?)?;
+    }
+    let first = cell(table.data_table.first()?, col_idx)?;
     if table.data_table[1..]
         .iter()
-        .all(|row| cell(row).as_deref() == Some(&*first))
+        .all(|row| cell(row, col_idx) == Some(first))
     {
-        Some(first)
+        Some(first.into())
     } else {
         None
     }

--- a/thetadatadx-rs/tests/test_column_projection.rs
+++ b/thetadatadx-rs/tests/test_column_projection.rs
@@ -20,7 +20,9 @@
 
 use thetadatadx::frames::{TicksArrowExt, TicksPolarsExt};
 use thetadatadx::wire as proto;
-use thetadatadx::{decode, ColumnPresence, EodTick, TradeQuoteTick, TradeTick, WireColumns};
+use thetadatadx::{
+    decode, ColumnPresence, EodTick, QuoteTick, TradeQuoteTick, TradeTick, WireColumns,
+};
 
 #[path = "common/capture_loader.rs"]
 mod capture_loader;
@@ -297,24 +299,45 @@ fn stock_eod_projects_out_contract_id() {
     let present = presence_of::<EodTick>(&table);
     let ticks: Vec<EodTick> = decode::parse_eod_ticks(&table).expect("parse_eod_ticks");
 
-    let cols = arrow_columns(&ticks.as_slice().to_arrow_projected(&present).unwrap());
+    let batch = ticks.as_slice().to_arrow_projected(&present).unwrap();
+    let cols = arrow_columns(&batch);
     for cid in ["expiration", "strike", "right"] {
         assert!(
             !cols.contains(&cid.to_string()),
             "stock EOD must not carry contract-id column {cid}; got {cols:?}"
         );
     }
-    // The EOD wire sends `created`, not a separate `date` column. The
-    // `("date","created")` alias must NOT resurrect a phantom `date` column
-    // off the same `created` header — one wire column feeds one schema
-    // column (the exact `created` -> `created_ms_of_day` match claims it).
-    assert!(
-        !cols.contains(&"date".to_string()),
-        "stock EOD must not carry a phantom `date` column (alias overlap with `created`); got {cols:?}"
-    );
+    // The EOD wire sends one `created` Timestamp that the schema splits into
+    // `created_ms_of_day` (time) AND `date` (YYYYMMDD). Both must survive the
+    // projection: the ms-of-day field claims the header and `date` rides the
+    // same column, so the trading day is not lost. Without `date` the four
+    // rows are indistinguishable (their `created_ms_of_day` is a ~17:1x ET
+    // near-constant).
     assert!(
         cols.contains(&"created_ms_of_day".to_string()),
         "got {cols:?}"
+    );
+    assert!(
+        cols.contains(&"date".to_string()),
+        "stock EOD must keep the trading `date` split from the `created` Timestamp; got {cols:?}"
+    );
+    // The `date` column carries the distinct trading days, not a constant.
+    use arrow_array::Array as _;
+    let date_idx = batch.schema().index_of("date").unwrap();
+    let dates = batch
+        .column(date_idx)
+        .as_any()
+        .downcast_ref::<arrow_array::Int32Array>()
+        .expect("date column is Int32");
+    let values: Vec<i32> = (0..dates.len()).map(|i| dates.value(i)).collect();
+    assert_eq!(
+        values,
+        vec![20240102, 20240103, 20240104, 20240105],
+        "date column must carry the distinct YYYYMMDD trading days"
+    );
+    assert!(
+        values.windows(2).all(|w| w[0] != w[1]),
+        "dates must differ across rows; got {values:?}"
     );
     // But the EOD data columns the wire sent are all present.
     for kept in [
@@ -423,6 +446,34 @@ fn index_snapshot_market_value_drops_bid_ask() {
             "index market_value must not carry {dropped}; got {index:?}"
         );
     }
+}
+
+/// `QuoteTick.midpoint` is computed at decode from `bid` + `ask` and is never a
+/// wire header, so the projected frame must key its presence on both inputs:
+/// present when bid + ask are, absent otherwise. Regression guard — a decode
+/// path that dropped midpoint left `ticks[0].midpoint` populated while the
+/// frame omitted the column.
+#[test]
+fn quote_projects_midpoint_when_bid_and_ask_present() {
+    let with = projected_columns::<QuoteTick>(&[
+        "ms_of_day",
+        "bid_size",
+        "bid",
+        "ask_size",
+        "ask",
+        "date",
+    ]);
+    assert!(
+        with.contains(&"midpoint".to_string()),
+        "midpoint must ride whenever bid + ask do; got {with:?}"
+    );
+
+    // A subset without bid/ask carries no midpoint.
+    let without = projected_columns::<QuoteTick>(&["ms_of_day", "date"]);
+    assert!(
+        !without.contains(&"midpoint".to_string()),
+        "midpoint must be absent when its inputs are; got {without:?}"
+    );
 }
 
 // ── The full (hand-built) path is unchanged ───────────────────────────────


### PR DESCRIPTION
## What

Projected historical / snapshot frames were silently dropping distinguishing data. Root cause fixed once in the presence generator and the symbol reader, not per call site.

### Trading `date` dropped from projected frames

A v3 response sends one `Timestamp` header that the schema splits into a time-of-day field (`*_ms_of_day`) and `date` (`YYYYMMDD`). First-claim presence let the ms-of-day field claim the header and marked `date` not-present, so `to_arrow_projected` / `to_polars_projected` emitted only time-of-day. On the checked-in `stock_history_eod` capture the four rows decode distinct dates (`20240102..20240105`) but the projected frame had no `date` and `created_ms_of_day` is a ~17:1x ET near-constant, so the rows were indistinguishable. Same on every trade / quote / trade_quote / greeks history endpoint. `date` is now exempt from first-claim: it rides the shared `Timestamp` column whenever it resolves, while a genuine standalone `date` header still claims its own column.

### Row-0 `symbol` broadcast to every row

`response_symbol` read the symbol cell from row 0 only and broadcast it to every row. For a multi-symbol snapshot (per-row-varying `symbol`) this labelled every row with row 0's value, and it broadcast an empty string when row 0 was non-Text. The broadcast is now attached only when the whole symbol column is a single constant `Text` value; a varying or non-Text column omits it, so the frame is never mislabelled.

### `QuoteTick.midpoint` regression

`midpoint` is computed at decode and is never a wire header, so it could never enter the present set and the projected builder gated it out even though `ticks[0].midpoint` was populated. Presence now keys `midpoint` on `bid` + `ask` presence.

### Ordering hardening

Claiming is now two-pass (exact matches before aliases) so an aliased column can no longer starve a column that names the header exactly.

## Where

- `thetadatadx-rs/src/columns.rs` — new shared `present_columns_from` helper carrying the two-pass claim, and the `date` / `midpoint` exemptions.
- `thetadatadx-rs/build_support/ticks/parser.rs` — the presence generator now emits the column table and calls the shared helper.
- `thetadatadx-rs/src/mdds/decode/extract.rs` — `response_symbol` scans for a constant symbol.

## Tests

- Flipped `stock_eod_projects_out_contract_id` to assert `date` IS present with the distinct `20240102..20240105` values and that dates differ across rows.
- Added a projected `midpoint` presence test, a two-symbol / non-Text `response_symbol` test, and unit coverage for the presence helper (date exemption, midpoint, two-pass exact-beats-alias).

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p thetadatadx` (1045 lib + all integration suites), and codegen drift `--check` all pass. No version bump.
