### PR TITLE
fix(auth): harden the Nexus credential exchange and session refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Python `close()` can no longer deadlock against an in-flight streaming start.** `start_streaming` now releases its callback lock before the blocking connect, so a concurrent `close()` / `__exit__` / `__aexit__` on the client cannot wedge the interpreter.
 - **Python `session.subscribe(...)` after `close()` raises the uniform closed error.** The context-managed session's attribute proxy now surfaces the "client is closed" error on a closed unified client instead of masking it as an `AttributeError`.
 - **Python `close()` called from inside a streaming callback returns promptly.** Closing from the dispatcher thread now skips the drain wait it could never observe, instead of burning the full drain timeout and emitting a spurious warning.
+- **The credential exchange no longer follows redirects.** The Nexus auth client is set to not follow redirects, so a 3xx from the auth endpoint surfaces as a server error instead of the credential request body being replayed to the redirect target. Nexus never redirects auth.
+- **`SessionSnapshot` no longer prints its session UUID.** The `Debug` output now redacts the UUID with the same `***` marker the auth response uses, so the bearer token cannot land in panic output or `Debug`-formatted logs.
+- **A concurrent burst of failed session refreshes now issues a single Nexus round-trip.** When several requests observe an expired session at once and the re-authentication fails, callers queued behind the first coalesce onto that outcome instead of each re-authenticating in series.
 
 ## [13.0.0-rc.12] - 2026-07-01
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Python `close()` can no longer deadlock against an in-flight streaming start.** `start_streaming` now releases its callback lock before the blocking connect, so a concurrent `close()` / `__exit__` / `__aexit__` on the client cannot wedge the interpreter.
 - **Python `session.subscribe(...)` after `close()` raises the uniform closed error.** The context-managed session's attribute proxy now surfaces the "client is closed" error on a closed unified client instead of masking it as an `AttributeError`.
 - **Python `close()` called from inside a streaming callback returns promptly.** Closing from the dispatcher thread now skips the drain wait it could never observe, instead of burning the full drain timeout and emitting a spurious warning.
+- **The credential exchange no longer follows redirects.** The Nexus auth client is set to not follow redirects, so a 3xx from the auth endpoint surfaces as a server error instead of the credential request body being replayed to the redirect target. Nexus never redirects auth.
+- **`SessionSnapshot` no longer prints its session UUID.** The `Debug` output now redacts the UUID with the same `***` marker the auth response uses, so the bearer token cannot land in panic output or `Debug`-formatted logs.
+- **A concurrent burst of failed session refreshes now issues a single Nexus round-trip.** When several requests observe an expired session at once and the re-authentication fails, callers queued behind the first coalesce onto that outcome instead of each re-authenticating in series.
 
 ## [13.0.0-rc.12] - 2026-07-01
 

--- a/thetadatadx-rs/src/auth/nexus.rs
+++ b/thetadatadx-rs/src/auth/nexus.rs
@@ -466,6 +466,13 @@ pub async fn authenticate_at(
 
     let client = reqwest::Client::builder()
         .use_preconfigured_tls(auth_tls_config()?)
+        // Do not follow redirects on the credential exchange. The POST body
+        // carries the password / apiKey; reqwest strips sensitive *headers*
+        // (Authorization, Cookie) on a cross-host redirect but replays the
+        // request body on a 307/308, so a 3xx to another host would send the
+        // credential body off to the redirect target. Nexus never redirects
+        // auth, so refuse to follow and surface any 3xx as a server error.
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(Duration::from_secs(10))
         .connect_timeout(Duration::from_secs(5))
         .build()

--- a/thetadatadx-rs/src/auth/session.rs
+++ b/thetadatadx-rs/src/auth/session.rs
@@ -238,7 +238,7 @@ impl SessionToken {
         // failure) before releasing the refresh lock, so callers queued behind
         // us coalesce onto this outcome instead of re-hitting Nexus.
         let mut guard = self.state.write().await;
-        guard.attempts = guard.attempts.wrapping_add(1);
+        guard.attempts = guard.attempts.saturating_add(1);
         let resp = match result {
             Ok(resp) => resp,
             Err(e) => {

--- a/thetadatadx-rs/src/auth/session.rs
+++ b/thetadatadx-rs/src/auth/session.rs
@@ -59,6 +59,11 @@ struct Inner {
     /// Used by [`SessionToken::refresh`] to deduplicate concurrent
     /// refreshes — see the module doc.
     version: u64,
+    /// Monotonic counter incremented once per completed refresh attempt,
+    /// success OR failure. Lets [`SessionToken::refresh`] coalesce a burst
+    /// of concurrent callers onto a single Nexus round-trip even when that
+    /// round-trip fails (where `version` does not move) — see `refresh`.
+    attempts: u64,
     /// Nexus URL the token was originally issued from. Reused on
     /// refresh so a staging config stays on its staging endpoint.
     nexus_url: String,
@@ -71,15 +76,38 @@ struct Inner {
     creds: Credentials,
 }
 
+/// Error surfaced to callers that coalesced onto a concurrent refresh which
+/// already failed for the same token generation. They issued no Nexus
+/// round-trip of their own; the caller surfaces this rather than stampeding a
+/// Nexus that just rejected the identical credentials.
+fn coalesced_refresh_error() -> Error {
+    Error::Auth {
+        kind: crate::error::AuthErrorKind::ServerError,
+        message: "session refresh already failed for this token generation".into(),
+    }
+}
+
 /// Snapshot of the token at a point in time. Used to deduplicate
 /// concurrent refreshes — see [`SessionToken::refresh`].
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SessionSnapshot {
     /// Session UUID observed at snapshot time.
     pub uuid: String,
     /// Token version observed at snapshot time. [`SessionToken::refresh`]
     /// re-authenticates only while the live version still equals this.
     pub version: u64,
+}
+
+impl std::fmt::Debug for SessionSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the UUID — it is a bearer token, redacted with the same
+        // `***` marker `AuthResponse`'s `session_id` uses. Version is safe
+        // operator diagnostics.
+        f.debug_struct("SessionSnapshot")
+            .field("uuid", &"***")
+            .field("version", &self.version)
+            .finish()
+    }
 }
 
 impl SessionToken {
@@ -100,6 +128,7 @@ impl SessionToken {
             state: Arc::new(RwLock::new(Inner {
                 uuid,
                 version: 0,
+                attempts: 0,
                 nexus_url,
                 environment,
                 creds,
@@ -138,8 +167,11 @@ impl SessionToken {
     /// itself and an infinite refresh loop is worse than a surfaced
     /// error.
     pub async fn refresh(&self, stale: &SessionSnapshot) -> Result<SessionSnapshot, Error> {
-        // Fast path: someone may have already refreshed past `stale`.
-        {
+        // Fast path: someone may have already refreshed past `stale`. Capture
+        // the attempt generation observed on entry so that, after waiting on
+        // the refresh lock, we can tell whether a concurrent attempt for this
+        // same generation already ran and failed while we were queued.
+        let entry_attempts = {
             let guard = self.state.read().await;
             if guard.version != stale.version {
                 return Ok(SessionSnapshot {
@@ -147,7 +179,8 @@ impl SessionToken {
                     version: guard.version,
                 });
             }
-        }
+            guard.attempts
+        };
 
         // Serialize refresh attempts. Inside this critical section the
         // state RwLock is NOT held, so snapshot()/current_uuid() readers
@@ -164,6 +197,16 @@ impl SessionToken {
                     version: guard.version,
                 });
             }
+            // A concurrent refresh for this same token generation already ran
+            // and failed while we waited on the lock (version unchanged, but
+            // the attempt counter advanced). Coalesce onto that outcome rather
+            // than issuing a second Nexus round-trip, so a burst of N callers
+            // that all observe the same `Unauthenticated` makes at most one
+            // auth attempt. A failed credential or a down Nexus will not fix
+            // itself on an immediate re-attempt.
+            if guard.attempts != entry_attempts {
+                return Err(coalesced_refresh_error());
+            }
             (
                 guard.nexus_url.clone(),
                 guard.environment,
@@ -171,10 +214,16 @@ impl SessionToken {
             )
         };
 
-        let resp = authenticate_at(&nexus_url, &creds, environment).await?;
+        let result = authenticate_at(&nexus_url, &creds, environment).await;
 
-        // Briefly take the write lock to swap the UUID + bump the version.
+        // Record that an attempt completed for this generation (success OR
+        // failure) before releasing the refresh lock, so callers queued behind
+        // us coalesce onto this outcome instead of re-hitting Nexus.
         let mut guard = self.state.write().await;
+        guard.attempts = guard.attempts.wrapping_add(1);
+        let resp = result?;
+
+        // Swap the UUID + bump the version on success.
         guard.uuid = resp.session_id;
         guard.version = guard.version.wrapping_add(1);
         metrics::counter!("thetadatadx.auth.refresh").increment(1);
@@ -207,6 +256,14 @@ impl SessionToken {
         let mut guard = self.state.write().await;
         guard.uuid = new_uuid.to_string();
         guard.version = guard.version.wrapping_add(1);
+    }
+
+    /// Test-only: number of completed refresh attempts (Nexus round-trips
+    /// issued from `refresh`, success or failure). Lets the single-flight
+    /// test assert a concurrent burst produced exactly one attempt.
+    #[cfg(test)]
+    pub(crate) async fn attempts_for_test(&self) -> u64 {
+        self.state.read().await.attempts
     }
 }
 
@@ -246,6 +303,21 @@ mod tests {
             HistoricalEnvironment::Prod,
             fake_creds(),
         )
+    }
+
+    #[test]
+    fn snapshot_debug_redacts_uuid() {
+        // The session UUID is a bearer token; the Debug impl must never print
+        // it (panic output / `tracing::error!("{snap:?}")` / crash dumps).
+        let snap = SessionSnapshot {
+            uuid: "11111111-2222-3333-4444-555555555555".to_string(),
+            version: 7,
+        };
+        let dbg = format!("{snap:?}");
+        assert!(!dbg.contains("11111111"), "session uuid leaked: {dbg}");
+        assert!(dbg.contains("***"), "uuid not redacted: {dbg}");
+        // Version is safe diagnostics and must still render.
+        assert!(dbg.contains('7'), "version must still render: {dbg}");
     }
 
     #[tokio::test]
@@ -391,6 +463,17 @@ mod tests {
         assert!(matches!(r1, Err(Error::Auth { .. }) | Err(Error::Http(_))));
         assert!(matches!(r2, Err(Error::Auth { .. }) | Err(Error::Http(_))));
         assert_eq!(t.snapshot().await.version, 0);
+        // Single-flight on failure: only ONE of the two callers issued a Nexus
+        // round-trip. The winner ran `authenticate_at` (and failed); the loser
+        // acquired the refresh lock, saw the attempt counter had advanced while
+        // the version had not, and coalesced onto that failure instead of
+        // hammering Nexus with a second attempt. Before this fix both callers
+        // re-authenticated in series, so `attempts` would be 2.
+        assert_eq!(
+            t.attempts_for_test().await,
+            1,
+            "a concurrent failed-refresh burst must issue exactly one Nexus attempt"
+        );
         // Wall-clock sanity: the test must complete without hanging.
         // 30s is generous — both tasks should fail-fast on connect
         // refused. If we hit this bound something is wrong with the

--- a/thetadatadx-rs/src/auth/session.rs
+++ b/thetadatadx-rs/src/auth/session.rs
@@ -59,11 +59,17 @@ struct Inner {
     /// Used by [`SessionToken::refresh`] to deduplicate concurrent
     /// refreshes — see the module doc.
     version: u64,
-    /// Monotonic counter incremented once per completed refresh attempt,
-    /// success OR failure. Lets [`SessionToken::refresh`] coalesce a burst
-    /// of concurrent callers onto a single Nexus round-trip even when that
-    /// round-trip fails (where `version` does not move) — see `refresh`.
+    /// Monotonic counter incremented once per refresh invocation that
+    /// entered `authenticate_at`, success OR failure. Lets
+    /// [`SessionToken::refresh`] coalesce a burst of concurrent callers onto a
+    /// single `authenticate_at` call even when it fails (where `version` does
+    /// not move) — see `refresh`.
     attempts: u64,
+    /// Classification + message of the most recent failed refresh, recorded so
+    /// a caller that coalesces behind it surfaces the same `AuthErrorKind`
+    /// (e.g. `InvalidCredentials`) instead of a generic error and misbranching
+    /// its retry decision. Cleared on the next successful refresh.
+    last_failure: Option<(crate::error::AuthErrorKind, String)>,
     /// Nexus URL the token was originally issued from. Reused on
     /// refresh so a staging config stays on its staging endpoint.
     nexus_url: String,
@@ -77,13 +83,22 @@ struct Inner {
 }
 
 /// Error surfaced to callers that coalesced onto a concurrent refresh which
-/// already failed for the same token generation. They issued no Nexus
-/// round-trip of their own; the caller surfaces this rather than stampeding a
-/// Nexus that just rejected the identical credentials.
-fn coalesced_refresh_error() -> Error {
-    Error::Auth {
-        kind: crate::error::AuthErrorKind::ServerError,
-        message: "session refresh already failed for this token generation".into(),
+/// already failed for the same token generation. They issued no
+/// `authenticate_at` call of their own; they surface the failing refresh's own
+/// classification (so a caller branching on `InvalidCredentials` vs `Timeout`
+/// still sees the real cause) rather than stampeding a Nexus that just rejected
+/// the identical credentials. Falls back to a generic error only if no failure
+/// was recorded.
+fn coalesced_refresh_error(last: Option<&(crate::error::AuthErrorKind, String)>) -> Error {
+    match last {
+        Some((kind, message)) => Error::Auth {
+            kind: *kind,
+            message: message.clone(),
+        },
+        None => Error::Auth {
+            kind: crate::error::AuthErrorKind::ServerError,
+            message: "session refresh already failed for this token generation".into(),
+        },
     }
 }
 
@@ -129,6 +144,7 @@ impl SessionToken {
                 uuid,
                 version: 0,
                 attempts: 0,
+                last_failure: None,
                 nexus_url,
                 environment,
                 creds,
@@ -200,12 +216,14 @@ impl SessionToken {
             // A concurrent refresh for this same token generation already ran
             // and failed while we waited on the lock (version unchanged, but
             // the attempt counter advanced). Coalesce onto that outcome rather
-            // than issuing a second Nexus round-trip, so a burst of N callers
-            // that all observe the same `Unauthenticated` makes at most one
-            // auth attempt. A failed credential or a down Nexus will not fix
+            // than issuing a second `authenticate_at` call, so a burst of N
+            // callers that all observe the same `Unauthenticated` enters
+            // `authenticate_at` at most once. Surface the failing refresh's own
+            // classification so a caller branching on the kind still sees the
+            // real cause. A failed credential or a down Nexus will not fix
             // itself on an immediate re-attempt.
             if guard.attempts != entry_attempts {
-                return Err(coalesced_refresh_error());
+                return Err(coalesced_refresh_error(guard.last_failure.as_ref()));
             }
             (
                 guard.nexus_url.clone(),
@@ -216,14 +234,25 @@ impl SessionToken {
 
         let result = authenticate_at(&nexus_url, &creds, environment).await;
 
-        // Record that an attempt completed for this generation (success OR
+        // Record that this generation entered `authenticate_at` (success OR
         // failure) before releasing the refresh lock, so callers queued behind
         // us coalesce onto this outcome instead of re-hitting Nexus.
         let mut guard = self.state.write().await;
         guard.attempts = guard.attempts.wrapping_add(1);
-        let resp = result?;
+        let resp = match result {
+            Ok(resp) => resp,
+            Err(e) => {
+                // Record the classification so a coalescing caller surfaces the
+                // same `AuthErrorKind` rather than a generic error.
+                if let Error::Auth { kind, message } = &e {
+                    guard.last_failure = Some((*kind, message.clone()));
+                }
+                return Err(e);
+            }
+        };
 
-        // Swap the UUID + bump the version on success.
+        // Swap the UUID + bump the version on success; clear the stale failure.
+        guard.last_failure = None;
         guard.uuid = resp.session_id;
         guard.version = guard.version.wrapping_add(1);
         metrics::counter!("thetadatadx.auth.refresh").increment(1);
@@ -258,9 +287,10 @@ impl SessionToken {
         guard.version = guard.version.wrapping_add(1);
     }
 
-    /// Test-only: number of completed refresh attempts (Nexus round-trips
-    /// issued from `refresh`, success or failure). Lets the single-flight
-    /// test assert a concurrent burst produced exactly one attempt.
+    /// Test-only: number of refresh invocations that entered `authenticate_at`
+    /// (success or failure), not counting `authenticate_at`'s own internal
+    /// retries. Lets the single-flight test assert a concurrent burst entered
+    /// `authenticate_at` exactly once.
     #[cfg(test)]
     pub(crate) async fn attempts_for_test(&self) -> u64 {
         self.state.read().await.attempts
@@ -460,19 +490,33 @@ mod tests {
         // important invariant: neither task panicked, neither
         // deadlocked, both returned typed errors. Version stayed at
         // 0 because no auth ever succeeded.
-        assert!(matches!(r1, Err(Error::Auth { .. }) | Err(Error::Http(_))));
-        assert!(matches!(r2, Err(Error::Auth { .. }) | Err(Error::Http(_))));
+        // Both surface the failing refresh's real classification: the winner's
+        // unreachable-URL failure is a connect error (NetworkError), and the
+        // coalescing loser copies that kind rather than a hardcoded ServerError,
+        // so a caller branching on `AuthErrorKind` still sees the true cause.
+        for r in [&r1, &r2] {
+            assert!(
+                matches!(
+                    r,
+                    Err(Error::Auth {
+                        kind: crate::error::AuthErrorKind::NetworkError,
+                        ..
+                    })
+                ),
+                "expected NetworkError from the failed/coalesced refresh: {r:?}"
+            );
+        }
         assert_eq!(t.snapshot().await.version, 0);
-        // Single-flight on failure: only ONE of the two callers issued a Nexus
-        // round-trip. The winner ran `authenticate_at` (and failed); the loser
-        // acquired the refresh lock, saw the attempt counter had advanced while
-        // the version had not, and coalesced onto that failure instead of
-        // hammering Nexus with a second attempt. Before this fix both callers
+        // Single-flight on failure: only ONE of the two callers entered
+        // `authenticate_at`. The winner ran it (and failed); the loser acquired
+        // the refresh lock, saw the attempt counter had advanced while the
+        // version had not, and coalesced onto that failure instead of entering
+        // `authenticate_at` a second time. Before this fix both callers
         // re-authenticated in series, so `attempts` would be 2.
         assert_eq!(
             t.attempts_for_test().await,
             1,
-            "a concurrent failed-refresh burst must issue exactly one Nexus attempt"
+            "a concurrent failed-refresh burst must enter authenticate_at exactly once"
         );
         // Wall-clock sanity: the test must complete without hanging.
         // 30s is generous — both tasks should fail-fast on connect


### PR DESCRIPTION
Three hardening changes to the Nexus auth client.

Do not follow redirects on the credential exchange. The auth POST body carries the password or apiKey. reqwest strips sensitive headers (Authorization, Cookie) on a cross-host redirect but replays the request body on a 307/308, so a 3xx to another host would send the credential body to the redirect target. The auth client now uses a no-follow redirect policy, and since Nexus never redirects auth, any 3xx surfaces as a server error.

Redact the session UUID in the `SessionSnapshot` `Debug` impl. The UUID is a bearer token; `Debug` now shows the same `***` marker `AuthResponse.session_id` uses, so it cannot land in panic output or `Debug`-formatted logs. Version still renders as safe operator diagnostics.

Coalesce a concurrent burst of failed session refreshes onto a single Nexus round-trip. Refresh already deduped concurrent callers via a version counter on success, but on failure the version does not move, so queued callers each re-authenticated in series. A per-generation attempt counter now lets callers queued behind an in-flight refresh that already failed return that outcome instead of hitting Nexus again.

Tests: `SessionSnapshot` `Debug` contains no UUID and shows `***`; a concurrent failed-refresh burst issues exactly one Nexus attempt (`attempts == 1`). Full auth suite passes under default and `__internal` features; fmt and clippy `-D warnings` clean.

Closes #1087