### PR TITLE
fix(flatfiles,tdbe): fail loud on truncated and header-drifted decodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The credential exchange no longer follows redirects.** The Nexus auth client is set to not follow redirects, so a 3xx from the auth endpoint surfaces as a server error instead of the credential request body being replayed to the redirect target. Nexus never redirects auth.
 - **`SessionSnapshot` no longer prints its session UUID.** The `Debug` output now redacts the UUID with the same `***` marker the auth response uses, so the bearer token cannot land in panic output or `Debug`-formatted logs.
 - **A concurrent burst of failed session refreshes now issues a single Nexus round-trip.** When several requests observe an expired session at once and the re-authentication fails, callers queued behind the first coalesce onto that outcome instead of each re-authenticating in series.
+- **Flat-files reject a truncated FIT block instead of emitting a garbage final row.** A per-contract block that ends before its terminating marker now raises a typed decode error, matching the streaming delta path, rather than pushing a partially decoded final row (#1084).
+- **End-of-day responses with fully drifted headers now error instead of returning zero-filled rows.** A rows-present EOD response whose headers fail to resolve raises a missing-required-header error like every other parser; an empty response still returns no rows (#1084).
+- **Flat-file downloads no longer destroy a prior good file or leave a partial under the final name.** Both the raw download and the decoded output write to a sibling temp file and rename onto the final path only after the write finishes, and the temp is removed on failure (#1085).
+- **Local disk faults during a flat-file download surface immediately.** A full, read-only, or permission-denied output filesystem is now terminal rather than triggering a full re-download on the retry ladder.
+- **FIT integer fields saturate on overflow.** A digit run longer than an i32 can hold now saturates to the signed bound instead of silently dropping the surplus digits and emitting a plausible wrong value.
+- **Price comparison agrees with display for absent prices.** A price carrying type 0 now compares as zero, consistent with its `0.0` rendering and `to_f64`.
 
 ## [13.0.0-rc.12] - 2026-07-01
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The credential exchange no longer follows redirects.** The Nexus auth client is set to not follow redirects, so a 3xx from the auth endpoint surfaces as a server error instead of the credential request body being replayed to the redirect target. Nexus never redirects auth.
 - **`SessionSnapshot` no longer prints its session UUID.** The `Debug` output now redacts the UUID with the same `***` marker the auth response uses, so the bearer token cannot land in panic output or `Debug`-formatted logs.
 - **A concurrent burst of failed session refreshes now issues a single Nexus round-trip.** When several requests observe an expired session at once and the re-authentication fails, callers queued behind the first coalesce onto that outcome instead of each re-authenticating in series.
+- **Flat-files reject a truncated FIT block instead of emitting a garbage final row.** A per-contract block that ends before its terminating marker now raises a typed decode error, matching the streaming delta path, rather than pushing a partially decoded final row (#1084).
+- **End-of-day responses with fully drifted headers now error instead of returning zero-filled rows.** A rows-present EOD response whose headers fail to resolve raises a missing-required-header error like every other parser; an empty response still returns no rows (#1084).
+- **Flat-file downloads no longer destroy a prior good file or leave a partial under the final name.** Both the raw download and the decoded output write to a sibling temp file and rename onto the final path only after the write finishes, and the temp is removed on failure (#1085).
+- **Local disk faults during a flat-file download surface immediately.** A full, read-only, or permission-denied output filesystem is now terminal rather than triggering a full re-download on the retry ladder.
+- **FIT integer fields saturate on overflow.** A digit run longer than an i32 can hold now saturates to the signed bound instead of silently dropping the surplus digits and emitting a plausible wrong value.
+- **Price comparison agrees with display for absent prices.** A price carrying type 0 now compares as zero, consistent with its `0.0` rendering and `to_f64`.
 
 ## [13.0.0-rc.12] - 2026-07-01
 

--- a/thetadatadx-rs/build_support/ticks/parser.rs
+++ b/thetadatadx-rs/build_support/ticks/parser.rs
@@ -116,42 +116,41 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
 
     // Phase 1: resolve the column layout once.
     //
-    // Required header guards (non-eod only). A missing required header on a
-    // non-empty response is a schema drift: silently returning `Ok(vec![])`
-    // masked real data loss for ~1M-row `TradeQuoteTick` responses (P11).
-    // Now we raise `DecodeError::MissingRequiredHeader` whenever the server
-    // returns rows without the declared header. Empty responses ("no trades
-    // today") still return `Ok(vec![])` because a vendor holiday / symbol
-    // with no activity is legitimate.
-    if !def.eod_style {
-        for req in &def.required {
-            let var = format!("{req}_idx");
-            writeln!(
-                out,
-                "    let {var} = match find_header(&h, \"{req}\") {{\n\
-                 \x20       Some(i) => i,\n\
-                 \x20       None => {{\n\
-                 \x20           if table.data_table.is_empty() {{\n\
-                 \x20               return Ok(vec![]);\n\
-                 \x20           }}\n\
-                 \x20           return Err(DecodeError::MissingRequiredHeader {{\n\
-                 \x20               header: \"{req}\",\n\
-                 \x20               rows: table.data_table.len(),\n\
-                 \x20               available: h.join(\",\"),\n\
-                 \x20           }});\n\
-                 \x20       }}\n\
-                 \x20   }};"
-            )
-            .unwrap();
-        }
-        if !def.required.is_empty() {
-            out.push('\n');
-        }
+    // Required header guards. A missing required header on a non-empty
+    // response is a schema drift: silently returning `Ok(vec![])` masked real
+    // data loss for ~1M-row `TradeQuoteTick` responses (P11). We raise
+    // `DecodeError::MissingRequiredHeader` whenever the server returns rows
+    // without the declared header — eod-style parsers included, so a fully
+    // header-drifted EOD response errors instead of yielding zero-seeded ticks.
+    // Empty responses ("no trades today") still return `Ok(vec![])` because a
+    // vendor holiday / symbol with no activity is legitimate.
+    for req in &def.required {
+        let var = format!("{req}_idx");
+        writeln!(
+            out,
+            "    let {var} = match find_header(&h, \"{req}\") {{\n\
+             \x20       Some(i) => i,\n\
+             \x20       None => {{\n\
+             \x20           if table.data_table.is_empty() {{\n\
+             \x20               return Ok(vec![]);\n\
+             \x20           }}\n\
+             \x20           return Err(DecodeError::MissingRequiredHeader {{\n\
+             \x20               header: \"{req}\",\n\
+             \x20               rows: table.data_table.len(),\n\
+             \x20               available: h.join(\",\"),\n\
+             \x20           }});\n\
+             \x20       }}\n\
+             \x20   }};"
+        )
+        .unwrap();
+    }
+    if !def.required.is_empty() {
+        out.push('\n');
     }
 
     // Optional column lookups (alias-aware).
     for col in &def.columns {
-        if !def.eod_style && def.required.contains(&col.name) {
+        if def.required.contains(&col.name) {
             // Already resolved above as required.
             continue;
         }
@@ -209,7 +208,7 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
         let call = format!(
             "crate::decode::column::extract_column(rows, ticks, row_base, {{idx}}, \"{name}\", {fill}, {decoder}, |t, v| t.{field} = v)?;"
         );
-        if !def.eod_style && def.required.contains(&col.name) {
+        if def.required.contains(&col.name) {
             writeln!(out, "        {}", call.replace("{idx}", &var)).unwrap();
         } else {
             writeln!(out, "        if let Some(idx) = {var} {{").unwrap();

--- a/thetadatadx-rs/src/flatfiles/decode.rs
+++ b/thetadatadx-rs/src/flatfiles/decode.rs
@@ -49,6 +49,15 @@ pub(crate) fn decode_block(
             // skips DATE rows before they reach `toCSV2`, so we do too.
             continue;
         }
+        if !reader.row_complete && n > 0 {
+            // The block ran out before the terminating END nibble, so the
+            // reader flushed a partial integer and the trailing slots are
+            // untrustworthy. The FPSS delta path rejects this same shape;
+            // match it here rather than emit a garbage final row.
+            return Err(Error::decode_codec(
+                "flatfiles: FIT block truncated mid-row",
+            ));
+        }
         if n == 0 {
             // Either an exhausted-buffer artefact or a zero-field row;
             // either way nothing to emit.
@@ -124,6 +133,20 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert_eq!(out[0], vec![100, 50, 200]);
         assert_eq!(out[1], vec![105, 47, 210]);
+    }
+
+    #[test]
+    fn truncated_final_row_is_rejected() {
+        // "12," then "34" with NO terminating END nibble: the block runs out
+        // mid-row. The FPSS delta path rejects this shape; decode_block must
+        // too, rather than push a garbage final row.
+        let buf = vec![pack(1, 2), pack(FIELD_SEP, 3), pack(4, 0)];
+        let mut out = Vec::new();
+        let err = decode_block(&buf, 2, &mut out).unwrap_err();
+        assert!(
+            err.to_string().contains("truncated"),
+            "expected a truncation decode error, got: {err}"
+        );
     }
 
     #[test]

--- a/thetadatadx-rs/src/flatfiles/decode.rs
+++ b/thetadatadx-rs/src/flatfiles/decode.rs
@@ -44,19 +44,21 @@ pub(crate) fn decode_block(
     while !reader.is_exhausted() {
         alloc.iter_mut().for_each(|v| *v = 0);
         let n = reader.read_changes(&mut alloc[..]);
+        if !reader.row_complete {
+            // The block ran out before a terminating END nibble — a truncated
+            // data row (partial integer flushed, trailing slots untrustworthy)
+            // or a truncated DATE marker (returns n==0). An END-terminated row
+            // always sets `row_complete`, so a false value here is always
+            // truncation. The FPSS delta path rejects this same shape; match
+            // it rather than accept the truncated block.
+            return Err(Error::decode_codec(
+                "flatfiles: FIT block truncated mid-row",
+            ));
+        }
         if reader.is_date {
             // DATE marker row — no user-visible data. Vendor's writer
             // skips DATE rows before they reach `toCSV2`, so we do too.
             continue;
-        }
-        if !reader.row_complete && n > 0 {
-            // The block ran out before the terminating END nibble, so the
-            // reader flushed a partial integer and the trailing slots are
-            // untrustworthy. The FPSS delta path rejects this same shape;
-            // match it here rather than emit a garbage final row.
-            return Err(Error::decode_codec(
-                "flatfiles: FIT block truncated mid-row",
-            ));
         }
         if n == 0 {
             // Either an exhausted-buffer artefact or a zero-field row;
@@ -141,6 +143,20 @@ mod tests {
         // mid-row. The FPSS delta path rejects this shape; decode_block must
         // too, rather than push a garbage final row.
         let buf = vec![pack(1, 2), pack(FIELD_SEP, 3), pack(4, 0)];
+        let mut out = Vec::new();
+        let err = decode_block(&buf, 2, &mut out).unwrap_err();
+        assert!(
+            err.to_string().contains("truncated"),
+            "expected a truncation decode error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_date_marker_missing_end_is_rejected() {
+        // A DATE marker byte (0xCE) with no terminating END nibble: the reader
+        // returns n==0 and row_complete==false. That is still a truncated
+        // block and must be rejected, not silently skipped as a DATE row.
+        let buf = vec![0xCE, pack(1, 2)]; // marker + digits, no END
         let mut out = Vec::new();
         let err = decode_block(&buf, 2, &mut out).unwrap_err();
         assert!(

--- a/thetadatadx-rs/src/flatfiles/decoded.rs
+++ b/thetadatadx-rs/src/flatfiles/decoded.rs
@@ -246,6 +246,7 @@ pub(crate) fn decode_to_file(
     // complete and closed; publish it onto the final name. Windows `rename`
     // (unlike Unix) fails when the destination exists, so remove a prior file
     // first there; the Unix path stays an atomic replace.
+    // ponytail: Windows publish is remove-then-rename, not atomic; ReplaceFileW-via-windows-crate if a concurrent-writer race is ever observed
     #[cfg(windows)]
     let _ = std::fs::remove_file(output_path);
     std::fs::rename(&tmp_path, output_path)?;

--- a/thetadatadx-rs/src/flatfiles/decoded.rs
+++ b/thetadatadx-rs/src/flatfiles/decoded.rs
@@ -21,6 +21,7 @@ use crate::flatfiles::index::{parse_header, IndexIter};
 use crate::flatfiles::request::flatfile_request_raw_with_config;
 use crate::flatfiles::types::{ReqType, SecType};
 use crate::flatfiles::writer::{CsvSink, JsonlSink, RowSink, RowView};
+use crate::flatfiles::ScratchGuard;
 use crate::util::random_id::random_id_hex;
 
 /// Narrow a wire `u64` byte offset to the platform `usize` used for slicing.
@@ -120,14 +121,15 @@ pub async fn flatfile_request_with_config(
     let final_path = format.ensure_extension(output_path.as_ref());
     let raw_path = final_path.with_extension(format!("{}.raw", format.extension()));
 
-    // Run the pull + decode, then reap the raw scratch blob on every
-    // outcome. The raw artifact is created by the wire layer once auth
-    // succeeds, so any post-handshake failure (StreamTruncated, a
-    // mid-stream DISCONNECTED, a read error) or a decode fault would
-    // otherwise orphan it; an error before `File::create` (connect /
-    // login) leaves no file, and the ignored `NotFound` from removing it
-    // is harmless.
-    let result = pull_and_decode_to_file(
+    // Reap the raw scratch blob on every outcome. The raw artifact is created
+    // by the wire layer once auth succeeds, so any post-handshake failure
+    // (StreamTruncated, a mid-stream DISCONNECTED, a read error) or a decode
+    // fault would otherwise orphan it; an error before `File::create` (connect
+    // / login) leaves no file, and the ignored `NotFound` on removal is
+    // harmless. The guard drops even if this future is cancelled mid-await,
+    // which a post-await cleanup line would miss.
+    let _raw_guard = ScratchGuard::new(&raw_path);
+    pull_and_decode_to_file(
         creds,
         sec,
         req,
@@ -137,9 +139,8 @@ pub async fn flatfile_request_with_config(
         format,
         config,
     )
-    .await;
-    let _ = tokio::fs::remove_file(&raw_path).await;
-    result.map(|()| final_path)
+    .await?;
+    Ok(final_path)
 }
 
 /// Pull the raw blob into `raw_path` and decode it onto `final_path`.
@@ -192,15 +193,26 @@ pub(crate) fn decode_to_file(
     let hdr = parse_header(&blob)?;
     let (index_bytes, data_bytes) = slice_sections(&blob, &hdr)?;
 
+    // Decode into a sibling `.tmp` and rename onto `output_path` only after
+    // `finish()` flushes cleanly. A decode fault mid-walk then leaves the
+    // partial under the temp name, never a valid-looking partial under the
+    // requested final name. The guard reaps the temp on any `?` early return.
+    let tmp_path = {
+        let mut p = output_path.as_os_str().to_owned();
+        p.push(".tmp");
+        PathBuf::from(p)
+    };
+    let mut tmp_guard = ScratchGuard::new(&tmp_path);
+
     let mut sink: Box<dyn RowSink> = match format {
         FlatFileFormat::Csv => Box::new(CsvSink::new(
-            output_path,
+            &tmp_path,
             sec,
             hdr.fmt.clone(),
             hdr.price_type_idx,
         )?),
         FlatFileFormat::Jsonl => Box::new(JsonlSink::new(
-            output_path,
+            &tmp_path,
             sec,
             hdr.fmt.clone(),
             hdr.price_type_idx,
@@ -230,6 +242,10 @@ pub(crate) fn decode_to_file(
         }
     }
     sink.finish()?;
+    // `finish` consumed the sink and flushed its writer, so the temp file is
+    // complete and closed; publish it onto the final name atomically.
+    std::fs::rename(&tmp_path, output_path)?;
+    tmp_guard.disarm();
     Ok(())
 }
 
@@ -276,10 +292,10 @@ pub async fn flatfile_request_decoded_with_config(
     // as the on-disk path. The blob is created by the wire layer once
     // auth succeeds, so a post-handshake pull failure or a decode fault
     // would otherwise orphan it; a pre-`File::create` failure leaves no
-    // file and the ignored `NotFound` is harmless.
-    let result = pull_and_decode_to_memory(creds, sec, req, date, &scratch, config).await;
-    let _ = tokio::fs::remove_file(&scratch).await;
-    result
+    // file and the ignored `NotFound` is harmless. The guard drops even on
+    // a cancelled future, which a post-await cleanup line would miss.
+    let _scratch_guard = ScratchGuard::new(&scratch);
+    pull_and_decode_to_memory(creds, sec, req, date, &scratch, config).await
 }
 
 /// Pull the raw blob into `scratch` and decode it into a typed `Vec`.

--- a/thetadatadx-rs/src/flatfiles/decoded.rs
+++ b/thetadatadx-rs/src/flatfiles/decoded.rs
@@ -243,7 +243,11 @@ pub(crate) fn decode_to_file(
     }
     sink.finish()?;
     // `finish` consumed the sink and flushed its writer, so the temp file is
-    // complete and closed; publish it onto the final name atomically.
+    // complete and closed; publish it onto the final name. Windows `rename`
+    // (unlike Unix) fails when the destination exists, so remove a prior file
+    // first there; the Unix path stays an atomic replace.
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(output_path);
     std::fs::rename(&tmp_path, output_path)?;
     tmp_guard.disarm();
     Ok(())

--- a/thetadatadx-rs/src/flatfiles/mod.rs
+++ b/thetadatadx-rs/src/flatfiles/mod.rs
@@ -38,6 +38,42 @@ pub use decoded::{
     flatfile_request, flatfile_request_decoded, flatfile_request_decoded_with_config,
     flatfile_request_with_config,
 };
+
+/// Removes `path` on drop unless [`disarm`](Self::disarm) has been called.
+///
+/// Reaps a scratch / temp file on every exit path — a `?` early return, an
+/// error, or a dropped (cancelled) future — where a single post-await cleanup
+/// line would be skipped on cancellation. `disarm` hands ownership back to the
+/// caller once the file has been renamed onto its final name or returned on
+/// success. Cleanup is best-effort and ignores a missing file.
+// ponytail: sync unlink in Drop; a single best-effort syscall, no async needed.
+pub(crate) struct ScratchGuard {
+    path: std::path::PathBuf,
+    armed: bool,
+}
+
+impl ScratchGuard {
+    pub(crate) fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            armed: true,
+        }
+    }
+
+    /// Cancel removal — the file is now the caller's (renamed onto its final
+    /// name or handed back on success).
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ScratchGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
 pub use decoded_row::{FlatFileRow, FlatFileValue};
 pub use format::FlatFileFormat;
 pub use request::{flatfile_request_raw, flatfile_request_raw_with_config};

--- a/thetadatadx-rs/src/flatfiles/request.rs
+++ b/thetadatadx-rs/src/flatfiles/request.rs
@@ -360,6 +360,7 @@ async fn run_one_attempt(
     // guard so it does not reap the file we just renamed. Windows `rename`
     // (unlike Unix) fails when the destination exists, so remove a prior file
     // first there; the Unix path stays an atomic replace.
+    // ponytail: Windows publish is remove-then-rename, not atomic; ReplaceFileW-via-windows-crate if a concurrent-writer race is ever observed
     #[cfg(windows)]
     let _ = tokio::fs::remove_file(output_path).await;
     tokio::fs::rename(&tmp_path, output_path).await?;

--- a/thetadatadx-rs/src/flatfiles/request.rs
+++ b/thetadatadx-rs/src/flatfiles/request.rs
@@ -356,8 +356,12 @@ async fn run_one_attempt(
     }
     out.flush().await?;
     drop(out);
-    // Atomically publish the completed download onto the final name, then
-    // release the guard so it does not reap the file we just renamed.
+    // Publish the completed download onto the final name, then release the
+    // guard so it does not reap the file we just renamed. Windows `rename`
+    // (unlike Unix) fails when the destination exists, so remove a prior file
+    // first there; the Unix path stays an atomic replace.
+    #[cfg(windows)]
+    let _ = tokio::fs::remove_file(output_path).await;
     tokio::fs::rename(&tmp_path, output_path).await?;
     tmp_guard.disarm();
     tracing::info!(

--- a/thetadatadx-rs/src/flatfiles/request.rs
+++ b/thetadatadx-rs/src/flatfiles/request.rs
@@ -37,6 +37,7 @@ use crate::flatfiles::framing::{msg, read_frame, Frame};
 use crate::flatfiles::mdds_spki::{ALLOWED_MDDS_HOSTS, MDDS_PORTS};
 use crate::flatfiles::session::{connect_and_login, MddsHost};
 use crate::flatfiles::types::{flat_file_serves, FlatFilesUnavailableReason, ReqType, SecType};
+use crate::flatfiles::ScratchGuard;
 
 /// Process-wide monotonic id generator. The server treats id as opaque; we
 /// use an `AtomicI64` so concurrent `flatfile_request_raw` calls cannot
@@ -118,8 +119,16 @@ fn error_is_transient(err: &Error) -> bool {
         // Local I/O failures (connect refused, mid-stream TLS reset,
         // unexpected EOF before any payload arrived). The next attempt
         // re-runs the host candidate list from the top so a momentary
-        // single-host blip rotates onto the next reachable host.
-        Error::Io(_) => true,
+        // single-host blip rotates onto the next reachable host. Local
+        // disk faults are the exception: a full, read-only, or
+        // permission-denied output filesystem will not heal on retry, so
+        // surface those immediately instead of re-running the whole download.
+        Error::Io(io) => !matches!(
+            io.kind(),
+            std::io::ErrorKind::StorageFull
+                | std::io::ErrorKind::PermissionDenied
+                | std::io::ErrorKind::ReadOnlyFilesystem
+        ),
         // Explicit reason classifier on the typed FLATFILES failure.
         // `StreamTruncated` is transient; `RequestRejected` is terminal;
         // `AuthRejected` depends on the wire reason code.
@@ -282,7 +291,19 @@ async fn run_one_attempt(
     )
     .await?;
 
-    let file = File::create(output_path).await?;
+    // Download into a sibling `.tmp` and rename onto `output_path` only after
+    // the stream finishes and flushes. A prior good file at `output_path` is
+    // never truncated up front, so an all-attempts-fail run leaves it intact,
+    // and a mid-stream failure leaves the partial under the temp name, not the
+    // final one. The guard reaps the temp on every failing exit (a `?` return
+    // or a cancelled future); `disarm` after a successful rename.
+    let tmp_path = {
+        let mut p = output_path.as_os_str().to_owned();
+        p.push(".tmp");
+        PathBuf::from(p)
+    };
+    let mut tmp_guard = ScratchGuard::new(&tmp_path);
+    let file = File::create(&tmp_path).await?;
     // 1 MB buffer — typical chunks are ~8-64 KB, so this batches many
     // chunks per actual write syscall.
     let mut out = BufWriter::with_capacity(1 << 20, file);
@@ -335,6 +356,10 @@ async fn run_one_attempt(
     }
     out.flush().await?;
     drop(out);
+    // Atomically publish the completed download onto the final name, then
+    // release the guard so it does not reap the file we just renamed.
+    tokio::fs::rename(&tmp_path, output_path).await?;
+    tmp_guard.disarm();
     tracing::info!(
         target: "flatfiles",
         "FLAT_FILE_END id={request_id} chunks={chunks} bytes={total} -> {}",

--- a/thetadatadx-rs/src/mdds/decode/tests.rs
+++ b/thetadatadx-rs/src/mdds/decode/tests.rs
@@ -1835,8 +1835,12 @@ fn parse_trade_ticks_rejects_numeric_expiration_overflowing_i32() {
 #[test]
 fn parse_eod_ticks_rejects_numeric_date_overflowing_i32() {
     let table = proto::DataTable {
-        headers: vec!["date".into(), "open".into()],
-        data_table: vec![row_of(vec![dv_number(i64::MAX), dv_number(15_000)])],
+        headers: vec!["created".into(), "date".into(), "open".into()],
+        data_table: vec![row_of(vec![
+            dv_number(0),
+            dv_number(i64::MAX),
+            dv_number(15_000),
+        ])],
     };
     assert_eq!(
         parse_eod_ticks(&table).unwrap_err(),
@@ -2219,8 +2223,8 @@ fn parse_calendar_days_v3_accepts_numeric_open_at_session_start() {
 #[test]
 fn parse_eod_ticks_rejects_price_type_above_max() {
     let table = proto::DataTable {
-        headers: vec!["open".into()],
-        data_table: vec![row_of(vec![dv_price(100, 20)])],
+        headers: vec!["created".into(), "open".into()],
+        data_table: vec![row_of(vec![dv_number(0), dv_price(100, 20)])],
     };
     assert_eq!(
         parse_eod_ticks(&table).unwrap_err(),
@@ -2231,8 +2235,8 @@ fn parse_eod_ticks_rejects_price_type_above_max() {
 #[test]
 fn parse_eod_ticks_rejects_price_type_21() {
     let table = proto::DataTable {
-        headers: vec!["high".into()],
-        data_table: vec![row_of(vec![dv_price(250, 21)])],
+        headers: vec!["created".into(), "high".into()],
+        data_table: vec![row_of(vec![dv_number(0), dv_price(250, 21)])],
     };
     assert_eq!(
         parse_eod_ticks(&table).unwrap_err(),
@@ -2243,8 +2247,8 @@ fn parse_eod_ticks_rejects_price_type_21() {
 #[test]
 fn parse_eod_ticks_rejects_negative_price_type() {
     let table = proto::DataTable {
-        headers: vec!["low".into()],
-        data_table: vec![row_of(vec![dv_price(99, -1)])],
+        headers: vec!["created".into(), "low".into()],
+        data_table: vec![row_of(vec![dv_number(0), dv_price(99, -1)])],
     };
     assert_eq!(
         parse_eod_ticks(&table).unwrap_err(),
@@ -2255,8 +2259,8 @@ fn parse_eod_ticks_rejects_negative_price_type() {
 #[test]
 fn parse_eod_ticks_rejects_price_type_i32_max() {
     let table = proto::DataTable {
-        headers: vec!["close".into()],
-        data_table: vec![row_of(vec![dv_price(1, i32::MAX)])],
+        headers: vec!["created".into(), "close".into()],
+        data_table: vec![row_of(vec![dv_number(0), dv_price(1, i32::MAX)])],
     };
     assert_eq!(
         parse_eod_ticks(&table).unwrap_err(),
@@ -2268,6 +2272,8 @@ fn parse_eod_ticks_rejects_price_type_i32_max() {
 fn parse_eod_ticks_smoke_with_in_range_price_type() {
     let table = proto::DataTable {
         headers: vec![
+            "created".into(),
+            "date".into(),
             "open".into(),
             "high".into(),
             "low".into(),
@@ -2276,6 +2282,8 @@ fn parse_eod_ticks_smoke_with_in_range_price_type() {
             "ask".into(),
         ],
         data_table: vec![row_of(vec![
+            dv_number(0),
+            dv_number(20_240_315),
             dv_price(15_000, 10),
             dv_price(15_500, 10),
             dv_price(14_800, 10),
@@ -2293,4 +2301,22 @@ fn parse_eod_ticks_smoke_with_in_range_price_type() {
     assert!((t.close - 15_200.0).abs() < 1e-10);
     assert!((t.bid - 15_100.0).abs() < 1e-10);
     assert!((t.ask - 15_300.0).abs() < 1e-10);
+}
+
+#[test]
+fn parse_eod_ticks_rejects_rows_missing_created_header() {
+    // A rows-present EOD response whose `created` header failed to resolve must
+    // error like every other parser rather than return zero-seeded ticks. An
+    // empty response still returns Ok (see parse_eod_handles_empty_table).
+    let table = proto::DataTable {
+        headers: vec!["open".into()],
+        data_table: vec![row_of(vec![dv_price(15_000, 10)])],
+    };
+    assert!(matches!(
+        parse_eod_ticks(&table).unwrap_err(),
+        DecodeError::MissingRequiredHeader {
+            header: "created",
+            ..
+        }
+    ));
 }

--- a/thetadatadx-rs/src/tdbe/codec/fit.rs
+++ b/thetadatadx-rs/src/tdbe/codec/fit.rs
@@ -123,6 +123,7 @@ impl<'a> FitReader<'a> {
         let mut digits = [0u8; MAX_DIGITS];
         let mut count: usize = 0;
         let mut negative = false;
+        let mut overflow = false;
 
         while self.pos < self.buf.len() {
             let byte = self.buf[self.pos];
@@ -140,11 +141,20 @@ impl<'a> FitReader<'a> {
                 &mut digits,
                 &mut count,
                 &mut negative,
+                &mut overflow,
             ) {
                 self.row_complete = true;
                 return idx;
             }
-            if Self::process_nibble(low, alloc, &mut idx, &mut digits, &mut count, &mut negative) {
+            if Self::process_nibble(
+                low,
+                alloc,
+                &mut idx,
+                &mut digits,
+                &mut count,
+                &mut negative,
+                &mut overflow,
+            ) {
                 self.row_complete = true;
                 return idx;
             }
@@ -153,8 +163,8 @@ impl<'a> FitReader<'a> {
         // Buffer exhausted without END nibble, so flush whatever we have. The
         // row is truncated: `row_complete` stays `false` so callers can reject
         // it rather than emit a partial/zero-filled tick.
-        if count > 0 || negative {
-            let val = flush_digits(&digits, count, negative);
+        if count > 0 || negative || overflow {
+            let val = flush_digits(&digits, count, negative, overflow);
             if idx < alloc.len() {
                 alloc[idx] = val;
             }
@@ -174,36 +184,44 @@ impl<'a> FitReader<'a> {
         digits: &mut [u8; MAX_DIGITS],
         count: &mut usize,
         negative: &mut bool,
+        overflow: &mut bool,
     ) -> bool {
         match nibble {
             0..=9 => {
-                // Accumulate decimal digit.
+                // Accumulate decimal digit. Past the i32 digit budget, flag
+                // overflow so the flush saturates to the signed bound rather
+                // than silently dropping the surplus digits and emitting a
+                // plausible-but-wrong value.
                 if *count < MAX_DIGITS {
                     digits[*count] = nibble;
                     *count += 1;
+                } else {
+                    *overflow = true;
                 }
                 false
             }
             FIELD_SEP => {
                 // Flush current integer, advance to next slot.
-                let val = flush_digits(digits, *count, *negative);
+                let val = flush_digits(digits, *count, *negative, *overflow);
                 if *idx < alloc.len() {
                     alloc[*idx] = val;
                 }
                 *idx += 1;
                 *count = 0;
                 *negative = false;
+                *overflow = false;
                 false
             }
             ROW_SEP => {
                 // Flush current integer.
-                let val = flush_digits(digits, *count, *negative);
+                let val = flush_digits(digits, *count, *negative, *overflow);
                 if *idx < alloc.len() {
                     alloc[*idx] = val;
                 }
                 *idx += 1;
                 *count = 0;
                 *negative = false;
+                *overflow = false;
                 // Zero-fill up to index SPACING-1, advancing idx to SPACING.
                 while *idx < SPACING {
                     if *idx < alloc.len() {
@@ -223,12 +241,12 @@ impl<'a> FitReader<'a> {
             }
             END => {
                 // Flush and terminate.
-                let val = flush_digits(digits, *count, *negative);
+                let val = flush_digits(digits, *count, *negative, *overflow);
                 if *idx < alloc.len() {
                     alloc[*idx] = val;
                 }
                 *idx += 1;
-                // *count = 0;  // Not needed — we're done.
+                // *count / *overflow reset not needed — we're done.
                 true
             }
             NEGATIVE => {
@@ -268,10 +286,17 @@ impl<'a> FitReader<'a> {
 /// Uses an i64 accumulator internally to avoid overflow for 10-digit values
 /// near `i32::MAX`. Values that exceed i32 range are saturated.
 ///
+/// `overflow` is set by the caller when a digit run exceeded the `MAX_DIGITS`
+/// budget, so the surplus digits were never buffered; saturate to the signed
+/// bound by sign rather than return the truncated low-order value.
+///
 /// An empty digit buffer (count == 0) flushes as 0, so back-to-back
 /// separators in the wire format emit a 0 field.
 #[inline]
-fn flush_digits(digits: &[u8; MAX_DIGITS], count: usize, negative: bool) -> i32 {
+fn flush_digits(digits: &[u8; MAX_DIGITS], count: usize, negative: bool, overflow: bool) -> i32 {
+    if overflow {
+        return if negative { i32::MIN } else { i32::MAX };
+    }
     let mut val: i64 = 0;
     for &digit in digits.iter().take(count) {
         val = val * 10 + i64::from(digit);
@@ -325,17 +350,46 @@ mod tests {
     fn flush_digits_basic() {
         let mut d = [0u8; MAX_DIGITS];
         // Empty → 0
-        assert_eq!(flush_digits(&d, 0, false), 0);
+        assert_eq!(flush_digits(&d, 0, false, false), 0);
         // Single digit 7
         d[0] = 7;
-        assert_eq!(flush_digits(&d, 1, false), 7);
-        assert_eq!(flush_digits(&d, 1, true), -7);
+        assert_eq!(flush_digits(&d, 1, false, false), 7);
+        assert_eq!(flush_digits(&d, 1, true, false), -7);
         // 123
         d[0] = 1;
         d[1] = 2;
         d[2] = 3;
-        assert_eq!(flush_digits(&d, 3, false), 123);
-        assert_eq!(flush_digits(&d, 3, true), -123);
+        assert_eq!(flush_digits(&d, 3, false, false), 123);
+        assert_eq!(flush_digits(&d, 3, true, false), -123);
+    }
+
+    #[test]
+    fn flush_digits_overflow_saturates() {
+        // An overflow flag saturates to the signed bound by sign, regardless
+        // of the (truncated) low-order digits still in the buffer.
+        let d = [9u8; MAX_DIGITS];
+        assert_eq!(flush_digits(&d, MAX_DIGITS, false, true), i32::MAX);
+        assert_eq!(flush_digits(&d, MAX_DIGITS, true, true), i32::MIN);
+    }
+
+    #[test]
+    fn digit_run_past_budget_saturates() {
+        // "12345678901" is 11 digits — one past the i32 budget. Dropping the
+        // surplus digit would yield 1234567890; the overflow flag must instead
+        // saturate the field to i32::MAX.
+        let data = [
+            pack(1, 2),
+            pack(3, 4),
+            pack(5, 6),
+            pack(7, 8),
+            pack(9, 0),
+            pack(1, END),
+        ];
+        let mut alloc = [0i32; 4];
+        let mut reader = FitReader::new(&data);
+        let n = reader.read_changes(&mut alloc);
+        assert_eq!(n, 1);
+        assert_eq!(alloc[0], i32::MAX);
     }
 
     #[test]
@@ -905,8 +959,8 @@ mod tests {
             let mut buf = [0u8; MAX_DIGITS];
             buf[..digits.len()].copy_from_slice(&digits);
             for k in 1..digits.len() {
-                let prev = flush_digits(&buf, k, false);
-                let next = flush_digits(&buf, k + 1, false);
+                let prev = flush_digits(&buf, k, false, false);
+                let next = flush_digits(&buf, k + 1, false, false);
                 prop_assert!(next >= prev);
             }
         }

--- a/thetadatadx-rs/src/tdbe/types/price.rs
+++ b/thetadatadx-rs/src/tdbe/types/price.rs
@@ -234,8 +234,15 @@ impl Price {
     fn compare(&self, other: &Self) -> Ordering {
         let self_type = self.price_type.get();
         let other_type = other.price_type.get();
+        // `price_type == 0` means the price is absent — `to_f64` and `Display`
+        // both render it as `0.0` regardless of the raw mantissa, so the
+        // ordering must agree: treat a type-0 operand's value as 0 before any
+        // same-type or scaled comparison, otherwise two type-0 prices with
+        // different mantissas would sort unequal while both display `0.0`.
+        let self_val = i64::from(if self_type == 0 { 0 } else { self.value });
+        let other_val = i64::from(if other_type == 0 { 0 } else { other.value });
         if self_type == other_type {
-            return self.value.cmp(&other.value);
+            return self_val.cmp(&other_val);
         }
         // Scale to common base using i64 to avoid overflow.
         // For exponents > 18, i64 multiplication can overflow; fall back to f64.
@@ -245,9 +252,9 @@ impl Price {
                 // Fall back to f64 comparison for very large exponent differences.
                 return self.to_f64().total_cmp(&other.to_f64());
             }
-            let scaled = i64::from(self.value).checked_mul(POW10_I64[exp]);
+            let scaled = self_val.checked_mul(POW10_I64[exp]);
             match scaled {
-                Some(s) => s.cmp(&i64::from(other.value)),
+                Some(s) => s.cmp(&other_val),
                 // Overflow: fall back to f64 for correct sign handling.
                 None => self.to_f64().total_cmp(&other.to_f64()),
             }
@@ -256,9 +263,9 @@ impl Price {
             if exp > 18 {
                 return self.to_f64().total_cmp(&other.to_f64());
             }
-            let scaled = i64::from(other.value).checked_mul(POW10_I64[exp]);
+            let scaled = other_val.checked_mul(POW10_I64[exp]);
             match scaled {
-                Some(s) => i64::from(self.value).cmp(&s),
+                Some(s) => self_val.cmp(&s),
                 None => self.to_f64().total_cmp(&other.to_f64()),
             }
         }
@@ -358,6 +365,16 @@ mod tests {
         let c = Price::new(1502500, 6); // 150.25 (same value, different type)
         assert_eq!(a, c);
         assert_ne!(a, Price::new(15000, 8)); // 150.00
+    }
+
+    #[test]
+    fn test_price_type_zero_is_absent_and_equals_zero() {
+        // price_type 0 renders/converts to 0.0 regardless of mantissa, so
+        // equality must agree: any two type-0 prices are equal, and a type-0
+        // price equals a real zero, while staying distinct from a nonzero one.
+        assert_eq!(Price::new(999, 0), Price::new(-5, 0));
+        assert_eq!(Price::new(999, 0), Price::new(0, 8));
+        assert_ne!(Price::new(999, 0), Price::new(1, 8));
     }
 
     /// Every valid `price_type` (`0..=MAX_PRICE_TYPE`, i.e. `0..=19`)

--- a/thetadatadx-rs/tests/flatfiles_synthetic_golden.rs
+++ b/thetadatadx-rs/tests/flatfiles_synthetic_golden.rs
@@ -151,6 +151,10 @@ fn synthetic_blob_decodes_to_pinned_csv() {
     let raw = dir.join("synthetic.bin");
     let csv = dir.join("synthetic.csv");
     std::fs::write(&raw, &blob).unwrap();
+    // Seed a prior good file at the final path: a successful decode must
+    // publish over it (Windows `rename` does not replace an existing dest, so
+    // this pins the replace-capable publish on every target).
+    std::fs::write(&csv, b"stale prior contents\n").unwrap();
 
     thetadatadx::flatfiles::decoded_decode_to_file_for_test(
         &raw,

--- a/thetadatadx-rs/tests/flatfiles_synthetic_golden.rs
+++ b/thetadatadx-rs/tests/flatfiles_synthetic_golden.rs
@@ -169,3 +169,63 @@ fn synthetic_blob_decodes_to_pinned_csv() {
     // Cleanup. Failures above keep the artefacts in place for triage.
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// A decode fault mid-walk must leave no partial file under the requested
+/// final name: the sink writes to a `.tmp` sibling and only renames onto the
+/// final path after `finish()`. Drop the row-2 END nibble so the final FIT
+/// block is truncated — `decode_block` rejects it after the sink has already
+/// written its header to the temp — and assert the decode errors *and* the
+/// final path never materialises (nor a prior good file at it is clobbered).
+#[test]
+fn decode_error_leaves_final_path_untouched() {
+    // Start from the valid blob, then truncate one DATA byte while keeping the
+    // header's data length and the INDEX block_end consistent so the failure
+    // lands inside the row loop (after the sink is created), not at header parse.
+    let mut blob = synthetic_option_blob();
+    let count = i32::from_be_bytes(blob[0..4].try_into().unwrap()) as usize;
+    let data_len_pos = 4 + 4 * count + 8; // fmt + index_len i64
+    let index_start = data_len_pos + 8; // + data_len i64
+    let index_len = i64::from_be_bytes(blob[data_len_pos - 8..data_len_pos].try_into().unwrap());
+    let block_end_pos = index_start + index_len as usize - 8;
+
+    blob.pop(); // drop the row-2 END byte
+    let data_len = i64::from_be_bytes(blob[data_len_pos..data_len_pos + 8].try_into().unwrap());
+    blob[data_len_pos..data_len_pos + 8].copy_from_slice(&(data_len - 1).to_be_bytes());
+    let block_end = i64::from_be_bytes(blob[block_end_pos..block_end_pos + 8].try_into().unwrap());
+    blob[block_end_pos..block_end_pos + 8].copy_from_slice(&(block_end - 1).to_be_bytes());
+
+    let dir = std::env::temp_dir().join(format!("thetadatadx-flatfiles-tmprename-{}", {
+        let bytes: [u8; 16] = rand::random();
+        bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+    }));
+    std::fs::create_dir_all(&dir).unwrap();
+    let raw = dir.join("truncated.bin");
+    let csv = dir.join("out.csv");
+    std::fs::write(&raw, &blob).unwrap();
+
+    // Seed a prior good file at the final path; the failing decode must not
+    // clobber it with a partial.
+    std::fs::write(&csv, b"prior good contents\n").unwrap();
+
+    let res = thetadatadx::flatfiles::decoded_decode_to_file_for_test(
+        &raw,
+        SecType::Option,
+        &csv,
+        FlatFileFormat::Csv,
+    );
+    assert!(res.is_err(), "a truncated FIT block must fail the decode");
+    assert_eq!(
+        std::fs::read_to_string(&csv).unwrap(),
+        "prior good contents\n",
+        "the prior good file must survive the failed decode untouched"
+    );
+    // No leftover temp sibling under the final name.
+    let tmp = csv.with_extension("csv.tmp");
+    assert!(!tmp.exists(), "the temp sibling must be reaped on error");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/thetadatadx-rs/tick_schema.toml
+++ b/thetadatadx-rs/tick_schema.toml
@@ -229,7 +229,7 @@ align = 64
 contract_id = true
 parser = "parse_eod_ticks"
 eod_style = true
-required = []
+required = ["created"]
 columns = [
     { name = "created",       field = "created_ms_of_day",    type = "eod_num", doc = "EOD report creation time (NOT a trade time), milliseconds since midnight ET." },
     { name = "last_trade",    field = "last_trade_ms_of_day", type = "eod_num", doc = "Time of the day's last trade, milliseconds since midnight ET. 0 when no trades printed that day." },


### PR DESCRIPTION
Two decode paths accepted malformed input and emitted plausible wrong rows with no error, plus flat-file output could clobber a prior good file. This makes every path fail loud, matching the terminal.

## Flat-files (#1084, #1085)

Reject a truncated FIT block: a per-contract block that runs out before its terminating marker now raises a typed decode error, the same shape the streaming delta path already rejects, instead of pushing a partially decoded final row.

Require a header on end-of-day responses: EodTick declares `created` as a required header, so a rows-present response whose headers all fail to resolve raises a missing-required-header error like every other parser. An empty response still returns no rows. This required-header guard now applies to eod-style parsers in the generated code, not just the non-eod ones.

Atomic flat-file output: both the raw download and the decoded writer now write to a sibling temp file and rename onto the final path only after the write finishes, so a failing download or a mid-walk decode error can no longer destroy a prior good file or leave a partial under the requested final name. The temp is removed on failure through the same reap shape already used for the raw scratch.

Terminal disk faults: a full, read-only, or permission-denied output filesystem is now classified terminal rather than triggering a full re-download on the retry ladder.

Cancellation-safe scratch reap: the raw scratch blob is reaped through an RAII guard that runs even when the future is cancelled mid-await, where the previous post-await cleanup line was skipped.

## tdbe codec

FIT integer overflow: a digit run longer than an i32 can hold now saturates to the signed bound instead of silently dropping the surplus digits and emitting a plausible wrong value.

Price type-0 comparison: a price carrying type 0 now compares as zero, consistent with its `0.0` Display and `to_f64`.

## Tests

Added regression tests for the truncated-FIT reject (`decode_block` and the codec), the output temp-rename (a mid-walk decode failure leaves the prior good file untouched and no temp orphan), the FIT overflow saturation, the header-drifted EOD reject, and the type-0 Price equality.

## Gates

cargo fmt --check, cargo clippy --workspace --all-targets -D warnings, cargo test -p thetadatadx (lib + flatfiles + tdbe + decode), both codegen-drift --check binaries, and the docs-site changelog copy all pass. No version bump.

Closes #1084
Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)