### PR TITLE
fix(flatfiles): reject zero-column and over-width header drift in block decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Projected historical frames keep the trading `date`.** A response whose wire sends one `Timestamp` header split into a time-of-day field and `date` (every EOD and trade/quote/greeks history endpoint) no longer drops `date` from the Arrow / Polars frame, so rows spanning multiple days are distinguishable instead of collapsing to a near-constant time-of-day.
 - **Projected snapshot frames keep the per-row `symbol`.** A multi-symbol snapshot response no longer labels every row with the first row's symbol; the broadcast symbol column is emitted only when the response's `symbol` is provably constant across all rows.
+- **Flat-files block decode fails loud on two drifted-header shapes.** A header declaring zero columns over a non-empty DATA block, and a row carrying more fields than the header's column count, now return a typed decode error instead of silently emitting zero rows or clipping the surplus field. This matches the FPSS delta path's width guard and the existing mid-row truncation guard.
 
 ## [13.0.0-rc.13] - 2026-07-02
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Projected historical frames keep the trading `date`.** A response whose wire sends one `Timestamp` header split into a time-of-day field and `date` (every EOD and trade/quote/greeks history endpoint) no longer drops `date` from the Arrow / Polars frame, so rows spanning multiple days are distinguishable instead of collapsing to a near-constant time-of-day.
 - **Projected snapshot frames keep the per-row `symbol`.** A multi-symbol snapshot response no longer labels every row with the first row's symbol; the broadcast symbol column is emitted only when the response's `symbol` is provably constant across all rows.
+- **Flat-files block decode fails loud on two drifted-header shapes.** A header declaring zero columns over a non-empty DATA block, and a row carrying more fields than the header's column count, now return a typed decode error instead of silently emitting zero rows or clipping the surplus field. This matches the FPSS delta path's width guard and the existing mid-row truncation guard.
 
 ## [13.0.0-rc.13] - 2026-07-02
 

--- a/thetadatadx-rs/src/flatfiles/decode.rs
+++ b/thetadatadx-rs/src/flatfiles/decode.rs
@@ -32,8 +32,16 @@ pub(crate) fn decode_block(
     out: &mut Vec<Vec<i32>>,
 ) -> Result<(), Error> {
     out.clear();
-    if block.is_empty() || n_columns == 0 {
+    if block.is_empty() {
         return Ok(());
+    }
+    if n_columns == 0 {
+        // A zero-column schema over non-empty DATA is a drifted header: every
+        // row would decode to nothing while the block still carries bytes.
+        // Fail loud rather than emit zero rows, matching the truncation guard.
+        return Err(Error::decode_codec(
+            "flatfiles: zero-column header with non-empty data",
+        ));
     }
 
     let mut reader = FitReader::new(block);
@@ -53,6 +61,15 @@ pub(crate) fn decode_block(
             // it rather than accept the truncated block.
             return Err(Error::decode_codec(
                 "flatfiles: FIT block truncated mid-row",
+            ));
+        }
+        if n > n_columns {
+            // Row carries more fields than the blob's column schema, so the
+            // FIT reader already dropped the surplus into a silent clip. A
+            // wider row is a drifted header; reject it rather than emit a
+            // truncated row, matching the FPSS delta path's width guard.
+            return Err(Error::decode_codec(
+                "flatfiles: FIT row wider than header column count",
             ));
         }
         if reader.is_date {
@@ -162,6 +179,33 @@ mod tests {
         assert!(
             err.to_string().contains("truncated"),
             "expected a truncation decode error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn zero_column_header_with_data_is_rejected() {
+        // A header claiming zero columns over a non-empty DATA block is a
+        // drifted schema: silently decoding to zero rows would hide the drift.
+        let buf = vec![pack(1, END)];
+        let mut out = Vec::new();
+        let err = decode_block(&buf, 0, &mut out).unwrap_err();
+        assert!(
+            err.to_string().contains("zero-column"),
+            "expected a zero-column decode error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn over_width_row_is_rejected() {
+        // "12,34<END>" carries 2 fields against a 1-column schema: the extra
+        // field would be silently clipped. The FPSS delta path rejects the
+        // same width drift; decode_block must too.
+        let buf = vec![pack(1, 2), pack(FIELD_SEP, 3), pack(4, END)];
+        let mut out = Vec::new();
+        let err = decode_block(&buf, 1, &mut out).unwrap_err();
+        assert!(
+            err.to_string().contains("wider"),
+            "expected an over-width decode error, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Problem

`decode_block` in `thetadatadx-rs/src/flatfiles/decode.rs` passed two drifted/hostile-header shapes silently, unlike the mid-row truncation guard that already fails loud on the same surface:

1. A header declaring `fmt_count == 0` over a non-empty DATA block decoded to zero rows with no error. A drifted zero-column header vanished silently.
2. A row carrying more fields than the header's column count was silently clipped (the FIT reader drops surplus fields past the buffer length). The FPSS sibling decode path (`fpss/delta.rs`) rejects the same width drift.

## Solution

Both now return `Error::decode_codec`, matching the FPSS delta path's width guard and the existing truncation guard:

- `n_columns == 0` over a non-empty block returns a zero-column decode error (an empty block still returns `Ok` with no rows).
- A row with `n > n_columns` returns an over-width decode error. Delta rows legitimately carry `n < n_columns` (trailing carry-forward), so only wider rows are rejected.

Regression tests cover both shapes.

## Impact

A drifted flat-files header fails loud instead of producing silently wrong output. No behavior change on well-formed blocks; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)