### PR TITLE
feat(typescript): make the projected Arrow-IPC exit drivable from a live historical call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TypeScript projected Arrow-IPC is now drivable from a live historical call.** Every columnar historical method gains a `<method>WithColumns` variant returning `{ rows, presentColumns, symbol? }`: the same rows as the plain method plus the columns the response's wire actually carried (and the broadcast root symbol when the response has one). Feed `presentColumns` and `symbol` straight to `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame that omits the columns the wire omitted, without hand-supplying a header list. The existing `Array<Tick>` methods are unchanged. This brings TypeScript to parity with Python's presence-carrying tick list and the C and C++ `_with_options` presence out-param.
+
 ### Fixed
 
 - **A mid-stream reconnect on a historical `*_stream` no longer duplicates the leading rows.** When a server-streaming call delivered some chunks and then dropped with a transient status (or `Unauthenticated`), the shared retry loop restarted the call from chunk zero even though the buffered collectors behind the Python / TypeScript / C / C++ bindings had already appended those chunks, producing a successful result with duplicated leading rows. Because the upstream has no resume cursor, a restart is now allowed only while no chunk has reached the handler; once delivery has begun a later transient is surfaced as an error instead of silently replaying the delivered prefix. A transient before the first chunk still retries.

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TypeScript projected Arrow-IPC is now drivable from a live historical call.** Every columnar historical method gains a `<method>WithColumns` variant returning `{ rows, presentColumns, symbol? }`: the same rows as the plain method plus the columns the response's wire actually carried (and the broadcast root symbol when the response has one). Feed `presentColumns` and `symbol` straight to `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame that omits the columns the wire omitted, without hand-supplying a header list. The existing `Array<Tick>` methods are unchanged. This brings TypeScript to parity with Python's presence-carrying tick list and the C and C++ `_with_options` presence out-param.
+
 ### Fixed
 
 - **A mid-stream reconnect on a historical `*_stream` no longer duplicates the leading rows.** When a server-streaming call delivered some chunks and then dropped with a transient status (or `Unauthenticated`), the shared retry loop restarted the call from chunk zero even though the buffered collectors behind the Python / TypeScript / C / C++ bindings had already appended those chunks, producing a successful result with duplicated leading rows. Because the upstream has no resume cursor, a restart is now allowed only while no chunk has reached the handler; once delivery has begun a later transient is surfaced as an error instead of silently replaying the delivered prefix. A transient before the first chunk still retries.

--- a/parity.toml
+++ b/parity.toml
@@ -2822,23 +2822,29 @@ typescript = "Option<BigInt>"
 #
 #   * Decode-fed projected (only the columns the response's wire carried, plus
 #     the optional broadcast `symbol`) — `TicksArrowExt::to_arrow_projected`,
-#     the terminal-exact path: Python's `<TickName>List.to_arrow()` on a decoded
-#     list auto-projects from the `ColumnPresence` the list carries; TypeScript
-#     and C++ return bare rows, so the caller resolves the response headers to
-#     the present columns with `<tick>PresentColumns(headers)` /
-#     `thetadatadx_<tick>_present_columns` and hands them plus the optional
-#     `symbol` to `<tick>ToArrowIpcProjected(rows, presentColumns, symbol?)` /
+#     the terminal-exact path. Every binding surfaces the response's own
+#     `ColumnPresence` from a live query so the projection is drivable without
+#     hand-supplying the header list: Python's `<TickName>List.to_arrow()` on a
+#     decoded list auto-projects from the presence the list carries; the C ABI /
+#     C++ buffered `_with_options` entry points return the present columns
+#     through the `ColumnPresence` out-param; TypeScript's `<endpoint>WithColumns`
+#     method returns `{ rows, presentColumns, symbol? }`. The caller then hands
+#     `presentColumns` plus the optional `symbol` to
+#     `<tick>ToArrowIpcProjected(rows, presentColumns, symbol?)` /
 #     `thetadatadx_<tick>_to_arrow_ipc_projected`. The projected `RecordBatch` is
 #     identical; the only difference is where the presence is carried (on the
-#     Python result vs. an explicit argument on TS/C++).
+#     Python result, the C/C++ out-param, or the TypeScript return object).
 #
 # All surfaces are generated from `tick_schema.toml` and funnel through the one
 # `TicksArrowExt::to_arrow` / `to_arrow_projected` + Arrow IPC `StreamWriter`
 # path; the `generate_sdk_surfaces --check` drift gate and the
-# `check_c_abi_completeness` header/symbol parity gate guard a regression. They
-# are free functions, not methods on a tracked class, so they are not
-# expressible as `[[method]]` / `[[value_field]]` rows — this note records the
-# contract the drift gates enforce.
+# `check_c_abi_completeness` header/symbol parity gate guard a regression. The
+# per-tick serializer free functions are not methods on a tracked class, so they
+# are not expressible as `[[method]]` / `[[value_field]]` rows. The TypeScript
+# `<endpoint>WithColumns` reachability (a presence-carrying variant per columnar
+# buffered endpoint) is machine-enforced by the check_binding_parity
+# `withColumns` reachability gate, mirroring the C/C++ `_with_options` presence
+# out-param — this note records the rest of the contract the drift gates enforce.
 
 
 # ─── Historical server-stream surface ([[historical_streaming]]) ──────

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -124,6 +124,10 @@ def _resolve_ts_entry(pkg_dir: pathlib.Path, key: str, fallback: str) -> pathlib
 TS_DTS = _resolve_ts_entry(TS_PKG_DIR, "types", "index.d.ts")
 TS_MAIN_JS = _resolve_ts_entry(TS_PKG_DIR, "main", "index.js")
 TS_SRC = REPO_ROOT / "thetadatadx-ts" / "src"
+# The committed generated napi historical surface. The `<endpoint>WithColumns`
+# reachability gate reads its `#[napi(js_name = ...)]` attributes directly (a
+# deterministic no-build source the napi compile lowers into `index.d.ts`).
+TS_HISTORICAL_METHODS_RS = TS_SRC / "_generated" / "historical_methods.rs"
 CPP_HPP = REPO_ROOT / "thetadatadx-cpp" / "include" / "thetadatadx.hpp"
 CPP_H = REPO_ROOT / "thetadatadx-cpp" / "include" / "thetadatadx.h"
 FFI_SRC = REPO_ROOT / "thetadatadx-ffi" / "src"
@@ -4200,8 +4204,10 @@ def _collect_typescript_async_endpoints(
     `Promise`, so the buffered endpoint method IS the async surface — there
     is no separate `_async` spelling. Reuses the already-collected
     `{class: {method, ...}}` map: take the `HistoricalView` methods, drop
-    the `<endpoint>Stream` server-stream companions and the FPSS lifecycle
-    methods, and snake-ify the remainder to recover the endpoint names.
+    the `<endpoint>Stream` server-stream companions, the `<endpoint>WithColumns`
+    presence-carrying variants (tracked by the withColumns reachability gate),
+    and the FPSS lifecycle methods, and snake-ify the remainder to recover the
+    endpoint names.
     """
     out: set[str] = set()
     methods = ts_methods.get("HistoricalView", set())
@@ -4210,6 +4216,8 @@ def _collect_typescript_async_endpoints(
         if method in lifecycle:
             continue
         if method.endswith("Stream") and len(method) > len("Stream"):
+            continue
+        if method.endswith("WithColumns") and len(method) > len("WithColumns"):
             continue
         out.add(_endpoint_method_to_snake(method))
     return out
@@ -4379,6 +4387,92 @@ def _endpoint_is_calendar(endpoint: dict[str, Any]) -> bool:
     return a bounded result and get no server-stream terminal.
     """
     return endpoint.get("name", "").startswith("calendar")
+
+
+def _collect_rust_columnar_buffered_endpoints(
+    surface_toml: pathlib.Path,
+) -> set[str]:
+    """Snake_case names of every buffered COLUMNAR historical endpoint.
+
+    The buffered set (`_collect_rust_buffered_endpoints`) minus the flat
+    `StringList` list endpoints, which carry no column set. Each columnar
+    endpoint's `.await` decode yields a core `Ticks<T>` carrying the response's
+    `ColumnPresence`, so each must surface a presence-carrying variant on the
+    managed bindings for the projected Arrow-IPC exit to be drivable from a live
+    call. This is the expected set the TypeScript `withColumns` reachability gate
+    holds the binding to (the same registry of record the streaming / base
+    families read).
+    """
+    if not surface_toml.is_file():
+        return set()
+    data = tomllib.loads(surface_toml.read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for endpoint in data.get("endpoints", []):
+        name = endpoint.get("name")
+        if not name or name.endswith("_stream"):
+            continue
+        if _endpoint_is_simple_list(endpoint):
+            continue
+        out.add(name)
+    return out
+
+
+def _collect_typescript_with_columns_endpoints(
+    hist_methods_rs: pathlib.Path,
+) -> set[str]:
+    """Snake_case endpoint names whose TypeScript historical surface exposes a
+    `<endpoint>WithColumns` presence-carrying query variant.
+
+    Reads the committed generated napi source
+    (`thetadatadx-ts/src/_generated/historical_methods.rs`) rather than the
+    built `index.d.ts`, so the gate holds against the deterministic no-build
+    source the napi compile lowers into the `.d.ts` — the same reason the
+    streaming / buffered rows read `endpoint_surface.toml`. Each variant carries
+    a `#[napi(js_name = "<camel>WithColumns")]` attribute; the camel stem
+    snake-ifies back to the endpoint name. The method is emitted onto both the
+    `HistoricalView` and `HistoricalClient` impl blocks, so the set dedups.
+    """
+    out: set[str] = set()
+    if not hist_methods_rs.is_file():
+        return out
+    text = _read_source(hist_methods_rs)
+    for m in re.finditer(r'#\[napi\(js_name = "(\w+?)WithColumns"\)\]', text):
+        out.add(_endpoint_method_to_snake(m.group(1)))
+    return out
+
+
+def _check_typescript_with_columns_reachability(
+    expected: set[str],
+    actual: set[str],
+) -> list[str]:
+    """The TypeScript projected-Arrow reachability gate.
+
+    Every buffered columnar endpoint (`expected`) must surface a
+    `<endpoint>WithColumns` variant returning the rows plus the response's
+    `presentColumns` / `symbol`, so the projected Arrow-IPC exit is reachable
+    from a live call at parity with Python's presence-carrying `<Tick>List` and
+    the C / C++ `_with_options` presence out-param. A missing variant leaves the
+    only live-call path on that endpoint the full-schema `<tick>ToArrowIpc`,
+    which emits always-present flag / contract-identity columns the wire never
+    sent. An unexpected variant (present on TS but not a columnar buffered
+    endpoint) is generator drift. Both trip the gate.
+    """
+    errors: list[str] = []
+    for name in sorted(expected - actual):
+        errors.append(
+            f"  {name}: buffered columnar endpoint has no `{_snake_to_camel(name)}"
+            f"WithColumns` TypeScript variant. Without it a live caller cannot "
+            f"obtain the response's presentColumns / symbol, so the projected "
+            f"Arrow-IPC export is unreachable (the #1072 always-zero-flag frame). "
+            f"Regenerate the TypeScript historical surface."
+        )
+    for name in sorted(actual - expected):
+        errors.append(
+            f"  {name}: TypeScript exposes a `{_snake_to_camel(name)}WithColumns` "
+            f"variant but it is not a buffered columnar endpoint. Remove it or "
+            f"correct the endpoint registry."
+        )
+    return errors
 
 
 def _collect_rust_streaming_endpoints(
@@ -7963,6 +8057,23 @@ def main(argv: list[str] | None = None) -> int:
         historical_async_rows, rust_buffered, py_async, ts_async, cpp_async
     )
 
+    # TypeScript projected-Arrow reachability — every buffered columnar endpoint
+    # must surface a `<endpoint>WithColumns` variant returning the response's
+    # presentColumns / symbol alongside the rows, so the projected Arrow-IPC
+    # exit is drivable from a live call (parity with Python's presence-carrying
+    # `<Tick>List` and the C / C++ `_with_options` presence out-param). Read
+    # from the committed generated napi source, the deterministic no-build
+    # counterpart of the streaming / base families' `endpoint_surface.toml`.
+    ts_with_columns = _collect_typescript_with_columns_endpoints(
+        TS_HISTORICAL_METHODS_RS
+    )
+    rust_columnar_buffered = _collect_rust_columnar_buffered_endpoints(
+        ENDPOINT_SURFACE_TOML
+    )
+    ts_with_columns_errors = _check_typescript_with_columns_reachability(
+        rust_columnar_buffered, ts_with_columns
+    )
+
     # Historical buffered base surface ([[historical_base]] rows) — the
     # blocking query terminal per endpoint on ALL FIVE surfaces: the Rust
     # `HistoricalClient::<endpoint>` method (registry of record), the Python
@@ -8302,6 +8413,17 @@ def main(argv: list[str] | None = None) -> int:
             f"`[[historical_base]]` granularity):"
         )
         for e in historical_base_errors:
+            print(e)
+        print()
+
+    if ts_with_columns_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(ts_with_columns_errors)} TypeScript "
+            f"projected-Arrow reachability mismatch(es) (per-endpoint "
+            f"`<endpoint>WithColumns` variant):"
+        )
+        for e in ts_with_columns_errors:
             print(e)
         print()
 

--- a/thetadatadx-rs/build_support_bin/endpoints/sdk_render/typescript.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/sdk_render/typescript.rs
@@ -42,6 +42,8 @@
 
 use std::fmt::Write as _;
 
+use heck::ToLowerCamelCase as _;
+
 use super::super::helpers::{compose_endpoint_doc, endpoint_streams, is_streaming_endpoint};
 use super::super::model::GeneratedEndpoint;
 use super::super::sdk_helpers::{
@@ -90,6 +92,24 @@ pub(super) fn render_typescript_historical_methods(endpoints: &[GeneratedEndpoin
         out.push_str(&render_typescript_endpoint_options_struct(endpoint));
         out.push('\n');
     }
+    // One `<Tick>WithColumns` return object per distinct columnar return type —
+    // the `{ rows, presentColumns, symbol? }` shape the `<method>WithColumns`
+    // variant returns, so a live caller can drive the projected Arrow-IPC exit
+    // from the response's own column set. `StringList` endpoints carry no
+    // column set and get none.
+    let mut seen_return_types = std::collections::HashSet::new();
+    for endpoint in endpoints
+        .iter()
+        .filter(|endpoint| !is_streaming_endpoint(endpoint))
+        .filter(|endpoint| endpoint.return_type != "StringList")
+    {
+        if seen_return_types.insert(endpoint.return_type.clone()) {
+            out.push_str(&render_typescript_with_columns_struct(
+                &endpoint.return_type,
+            ));
+            out.push('\n');
+        }
+    }
     for class_name in HISTORICAL_IMPL_CLASSES {
         out.push_str(&render_typescript_historical_impl_block(
             endpoints, class_name,
@@ -133,6 +153,14 @@ fn render_typescript_historical_impl_block(
         // method.
         if endpoint_streams(endpoint) {
             out.push_str(&render_typescript_endpoint_stream_method(endpoint));
+            out.push('\n');
+        }
+        // Presence-carrying variant: the same query returning the rows plus the
+        // response's projected column set (and the broadcast `symbol` when the
+        // wire carried one), so the projected Arrow-IPC exit is reachable from a
+        // live call. `StringList` endpoints carry no column set and get none.
+        if endpoint.return_type != "StringList" {
+            out.push_str(&render_typescript_endpoint_with_columns_method(endpoint));
             out.push('\n');
         }
     }
@@ -195,11 +223,6 @@ fn render_typescript_endpoint_options_struct(endpoint: &GeneratedEndpoint) -> St
 fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     let method_params = method_params(endpoint);
     let is_string_list = endpoint.return_type == "StringList";
-    let builder_params = if is_string_list {
-        Vec::new()
-    } else {
-        builder_params(endpoint)
-    };
     let camel_name = to_camel_case(&endpoint.name);
     let struct_name = options_struct_name(endpoint);
     let mut out = String::new();
@@ -237,6 +260,74 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
         .unwrap();
     }
 
+    write_ts_request_prelude(&mut out, endpoint, is_string_list);
+
+    let has_symbols = method_params
+        .iter()
+        .any(|param| param.param_type == "Symbols");
+
+    if is_string_list {
+        let positional_args = method_params
+            .iter()
+            .map(|param| {
+                if param.param_type == "Symbols" {
+                    "&refs".into()
+                } else if matches!(param.param_type.as_str(), "Date" | "Expiration")
+                    || is_time_arg(param)
+                {
+                    format!("{}.as_str()", sdk_method_arg_name(param))
+                } else {
+                    format!("&{}", sdk_method_arg_name(param))
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        // The builder borrows `client` and the owned params, so it is
+        // constructed and awaited inside the spawned future where those
+        // values live for `'static`.
+        out.push_str("        spawn_endpoint_task(async move {\n");
+        if has_symbols {
+            out.push_str(
+                "            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();\n",
+            );
+        }
+        writeln!(
+            out,
+            "            let call = client.historical().{name}({positional_args});",
+            name = endpoint.name,
+        )
+        .unwrap();
+        write_timeout_call(&mut out, "            ");
+        out.push_str("        })\n");
+        out.push_str("        .await\n");
+        out.push_str("    }\n");
+        return out;
+    }
+
+    // Builder-backed endpoints.
+    write_ts_builder_request(&mut out, endpoint);
+    writeln!(
+        out,
+        "        Ok({}(&ticks))",
+        ts_class_vec_converter(&endpoint.return_type)
+    )
+    .unwrap();
+    out.push_str("    }\n");
+    out
+}
+
+/// Emit the shared method prelude: `options` unwrap, deadline validation,
+/// client-handle clone, and the argument / builder-parameter normalization.
+/// Byte-identical across the buffered `Array<Tick>` method, the `StringList`
+/// list method, and the presence-carrying `<method>WithColumns` variant, so
+/// they share one source of the request setup.
+fn write_ts_request_prelude(out: &mut String, endpoint: &GeneratedEndpoint, is_string_list: bool) {
+    let method_params = method_params(endpoint);
+    let builder_params = if is_string_list {
+        Vec::new()
+    } else {
+        builder_params(endpoint)
+    };
     out.push_str("        let options = options.unwrap_or_default();\n");
 
     // Validate the per-call deadline up front, before the request task
@@ -309,46 +400,19 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
             }
         }
     }
+}
 
-    if is_string_list {
-        let positional_args = method_params
-            .iter()
-            .map(|param| {
-                if param.param_type == "Symbols" {
-                    "&refs".into()
-                } else if matches!(param.param_type.as_str(), "Date" | "Expiration")
-                    || is_time_arg(param)
-                {
-                    format!("{}.as_str()", sdk_method_arg_name(param))
-                } else {
-                    format!("&{}", sdk_method_arg_name(param))
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        // The builder borrows `client` and the owned params, so it is
-        // constructed and awaited inside the spawned future where those
-        // values live for `'static`.
-        out.push_str("        spawn_endpoint_task(async move {\n");
-        if has_symbols {
-            out.push_str(
-                "            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();\n",
-            );
-        }
-        writeln!(
-            out,
-            "            let call = client.historical().{name}({positional_args});",
-            name = endpoint.name,
-        )
-        .unwrap();
-        write_timeout_call(&mut out, "            ");
-        out.push_str("        })\n");
-        out.push_str("        .await\n");
-        out.push_str("    }\n");
-        return out;
-    }
-
-    // Builder-backed endpoints.
+/// Emit the builder construction, spawn, and `.await?` for a builder-backed
+/// (non-`StringList`) endpoint, binding the decoded `ticks` — a core
+/// `Ticks<T>` carrying the response's column presence (`ticks.columns()`).
+/// Shared by the buffered `Array<Tick>` method and the `<method>WithColumns`
+/// variant, which read the presence off the same `ticks` binding.
+fn write_ts_builder_request(out: &mut String, endpoint: &GeneratedEndpoint) {
+    let method_params = method_params(endpoint);
+    let builder_params = builder_params(endpoint);
+    let has_symbols = method_params
+        .iter()
+        .any(|param| param.param_type == "Symbols");
     let positional_args = method_params
         .iter()
         .map(|param| {
@@ -401,12 +465,111 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     out.push_str("            request.await\n");
     out.push_str("        })\n");
     out.push_str("        .await?;\n");
+}
+
+/// `TradeTick` (the collection's element class) -> `TradeTickWithColumns`, the
+/// `#[napi(object)]` return shape of the `<method>WithColumns` variant.
+fn with_columns_struct_name(return_type: &str) -> String {
+    format!("{}WithColumns", ts_class_name(return_type))
+}
+
+/// Emit the `#[napi(object)] <Tick>WithColumns` return struct: the decoded
+/// rows plus the response's projected column set and optional broadcast
+/// `symbol`. A live caller feeds `presentColumns` (and `symbol`) straight into
+/// `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame, without
+/// hand-supplying the header list.
+fn render_typescript_with_columns_struct(return_type: &str) -> String {
+    let tick_class = ts_class_name(return_type);
+    let struct_name = with_columns_struct_name(return_type);
+    let mut out = String::new();
     writeln!(
         out,
-        "        Ok({}(&ticks))",
-        ts_class_vec_converter(&endpoint.return_type)
+        "/// A decoded history result paired with the columns the response's wire"
     )
     .unwrap();
+    out.push_str("/// actually carried. Returned by the `<method>WithColumns` variant so a\n");
+    out.push_str("/// live caller can serialize a projected Arrow-IPC frame (only the wire's\n");
+    out.push_str("/// columns, matching the terminal's columnar output) without hand-supplying\n");
+    writeln!(
+        out,
+        "/// the header list: pass `presentColumns` and `symbol` to `{}ToArrowIpcProjected`.",
+        tick_class.to_lower_camel_case()
+    )
+    .unwrap();
+    out.push_str("#[napi(object)]\n");
+    writeln!(out, "pub struct {struct_name} {{").unwrap();
+    out.push_str("    /// The decoded rows, identical to the `Array<Tick>` the buffered\n");
+    out.push_str("    /// method returns.\n");
+    writeln!(out, "    pub rows: Vec<{tick_class}>,").unwrap();
+    out.push_str("    /// The schema-column names the response's wire carried, in schema\n");
+    out.push_str("    /// order — the projection set for a terminal-exact Arrow frame.\n");
+    out.push_str("    pub present_columns: Vec<String>,\n");
+    out.push_str("    /// The response's constant `symbol` (root) when the wire carried one\n");
+    out.push_str("    /// (option and index responses), else `undefined` (stock responses).\n");
+    out.push_str("    pub symbol: Option<String>,\n");
+    out.push_str("}\n");
+    out
+}
+
+/// Emit the `<endpoint>WithColumns` method: the same query as the buffered
+/// method, returning the rows plus the response's projected column set and
+/// broadcast `symbol` (a `<Tick>WithColumns` object) so the projected
+/// Arrow-IPC exit is reachable from a live call — the TypeScript analogue of
+/// the C `_with_options` presence out-param and Python's presence-carrying
+/// `<Tick>List`. Only emitted for builder-backed (non-`StringList`) endpoints.
+fn render_typescript_endpoint_with_columns_method(endpoint: &GeneratedEndpoint) -> String {
+    let method_params = method_params(endpoint);
+    let camel_name = to_camel_case(&endpoint.name);
+    let struct_name = options_struct_name(endpoint);
+    let return_struct = with_columns_struct_name(&endpoint.return_type);
+    let converter = ts_class_vec_converter(&endpoint.return_type);
+    let mut out = String::new();
+
+    let doc = format!(
+        "Run the `{camel}` query and return the rows together with the columns the \
+         response's wire carried, so a projected Arrow-IPC frame is drivable from a \
+         live call. Same parameters and result rows as the `{camel}` method; the \
+         returned object adds `presentColumns` (the schema columns the wire sent, in \
+         schema order) and `symbol` (the response's constant root, set for option and \
+         index responses). Feed both to `{tick_camel}ToArrowIpcProjected` for a \
+         terminal-exact columnar export that omits the columns the wire omitted.",
+        camel = camel_name,
+        tick_camel = ts_class_name(&endpoint.return_type).to_lower_camel_case(),
+    );
+    out.push_str(&render_rust_doc_block("    ", &doc));
+    writeln!(out, "    #[napi(js_name = \"{camel_name}WithColumns\")]").unwrap();
+    writeln!(
+        out,
+        "    pub async fn {name}_with_columns(",
+        name = endpoint.name
+    )
+    .unwrap();
+    out.push_str("        &self,\n");
+    for param in &method_params {
+        writeln!(
+            out,
+            "        {}: {},",
+            sdk_method_arg_name(param),
+            ts_napi_arg_type(param)
+        )
+        .unwrap();
+    }
+    writeln!(out, "        options: Option<{struct_name}>,").unwrap();
+    writeln!(out, "    ) -> napi::Result<{return_struct}> {{").unwrap();
+
+    write_ts_request_prelude(&mut out, endpoint, false);
+    write_ts_builder_request(&mut out, endpoint);
+
+    // The core `Ticks<T>` carries the response's `ColumnPresence`: emit its
+    // present schema columns and broadcast `symbol` alongside the converted
+    // rows so the projected Arrow terminal is drivable without a header list.
+    writeln!(out, "        Ok({return_struct} {{").unwrap();
+    writeln!(out, "            rows: {converter}(&ticks),").unwrap();
+    out.push_str(
+        "            present_columns: ticks.columns().present_names().map(String::from).collect(),\n",
+    );
+    out.push_str("            symbol: ticks.columns().symbol().map(String::from),\n");
+    out.push_str("        })\n");
     out.push_str("    }\n");
     out
 }

--- a/thetadatadx-ts/__tests__/arrow_ipc_projected.test.mjs
+++ b/thetadatadx-ts/__tests__/arrow_ipc_projected.test.mjs
@@ -156,3 +156,66 @@ describe('projected Arrow-IPC terminal', () => {
     }
   });
 });
+
+// The `<method>WithColumns` live-call variant (#1098 TypeScript parity). The
+// plain `<method>` returns `Array<Tick>` with no presence, so a live caller
+// could only reach the full-schema `<tick>ToArrowIpc`. The variant returns
+// `{ rows, presentColumns, symbol? }`, so the response's own column set drives
+// `<tick>ToArrowIpcProjected` — the projected exit reachable from a live call.
+//
+// The prebuilt native addon in the tree predates this method, so the live call
+// itself is exercised against the committed generated napi source (the shape
+// napi lowers into index.d.ts, verified by the drift gate). The end-to-end
+// drivability of the RETURN SHAPE is exercised for real: the object a live call
+// yields is assembled and its `presentColumns` / `symbol` feed the real
+// projected serialiser in the addon.
+describe('withColumns live-call variant drives the projected export', () => {
+  const generated = readFileSync(
+    resolve(__dirname, '..', 'src', '_generated', 'historical_methods.rs'),
+    'utf8'
+  );
+
+  // Emulate what `stockHistoryTradeWithColumns` returns for a stock response:
+  // the converted rows plus the response's present columns (resolved from the
+  // wire headers exactly as the method does from the core ColumnPresence) and
+  // the broadcast symbol (absent on a stock response).
+  function withColumnsReturn(headers, symbol) {
+    return {
+      rows: sampleRows(),
+      presentColumns: addon.tradeTickPresentColumns(headers),
+      symbol: symbol ?? undefined,
+    };
+  }
+
+  it('projects a stock response to only its wire columns from the return object', () => {
+    const page = withColumnsReturn(STOCK_TRADE_HEADERS, null);
+    const buf = addon.tradeTickToArrowIpcProjected(page.rows, page.presentColumns, page.symbol ?? null);
+    const cols = ipcColumns(buf);
+    assert.deepEqual(cols, STOCK_TRADE_HEADERS, 'the return object must drive a terminal-exact frame');
+    for (const absent of ['condition_flags', 'price_flags', 'volume_type', 'records_back', 'expiration', 'strike', 'right']) {
+      assert.ok(!cols.includes(absent), `projected export leaked wire-absent column ${absent}`);
+    }
+  });
+
+  it('broadcasts the return object symbol as the leading column', () => {
+    const optionHeaders = ['expiration', 'strike', 'right', 'ms_of_day', 'sequence', 'condition', 'size', 'exchange', 'price'];
+    const page = withColumnsReturn(optionHeaders, 'SPY');
+    const buf = addon.tradeTickToArrowIpcProjected(page.rows, page.presentColumns, page.symbol ?? null);
+    const cols = ipcColumns(buf);
+    assert.equal(cols[0], 'symbol', 'the return object symbol must lead the projected frame');
+  });
+
+  it('generates the WithColumns variant on both historical classes', () => {
+    // Present on the standalone HistoricalClient and the unified HistoricalView
+    // (both impl blocks), returning the presence-carrying object, never the bare
+    // row array.
+    const jsName = (generated.match(/js_name = "(\w+WithColumns)"/g) || []).length;
+    assert.ok(jsName >= 2, 'stockHistoryTradeWithColumns must exist on both historical impl blocks');
+    assert.match(generated, /pub async fn stock_history_trade_with_columns\(/);
+    assert.match(generated, /-> napi::Result<TradeTickWithColumns>/);
+    assert.match(generated, /pub struct TradeTickWithColumns \{/);
+    assert.match(generated, /pub present_columns: Vec<String>,/);
+    // The plain buffered method is untouched (no breaking change).
+    assert.match(generated, /pub async fn stock_history_trade\(\s*&self,[\s\S]*?-> napi::Result<Vec<TradeTick>>/);
+  });
+});

--- a/thetadatadx-ts/__tests__/typed_surface.test.mjs
+++ b/thetadatadx-ts/__tests__/typed_surface.test.mjs
@@ -79,14 +79,17 @@ describe('historical methods resolve off the execution thread', () => {
   // The `<endpoint>Stream(...)` server-stream companions share the same
   // name families (`stockHistoryEODStream` etc.) but are a distinct
   // surface: they pump chunks into a callback and resolve `Promise<void>`
-  // rather than returning the buffered row array. They are excluded here
-  // so this block pins the buffered-fetch contract; their shape is
-  // covered by the bare-Array assertion below.
+  // rather than returning the buffered row array. The
+  // `<endpoint>WithColumns(...)` presence-carrying variants likewise share the
+  // families but return `Promise<<Tick>WithColumns>` (rows plus the response's
+  // present columns), not the bare row array. Both are excluded here so this
+  // block pins the buffered-fetch contract; their shapes are covered by their
+  // own tests.
   const familyRe =
     /^\s+((?:stock|option|index)History\w*|\w*Snapshot\w*|\w*AtTime\w*|\w*List\w*|calendar\w*|interestRate\w*)\(/;
   const methodLines = body
     .split('\n')
-    .filter((line) => familyRe.test(line) && !/Stream\(/.test(line));
+    .filter((line) => familyRe.test(line) && !/Stream\(/.test(line) && !/WithColumns\(/.test(line));
 
   it('every buffered data-fetch method is present (61 of them)', () => {
     // Pin the count so a generator change that drops a method, or leaks

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -876,6 +876,8 @@ export declare class HistoricalClient {
    * - `venue`: `"nqb"`
    */
   stockSnapshotOHLC(symbols: string | Array<string>, options?: StockSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Run the `stockSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotOHLCWithColumns(symbols: string | Array<string>, options?: StockSnapshotOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Get the latest trade snapshot for one or more stocks.
    *
@@ -887,6 +889,8 @@ export declare class HistoricalClient {
    * - `venue`: `"nqb"`
    */
   stockSnapshotTrade(symbols: string | Array<string>, options?: StockSnapshotTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Run the `stockSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotTradeWithColumns(symbols: string | Array<string>, options?: StockSnapshotTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Get the latest NBBO quote snapshot for one or more stocks.
    *
@@ -898,6 +902,8 @@ export declare class HistoricalClient {
    * - `venue`: `"nqb"`
    */
   stockSnapshotQuote(symbols: string | Array<string>, options?: StockSnapshotQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Run the `stockSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotQuoteWithColumns(symbols: string | Array<string>, options?: StockSnapshotQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Get the latest market value snapshot for one or more stocks.
    *
@@ -909,6 +915,8 @@ export declare class HistoricalClient {
    * - `venue`: `"nqb"`
    */
   stockSnapshotMarketValue(symbols: string | Array<string>, options?: StockSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
+  /** Run the `stockSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotMarketValueWithColumns(symbols: string | Array<string>, options?: StockSnapshotMarketValueOptions | undefined | null): Promise<MarketValueTickWithColumns>
   /**
    * Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
    *
@@ -917,6 +925,8 @@ export declare class HistoricalClient {
   stockHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `stock_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
+  /** Run the `stockHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryEODWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<EodTickWithColumns>
   /**
    * Fetch intraday OHLC bars for a stock on a single date.
    *
@@ -933,6 +943,8 @@ export declare class HistoricalClient {
   stockHistoryOHLC(symbol: string, date: string | Date, options?: StockHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `stock_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryOHLC` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryOHLCStream(symbol: string, date: string | Date, options: StockHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `stockHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryOHLCWithColumns(symbol: string, date: string | Date, options?: StockHistoryOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Fetch all trades for a stock on a given date.
    *
@@ -947,6 +959,8 @@ export declare class HistoricalClient {
   stockHistoryTrade(symbol: string, date: string | Date, options?: StockHistoryTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `stock_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryTradeStream(symbol: string, date: string | Date, options: StockHistoryTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `stockHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryTradeWithColumns(symbol: string, date: string | Date, options?: StockHistoryTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch NBBO quotes for a stock on a given date at a given interval.
    *
@@ -964,6 +978,8 @@ export declare class HistoricalClient {
   stockHistoryQuote(symbol: string, date: string | Date, options?: StockHistoryQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `stock_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryQuoteStream(symbol: string, date: string | Date, options: StockHistoryQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `stockHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryQuoteWithColumns(symbol: string, date: string | Date, options?: StockHistoryQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
    *
@@ -979,6 +995,8 @@ export declare class HistoricalClient {
   stockHistoryTradeQuote(symbol: string, date: string | Date, options?: StockHistoryTradeQuoteOptions | undefined | null): Promise<Array<TradeQuoteTick>>
   /** Stream `stock_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryTradeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryTradeQuoteStream(symbol: string, date: string | Date, options: StockHistoryTradeQuoteOptions | undefined | null, callback: ((arg: Array<TradeQuoteTick>) => void)): Promise<void>
+  /** Run the `stockHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryTradeQuoteWithColumns(symbol: string, date: string | Date, options?: StockHistoryTradeQuoteOptions | undefined | null): Promise<TradeQuoteTickWithColumns>
   /**
    * Fetch the trade at a specific time of day across a date range.
    *
@@ -996,6 +1014,8 @@ export declare class HistoricalClient {
   stockAtTimeTrade(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `stock_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockAtTimeTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockAtTimeTradeStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: StockAtTimeTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `stockAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockAtTimeTradeWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch the quote at a specific time of day across a date range.
    *
@@ -1013,6 +1033,8 @@ export declare class HistoricalClient {
   stockAtTimeQuote(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `stock_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockAtTimeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockAtTimeQuoteStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: StockAtTimeQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `stockAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockAtTimeQuoteWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * List all available option underlying symbols.
    *
@@ -1056,6 +1078,8 @@ export declare class HistoricalClient {
   optionListContracts(requestType: string, date: string | Date, options?: OptionListContractsOptions | undefined | null): Promise<Array<OptionContract>>
   /** Stream `option_list_contracts` rows into `callback` without materialising the full response in memory. `callback(chunk: OptionContract[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionListContracts` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionListContractsStream(requestType: string, date: string | Date, options: OptionListContractsOptions | undefined | null, callback: ((arg: Array<OptionContract>) => void)): Promise<void>
+  /** Run the `optionListContracts` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionListContracts` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `optionContractToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionListContractsWithColumns(requestType: string, date: string | Date, options?: OptionListContractsOptions | undefined | null): Promise<OptionContractWithColumns>
   /**
    * Get the latest OHLC snapshot for an option contract.
    *
@@ -1066,6 +1090,8 @@ export declare class HistoricalClient {
    * - `right`: `"both"`
    */
   optionSnapshotOHLC(symbol: string, expiration: string | Date, options?: OptionSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Run the `optionSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotOHLCWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Get the latest trade snapshot for an option contract.
    *
@@ -1077,6 +1103,8 @@ export declare class HistoricalClient {
    * - `right`: `"both"`
    */
   optionSnapshotTrade(symbol: string, expiration: string | Date, options?: OptionSnapshotTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Run the `optionSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotTradeWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Get the latest NBBO quote snapshot for an option contract.
    *
@@ -1088,6 +1116,8 @@ export declare class HistoricalClient {
    * - `right`: `"both"`
    */
   optionSnapshotQuote(symbol: string, expiration: string | Date, options?: OptionSnapshotQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Run the `optionSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotQuoteWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Get the latest open interest snapshot for an option contract.
    *
@@ -1100,6 +1130,8 @@ export declare class HistoricalClient {
    * - `right`: `"both"`
    */
   optionSnapshotOpenInterest(symbol: string, expiration: string | Date, options?: OptionSnapshotOpenInterestOptions | undefined | null): Promise<Array<OpenInterestTick>>
+  /** Run the `optionSnapshotOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotOpenInterestWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotOpenInterestOptions | undefined | null): Promise<OpenInterestTickWithColumns>
   /**
    * Get the latest market value snapshot for an option contract.
    *
@@ -1110,6 +1142,8 @@ export declare class HistoricalClient {
    * - `right`: `"both"`
    */
   optionSnapshotMarketValue(symbol: string, expiration: string | Date, options?: OptionSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
+  /** Run the `optionSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotMarketValueWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotMarketValueOptions | undefined | null): Promise<MarketValueTickWithColumns>
   /**
    * Get implied volatility snapshot for an option contract (from ThetaData server).
    *
@@ -1126,6 +1160,8 @@ export declare class HistoricalClient {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksImpliedVolatility(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<IvTick>>
+  /** Run the `optionSnapshotGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksImpliedVolatilityWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksImpliedVolatilityOptions | undefined | null): Promise<IvTickWithColumns>
   /**
    * Get all Greeks snapshot for an option contract (from ThetaData server).
    *
@@ -1140,6 +1176,8 @@ export declare class HistoricalClient {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksAll(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksAllOptions | undefined | null): Promise<Array<GreeksAllTick>>
+  /** Run the `optionSnapshotGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksAllWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksAllOptions | undefined | null): Promise<GreeksAllTickWithColumns>
   /**
    * Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
    *
@@ -1154,6 +1192,8 @@ export declare class HistoricalClient {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksFirstOrder(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksFirstOrderOptions | undefined | null): Promise<Array<GreeksFirstOrderTick>>
+  /** Run the `optionSnapshotGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksFirstOrderWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksFirstOrderOptions | undefined | null): Promise<GreeksFirstOrderTickWithColumns>
   /**
    * Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
    *
@@ -1168,6 +1208,8 @@ export declare class HistoricalClient {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksSecondOrder(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksSecondOrderOptions | undefined | null): Promise<Array<GreeksSecondOrderTick>>
+  /** Run the `optionSnapshotGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksSecondOrderWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksSecondOrderOptions | undefined | null): Promise<GreeksSecondOrderTickWithColumns>
   /**
    * Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
    *
@@ -1182,6 +1224,8 @@ export declare class HistoricalClient {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksThirdOrder(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksThirdOrderOptions | undefined | null): Promise<Array<GreeksThirdOrderTick>>
+  /** Run the `optionSnapshotGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksThirdOrderWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksThirdOrderOptions | undefined | null): Promise<GreeksThirdOrderTickWithColumns>
   /**
    * Fetch end-of-day option data for a contract over a date range.
    *
@@ -1197,6 +1241,8 @@ export declare class HistoricalClient {
   optionHistoryEOD(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `option_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryEODStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options: OptionHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
+  /** Run the `optionHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryEODWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryEodOptions | undefined | null): Promise<EodTickWithColumns>
   /**
    * Fetch intraday OHLC bars for an option contract.
    *
@@ -1214,6 +1260,8 @@ export declare class HistoricalClient {
   optionHistoryOHLC(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `option_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryOHLC` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryOHLCStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `optionHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryOHLCWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Fetch all trades for an option contract on a given date.
    *
@@ -1231,6 +1279,8 @@ export declare class HistoricalClient {
   optionHistoryTrade(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `option_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch NBBO quotes for an option contract on a given date.
    *
@@ -1248,6 +1298,8 @@ export declare class HistoricalClient {
   optionHistoryQuote(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `option_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryQuoteStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `optionHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryQuoteWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Fetch combined trade + quote ticks for an option contract.
    *
@@ -1266,6 +1318,8 @@ export declare class HistoricalClient {
   optionHistoryTradeQuote(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeQuoteOptions | undefined | null): Promise<Array<TradeQuoteTick>>
   /** Stream `option_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeQuoteStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeQuoteOptions | undefined | null, callback: ((arg: Array<TradeQuoteTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeQuoteWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeQuoteOptions | undefined | null): Promise<TradeQuoteTickWithColumns>
   /**
    * Fetch open interest history for an option contract.
    *
@@ -1280,6 +1334,8 @@ export declare class HistoricalClient {
   optionHistoryOpenInterest(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOpenInterestOptions | undefined | null): Promise<Array<OpenInterestTick>>
   /** Stream `option_history_open_interest` rows into `callback` without materialising the full response in memory. `callback(chunk: OpenInterestTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryOpenInterest` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryOpenInterestStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryOpenInterestOptions | undefined | null, callback: ((arg: Array<OpenInterestTick>) => void)): Promise<void>
+  /** Run the `optionHistoryOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryOpenInterestWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOpenInterestOptions | undefined | null): Promise<OpenInterestTickWithColumns>
   /**
    * Fetch end-of-day Greeks history for an option contract.
    *
@@ -1297,6 +1353,8 @@ export declare class HistoricalClient {
   optionHistoryGreeksEOD(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryGreeksEodOptions | undefined | null): Promise<Array<GreeksEodTick>>
   /** Stream `option_history_greeks_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksEodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksEODStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options: OptionHistoryGreeksEodOptions | undefined | null, callback: ((arg: Array<GreeksEodTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksEodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksEODWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryGreeksEodOptions | undefined | null): Promise<GreeksEodTickWithColumns>
   /**
    * Fetch all Greeks history for an option contract (intraday, sampled by interval).
    *
@@ -1317,6 +1375,8 @@ export declare class HistoricalClient {
   optionHistoryGreeksAll(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksAllOptions | undefined | null): Promise<Array<GreeksAllTick>>
   /** Stream `option_history_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksAll` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksAllStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksAllOptions | undefined | null, callback: ((arg: Array<GreeksAllTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksAllWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksAllOptions | undefined | null): Promise<GreeksAllTickWithColumns>
   /**
    * Fetch all Greeks on each trade for an option contract.
    *
@@ -1336,6 +1396,8 @@ export declare class HistoricalClient {
   optionHistoryTradeGreeksAll(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksAllOptions | undefined | null): Promise<Array<TradeGreeksAllTick>>
   /** Stream `option_history_trade_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksAll` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksAllStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksAllOptions | undefined | null, callback: ((arg: Array<TradeGreeksAllTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksAllWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksAllOptions | undefined | null): Promise<TradeGreeksAllTickWithColumns>
   /**
    * Fetch first-order Greeks history (intraday, sampled by interval).
    *
@@ -1356,6 +1418,8 @@ export declare class HistoricalClient {
   optionHistoryGreeksFirstOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksFirstOrderOptions | undefined | null): Promise<Array<GreeksFirstOrderTick>>
   /** Stream `option_history_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksFirstOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksFirstOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksFirstOrderOptions | undefined | null, callback: ((arg: Array<GreeksFirstOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksFirstOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksFirstOrderOptions | undefined | null): Promise<GreeksFirstOrderTickWithColumns>
   /**
    * Fetch first-order Greeks on each trade for an option contract.
    *
@@ -1375,6 +1439,8 @@ export declare class HistoricalClient {
   optionHistoryTradeGreeksFirstOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null): Promise<Array<TradeGreeksFirstOrderTick>>
   /** Stream `option_history_trade_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksFirstOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksFirstOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksFirstOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksFirstOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null): Promise<TradeGreeksFirstOrderTickWithColumns>
   /**
    * Fetch second-order Greeks history (intraday, sampled by interval).
    *
@@ -1395,6 +1461,8 @@ export declare class HistoricalClient {
   optionHistoryGreeksSecondOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksSecondOrderOptions | undefined | null): Promise<Array<GreeksSecondOrderTick>>
   /** Stream `option_history_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksSecondOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksSecondOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksSecondOrderOptions | undefined | null, callback: ((arg: Array<GreeksSecondOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksSecondOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksSecondOrderOptions | undefined | null): Promise<GreeksSecondOrderTickWithColumns>
   /**
    * Fetch second-order Greeks on each trade for an option contract.
    *
@@ -1414,6 +1482,8 @@ export declare class HistoricalClient {
   optionHistoryTradeGreeksSecondOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null): Promise<Array<TradeGreeksSecondOrderTick>>
   /** Stream `option_history_trade_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksSecondOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksSecondOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksSecondOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksSecondOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null): Promise<TradeGreeksSecondOrderTickWithColumns>
   /**
    * Fetch third-order Greeks history (intraday, sampled by interval).
    *
@@ -1434,6 +1504,8 @@ export declare class HistoricalClient {
   optionHistoryGreeksThirdOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksThirdOrderOptions | undefined | null): Promise<Array<GreeksThirdOrderTick>>
   /** Stream `option_history_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksThirdOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksThirdOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksThirdOrderOptions | undefined | null, callback: ((arg: Array<GreeksThirdOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksThirdOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksThirdOrderOptions | undefined | null): Promise<GreeksThirdOrderTickWithColumns>
   /**
    * Fetch third-order Greeks on each trade for an option contract.
    *
@@ -1453,6 +1525,8 @@ export declare class HistoricalClient {
   optionHistoryTradeGreeksThirdOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null): Promise<Array<TradeGreeksThirdOrderTick>>
   /** Stream `option_history_trade_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksThirdOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksThirdOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksThirdOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksThirdOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null): Promise<TradeGreeksThirdOrderTickWithColumns>
   /**
    * Fetch implied volatility history (intraday, sampled by interval).
    *
@@ -1472,6 +1546,8 @@ export declare class HistoricalClient {
   optionHistoryGreeksImpliedVolatility(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<IvTick>>
   /** Stream `option_history_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: IvTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksImpliedVolatility` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksImpliedVolatilityStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null, callback: ((arg: Array<IvTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksImpliedVolatilityWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null): Promise<IvTickWithColumns>
   /**
    * Fetch implied volatility on each trade for an option contract.
    *
@@ -1490,6 +1566,8 @@ export declare class HistoricalClient {
   optionHistoryTradeGreeksImpliedVolatility(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<TradeGreeksImpliedVolatilityTick>>
   /** Stream `option_history_trade_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksImpliedVolatilityTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksImpliedVolatility` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksImpliedVolatilityStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null, callback: ((arg: Array<TradeGreeksImpliedVolatilityTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksImpliedVolatilityTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksImpliedVolatilityWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null): Promise<TradeGreeksImpliedVolatilityTickWithColumns>
   /**
    * Fetch the trade at a specific time of day across a date range for an option.
    *
@@ -1505,6 +1583,8 @@ export declare class HistoricalClient {
   optionAtTimeTrade(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `option_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionAtTimeTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionAtTimeTradeStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: OptionAtTimeTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `optionAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionAtTimeTradeWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch the quote at a specific time of day across a date range for an option.
    *
@@ -1518,6 +1598,8 @@ export declare class HistoricalClient {
   optionAtTimeQuote(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `option_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionAtTimeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionAtTimeQuoteStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: OptionAtTimeQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `optionAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionAtTimeQuoteWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * List all available index symbols.
    *
@@ -1537,6 +1619,8 @@ export declare class HistoricalClient {
    * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotOHLC(symbols: string | Array<string>, options?: IndexSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Run the `indexSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexSnapshotOHLCWithColumns(symbols: string | Array<string>, options?: IndexSnapshotOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Get the latest price snapshot for one or more indices.
    *
@@ -1544,6 +1628,8 @@ export declare class HistoricalClient {
    * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotPrice(symbols: string | Array<string>, options?: IndexSnapshotPriceOptions | undefined | null): Promise<Array<PriceTick>>
+  /** Run the `indexSnapshotPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexSnapshotPriceWithColumns(symbols: string | Array<string>, options?: IndexSnapshotPriceOptions | undefined | null): Promise<PriceTickWithColumns>
   /**
    * Get the latest market value snapshot for one or more indices.
    *
@@ -1551,6 +1637,8 @@ export declare class HistoricalClient {
    * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotMarketValue(symbols: string | Array<string>, options?: IndexSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
+  /** Run the `indexSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexSnapshotMarketValueWithColumns(symbols: string | Array<string>, options?: IndexSnapshotMarketValueOptions | undefined | null): Promise<MarketValueTickWithColumns>
   /**
    * Fetch end-of-day index data for a date range.
    *
@@ -1559,6 +1647,8 @@ export declare class HistoricalClient {
   indexHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `index_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: IndexHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
+  /** Run the `indexHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexHistoryEODWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<EodTickWithColumns>
   /**
    * Fetch intraday OHLC bars for an index.
    *
@@ -1574,6 +1664,8 @@ export declare class HistoricalClient {
   indexHistoryOHLC(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `index_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryOHLC` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexHistoryOHLCStream(symbol: string, startDate: string | Date, endDate: string | Date, options: IndexHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `indexHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexHistoryOHLCWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Fetch intraday price history for an index.
    *
@@ -1590,6 +1682,8 @@ export declare class HistoricalClient {
   indexHistoryPrice(symbol: string, date: string | Date, options?: IndexHistoryPriceOptions | undefined | null): Promise<Array<PriceTick>>
   /** Stream `index_history_price` rows into `callback` without materialising the full response in memory. `callback(chunk: PriceTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryPrice` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexHistoryPriceStream(symbol: string, date: string | Date, options: IndexHistoryPriceOptions | undefined | null, callback: ((arg: Array<PriceTick>) => void)): Promise<void>
+  /** Run the `indexHistoryPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexHistoryPriceWithColumns(symbol: string, date: string | Date, options?: IndexHistoryPriceOptions | undefined | null): Promise<PriceTickWithColumns>
   /**
    * Fetch the index price at a specific time of day across a date range.
    *
@@ -1599,6 +1693,8 @@ export declare class HistoricalClient {
   indexAtTimePrice(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<Array<IndexPriceAtTimeTick>>
   /** Stream `index_at_time_price` rows into `callback` without materialising the full response in memory. `callback(chunk: IndexPriceAtTimeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexAtTimePrice` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexAtTimePriceStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: IndexAtTimePriceOptions | undefined | null, callback: ((arg: Array<IndexPriceAtTimeTick>) => void)): Promise<void>
+  /** Run the `indexAtTimePrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexAtTimePrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `indexPriceAtTimeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexAtTimePriceWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<IndexPriceAtTimeTickWithColumns>
   /**
    * Check whether the market is open today.
    *
@@ -1607,6 +1703,8 @@ export declare class HistoricalClient {
    * - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
    */
   calendarOpenToday(options?: CalendarOpenTodayOptions | undefined | null): Promise<Array<CalendarDay>>
+  /** Run the `calendarOpenToday` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOpenToday` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  calendarOpenTodayWithColumns(options?: CalendarOpenTodayOptions | undefined | null): Promise<CalendarDayWithColumns>
   /**
    * Get calendar information for a specific date.
    *
@@ -1616,6 +1714,8 @@ export declare class HistoricalClient {
    * - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
    */
   calendarOnDate(date: string | Date, options?: CalendarOnDateOptions | undefined | null): Promise<Array<CalendarDay>>
+  /** Run the `calendarOnDate` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOnDate` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  calendarOnDateWithColumns(date: string | Date, options?: CalendarOnDateOptions | undefined | null): Promise<CalendarDayWithColumns>
   /**
    * Get equity market holidays and early-close days for a year (vendor `year_holidays` endpoint — only non-standard days, not every trading day).
    *
@@ -1625,6 +1725,8 @@ export declare class HistoricalClient {
    * - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
    */
   calendarYear(year: string, options?: CalendarYearOptions | undefined | null): Promise<Array<CalendarDay>>
+  /** Run the `calendarYear` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarYear` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  calendarYearWithColumns(year: string, options?: CalendarYearOptions | undefined | null): Promise<CalendarDayWithColumns>
   /**
    * Fetch end-of-day interest rate history.
    *
@@ -1637,6 +1739,8 @@ export declare class HistoricalClient {
   interestRateHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: InterestRateHistoryEodOptions | undefined | null): Promise<Array<InterestRateTick>>
   /** Stream `interest_rate_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: InterestRateTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `interestRateHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   interestRateHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: InterestRateHistoryEodOptions | undefined | null, callback: ((arg: Array<InterestRateTick>) => void)): Promise<void>
+  /** Run the `interestRateHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `interestRateHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `interestRateTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  interestRateHistoryEODWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: InterestRateHistoryEodOptions | undefined | null): Promise<InterestRateTickWithColumns>
   /**
    * Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
    *
@@ -1649,6 +1753,8 @@ export declare class HistoricalClient {
   stockHistoryOHLCRange(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryOhlcRangeOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `stock_history_ohlc_range` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryOHLCRange` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryOHLCRangeStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryOhlcRangeOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `stockHistoryOHLCRange` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLCRange` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryOHLCRangeWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryOhlcRangeOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * FLATFILES namespace handle. Cheap — shares the underlying client connection.
    * The historical-only client opens the same data channel as the unified
@@ -1698,6 +1804,8 @@ export declare class HistoricalView {
    * - `venue`: `"nqb"`
    */
   stockSnapshotOHLC(symbols: string | Array<string>, options?: StockSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Run the `stockSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotOHLCWithColumns(symbols: string | Array<string>, options?: StockSnapshotOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Get the latest trade snapshot for one or more stocks.
    *
@@ -1709,6 +1817,8 @@ export declare class HistoricalView {
    * - `venue`: `"nqb"`
    */
   stockSnapshotTrade(symbols: string | Array<string>, options?: StockSnapshotTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Run the `stockSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotTradeWithColumns(symbols: string | Array<string>, options?: StockSnapshotTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Get the latest NBBO quote snapshot for one or more stocks.
    *
@@ -1720,6 +1830,8 @@ export declare class HistoricalView {
    * - `venue`: `"nqb"`
    */
   stockSnapshotQuote(symbols: string | Array<string>, options?: StockSnapshotQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Run the `stockSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotQuoteWithColumns(symbols: string | Array<string>, options?: StockSnapshotQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Get the latest market value snapshot for one or more stocks.
    *
@@ -1731,6 +1843,8 @@ export declare class HistoricalView {
    * - `venue`: `"nqb"`
    */
   stockSnapshotMarketValue(symbols: string | Array<string>, options?: StockSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
+  /** Run the `stockSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockSnapshotMarketValueWithColumns(symbols: string | Array<string>, options?: StockSnapshotMarketValueOptions | undefined | null): Promise<MarketValueTickWithColumns>
   /**
    * Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
    *
@@ -1739,6 +1853,8 @@ export declare class HistoricalView {
   stockHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `stock_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
+  /** Run the `stockHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryEODWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<EodTickWithColumns>
   /**
    * Fetch intraday OHLC bars for a stock on a single date.
    *
@@ -1755,6 +1871,8 @@ export declare class HistoricalView {
   stockHistoryOHLC(symbol: string, date: string | Date, options?: StockHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `stock_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryOHLC` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryOHLCStream(symbol: string, date: string | Date, options: StockHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `stockHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryOHLCWithColumns(symbol: string, date: string | Date, options?: StockHistoryOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Fetch all trades for a stock on a given date.
    *
@@ -1769,6 +1887,8 @@ export declare class HistoricalView {
   stockHistoryTrade(symbol: string, date: string | Date, options?: StockHistoryTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `stock_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryTradeStream(symbol: string, date: string | Date, options: StockHistoryTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `stockHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryTradeWithColumns(symbol: string, date: string | Date, options?: StockHistoryTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch NBBO quotes for a stock on a given date at a given interval.
    *
@@ -1786,6 +1906,8 @@ export declare class HistoricalView {
   stockHistoryQuote(symbol: string, date: string | Date, options?: StockHistoryQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `stock_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryQuoteStream(symbol: string, date: string | Date, options: StockHistoryQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `stockHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryQuoteWithColumns(symbol: string, date: string | Date, options?: StockHistoryQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
    *
@@ -1801,6 +1923,8 @@ export declare class HistoricalView {
   stockHistoryTradeQuote(symbol: string, date: string | Date, options?: StockHistoryTradeQuoteOptions | undefined | null): Promise<Array<TradeQuoteTick>>
   /** Stream `stock_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryTradeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryTradeQuoteStream(symbol: string, date: string | Date, options: StockHistoryTradeQuoteOptions | undefined | null, callback: ((arg: Array<TradeQuoteTick>) => void)): Promise<void>
+  /** Run the `stockHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryTradeQuoteWithColumns(symbol: string, date: string | Date, options?: StockHistoryTradeQuoteOptions | undefined | null): Promise<TradeQuoteTickWithColumns>
   /**
    * Fetch the trade at a specific time of day across a date range.
    *
@@ -1818,6 +1942,8 @@ export declare class HistoricalView {
   stockAtTimeTrade(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `stock_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockAtTimeTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockAtTimeTradeStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: StockAtTimeTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `stockAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockAtTimeTradeWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch the quote at a specific time of day across a date range.
    *
@@ -1835,6 +1961,8 @@ export declare class HistoricalView {
   stockAtTimeQuote(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `stock_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockAtTimeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockAtTimeQuoteStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: StockAtTimeQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `stockAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockAtTimeQuoteWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * List all available option underlying symbols.
    *
@@ -1878,6 +2006,8 @@ export declare class HistoricalView {
   optionListContracts(requestType: string, date: string | Date, options?: OptionListContractsOptions | undefined | null): Promise<Array<OptionContract>>
   /** Stream `option_list_contracts` rows into `callback` without materialising the full response in memory. `callback(chunk: OptionContract[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionListContracts` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionListContractsStream(requestType: string, date: string | Date, options: OptionListContractsOptions | undefined | null, callback: ((arg: Array<OptionContract>) => void)): Promise<void>
+  /** Run the `optionListContracts` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionListContracts` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `optionContractToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionListContractsWithColumns(requestType: string, date: string | Date, options?: OptionListContractsOptions | undefined | null): Promise<OptionContractWithColumns>
   /**
    * Get the latest OHLC snapshot for an option contract.
    *
@@ -1888,6 +2018,8 @@ export declare class HistoricalView {
    * - `right`: `"both"`
    */
   optionSnapshotOHLC(symbol: string, expiration: string | Date, options?: OptionSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Run the `optionSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotOHLCWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Get the latest trade snapshot for an option contract.
    *
@@ -1899,6 +2031,8 @@ export declare class HistoricalView {
    * - `right`: `"both"`
    */
   optionSnapshotTrade(symbol: string, expiration: string | Date, options?: OptionSnapshotTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Run the `optionSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotTradeWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Get the latest NBBO quote snapshot for an option contract.
    *
@@ -1910,6 +2044,8 @@ export declare class HistoricalView {
    * - `right`: `"both"`
    */
   optionSnapshotQuote(symbol: string, expiration: string | Date, options?: OptionSnapshotQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Run the `optionSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotQuoteWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Get the latest open interest snapshot for an option contract.
    *
@@ -1922,6 +2058,8 @@ export declare class HistoricalView {
    * - `right`: `"both"`
    */
   optionSnapshotOpenInterest(symbol: string, expiration: string | Date, options?: OptionSnapshotOpenInterestOptions | undefined | null): Promise<Array<OpenInterestTick>>
+  /** Run the `optionSnapshotOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotOpenInterestWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotOpenInterestOptions | undefined | null): Promise<OpenInterestTickWithColumns>
   /**
    * Get the latest market value snapshot for an option contract.
    *
@@ -1932,6 +2070,8 @@ export declare class HistoricalView {
    * - `right`: `"both"`
    */
   optionSnapshotMarketValue(symbol: string, expiration: string | Date, options?: OptionSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
+  /** Run the `optionSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotMarketValueWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotMarketValueOptions | undefined | null): Promise<MarketValueTickWithColumns>
   /**
    * Get implied volatility snapshot for an option contract (from ThetaData server).
    *
@@ -1948,6 +2088,8 @@ export declare class HistoricalView {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksImpliedVolatility(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<IvTick>>
+  /** Run the `optionSnapshotGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksImpliedVolatilityWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksImpliedVolatilityOptions | undefined | null): Promise<IvTickWithColumns>
   /**
    * Get all Greeks snapshot for an option contract (from ThetaData server).
    *
@@ -1962,6 +2104,8 @@ export declare class HistoricalView {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksAll(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksAllOptions | undefined | null): Promise<Array<GreeksAllTick>>
+  /** Run the `optionSnapshotGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksAllWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksAllOptions | undefined | null): Promise<GreeksAllTickWithColumns>
   /**
    * Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
    *
@@ -1976,6 +2120,8 @@ export declare class HistoricalView {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksFirstOrder(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksFirstOrderOptions | undefined | null): Promise<Array<GreeksFirstOrderTick>>
+  /** Run the `optionSnapshotGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksFirstOrderWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksFirstOrderOptions | undefined | null): Promise<GreeksFirstOrderTickWithColumns>
   /**
    * Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
    *
@@ -1990,6 +2136,8 @@ export declare class HistoricalView {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksSecondOrder(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksSecondOrderOptions | undefined | null): Promise<Array<GreeksSecondOrderTick>>
+  /** Run the `optionSnapshotGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksSecondOrderWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksSecondOrderOptions | undefined | null): Promise<GreeksSecondOrderTickWithColumns>
   /**
    * Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
    *
@@ -2004,6 +2152,8 @@ export declare class HistoricalView {
    * - `use_market_value`: `false`
    */
   optionSnapshotGreeksThirdOrder(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksThirdOrderOptions | undefined | null): Promise<Array<GreeksThirdOrderTick>>
+  /** Run the `optionSnapshotGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionSnapshotGreeksThirdOrderWithColumns(symbol: string, expiration: string | Date, options?: OptionSnapshotGreeksThirdOrderOptions | undefined | null): Promise<GreeksThirdOrderTickWithColumns>
   /**
    * Fetch end-of-day option data for a contract over a date range.
    *
@@ -2019,6 +2169,8 @@ export declare class HistoricalView {
   optionHistoryEOD(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `option_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryEODStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options: OptionHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
+  /** Run the `optionHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryEODWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryEodOptions | undefined | null): Promise<EodTickWithColumns>
   /**
    * Fetch intraday OHLC bars for an option contract.
    *
@@ -2036,6 +2188,8 @@ export declare class HistoricalView {
   optionHistoryOHLC(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `option_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryOHLC` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryOHLCStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `optionHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryOHLCWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Fetch all trades for an option contract on a given date.
    *
@@ -2053,6 +2207,8 @@ export declare class HistoricalView {
   optionHistoryTrade(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `option_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch NBBO quotes for an option contract on a given date.
    *
@@ -2070,6 +2226,8 @@ export declare class HistoricalView {
   optionHistoryQuote(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `option_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryQuoteStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `optionHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryQuoteWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * Fetch combined trade + quote ticks for an option contract.
    *
@@ -2088,6 +2246,8 @@ export declare class HistoricalView {
   optionHistoryTradeQuote(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeQuoteOptions | undefined | null): Promise<Array<TradeQuoteTick>>
   /** Stream `option_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeQuoteStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeQuoteOptions | undefined | null, callback: ((arg: Array<TradeQuoteTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeQuoteWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeQuoteOptions | undefined | null): Promise<TradeQuoteTickWithColumns>
   /**
    * Fetch open interest history for an option contract.
    *
@@ -2102,6 +2262,8 @@ export declare class HistoricalView {
   optionHistoryOpenInterest(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOpenInterestOptions | undefined | null): Promise<Array<OpenInterestTick>>
   /** Stream `option_history_open_interest` rows into `callback` without materialising the full response in memory. `callback(chunk: OpenInterestTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryOpenInterest` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryOpenInterestStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryOpenInterestOptions | undefined | null, callback: ((arg: Array<OpenInterestTick>) => void)): Promise<void>
+  /** Run the `optionHistoryOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryOpenInterestWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOpenInterestOptions | undefined | null): Promise<OpenInterestTickWithColumns>
   /**
    * Fetch end-of-day Greeks history for an option contract.
    *
@@ -2119,6 +2281,8 @@ export declare class HistoricalView {
   optionHistoryGreeksEOD(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryGreeksEodOptions | undefined | null): Promise<Array<GreeksEodTick>>
   /** Stream `option_history_greeks_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksEodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksEODStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options: OptionHistoryGreeksEodOptions | undefined | null, callback: ((arg: Array<GreeksEodTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksEodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksEODWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryGreeksEodOptions | undefined | null): Promise<GreeksEodTickWithColumns>
   /**
    * Fetch all Greeks history for an option contract (intraday, sampled by interval).
    *
@@ -2139,6 +2303,8 @@ export declare class HistoricalView {
   optionHistoryGreeksAll(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksAllOptions | undefined | null): Promise<Array<GreeksAllTick>>
   /** Stream `option_history_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksAll` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksAllStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksAllOptions | undefined | null, callback: ((arg: Array<GreeksAllTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksAllWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksAllOptions | undefined | null): Promise<GreeksAllTickWithColumns>
   /**
    * Fetch all Greeks on each trade for an option contract.
    *
@@ -2158,6 +2324,8 @@ export declare class HistoricalView {
   optionHistoryTradeGreeksAll(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksAllOptions | undefined | null): Promise<Array<TradeGreeksAllTick>>
   /** Stream `option_history_trade_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksAll` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksAllStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksAllOptions | undefined | null, callback: ((arg: Array<TradeGreeksAllTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksAllWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksAllOptions | undefined | null): Promise<TradeGreeksAllTickWithColumns>
   /**
    * Fetch first-order Greeks history (intraday, sampled by interval).
    *
@@ -2178,6 +2346,8 @@ export declare class HistoricalView {
   optionHistoryGreeksFirstOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksFirstOrderOptions | undefined | null): Promise<Array<GreeksFirstOrderTick>>
   /** Stream `option_history_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksFirstOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksFirstOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksFirstOrderOptions | undefined | null, callback: ((arg: Array<GreeksFirstOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksFirstOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksFirstOrderOptions | undefined | null): Promise<GreeksFirstOrderTickWithColumns>
   /**
    * Fetch first-order Greeks on each trade for an option contract.
    *
@@ -2197,6 +2367,8 @@ export declare class HistoricalView {
   optionHistoryTradeGreeksFirstOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null): Promise<Array<TradeGreeksFirstOrderTick>>
   /** Stream `option_history_trade_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksFirstOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksFirstOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksFirstOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksFirstOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null): Promise<TradeGreeksFirstOrderTickWithColumns>
   /**
    * Fetch second-order Greeks history (intraday, sampled by interval).
    *
@@ -2217,6 +2389,8 @@ export declare class HistoricalView {
   optionHistoryGreeksSecondOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksSecondOrderOptions | undefined | null): Promise<Array<GreeksSecondOrderTick>>
   /** Stream `option_history_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksSecondOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksSecondOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksSecondOrderOptions | undefined | null, callback: ((arg: Array<GreeksSecondOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksSecondOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksSecondOrderOptions | undefined | null): Promise<GreeksSecondOrderTickWithColumns>
   /**
    * Fetch second-order Greeks on each trade for an option contract.
    *
@@ -2236,6 +2410,8 @@ export declare class HistoricalView {
   optionHistoryTradeGreeksSecondOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null): Promise<Array<TradeGreeksSecondOrderTick>>
   /** Stream `option_history_trade_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksSecondOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksSecondOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksSecondOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksSecondOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null): Promise<TradeGreeksSecondOrderTickWithColumns>
   /**
    * Fetch third-order Greeks history (intraday, sampled by interval).
    *
@@ -2256,6 +2432,8 @@ export declare class HistoricalView {
   optionHistoryGreeksThirdOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksThirdOrderOptions | undefined | null): Promise<Array<GreeksThirdOrderTick>>
   /** Stream `option_history_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksThirdOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksThirdOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksThirdOrderOptions | undefined | null, callback: ((arg: Array<GreeksThirdOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksThirdOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksThirdOrderOptions | undefined | null): Promise<GreeksThirdOrderTickWithColumns>
   /**
    * Fetch third-order Greeks on each trade for an option contract.
    *
@@ -2275,6 +2453,8 @@ export declare class HistoricalView {
   optionHistoryTradeGreeksThirdOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null): Promise<Array<TradeGreeksThirdOrderTick>>
   /** Stream `option_history_trade_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksThirdOrder` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksThirdOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksThirdOrderTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksThirdOrderWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null): Promise<TradeGreeksThirdOrderTickWithColumns>
   /**
    * Fetch implied volatility history (intraday, sampled by interval).
    *
@@ -2294,6 +2474,8 @@ export declare class HistoricalView {
   optionHistoryGreeksImpliedVolatility(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<IvTick>>
   /** Stream `option_history_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: IvTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryGreeksImpliedVolatility` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryGreeksImpliedVolatilityStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null, callback: ((arg: Array<IvTick>) => void)): Promise<void>
+  /** Run the `optionHistoryGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryGreeksImpliedVolatilityWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null): Promise<IvTickWithColumns>
   /**
    * Fetch implied volatility on each trade for an option contract.
    *
@@ -2312,6 +2494,8 @@ export declare class HistoricalView {
   optionHistoryTradeGreeksImpliedVolatility(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<TradeGreeksImpliedVolatilityTick>>
   /** Stream `option_history_trade_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksImpliedVolatilityTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionHistoryTradeGreeksImpliedVolatility` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionHistoryTradeGreeksImpliedVolatilityStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null, callback: ((arg: Array<TradeGreeksImpliedVolatilityTick>) => void)): Promise<void>
+  /** Run the `optionHistoryTradeGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksImpliedVolatilityTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionHistoryTradeGreeksImpliedVolatilityWithColumns(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null): Promise<TradeGreeksImpliedVolatilityTickWithColumns>
   /**
    * Fetch the trade at a specific time of day across a date range for an option.
    *
@@ -2327,6 +2511,8 @@ export declare class HistoricalView {
   optionAtTimeTrade(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeTradeOptions | undefined | null): Promise<Array<TradeTick>>
   /** Stream `option_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionAtTimeTrade` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionAtTimeTradeStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: OptionAtTimeTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
+  /** Run the `optionAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionAtTimeTradeWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeTradeOptions | undefined | null): Promise<TradeTickWithColumns>
   /**
    * Fetch the quote at a specific time of day across a date range for an option.
    *
@@ -2340,6 +2526,8 @@ export declare class HistoricalView {
   optionAtTimeQuote(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
   /** Stream `option_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `optionAtTimeQuote` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   optionAtTimeQuoteStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: OptionAtTimeQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
+  /** Run the `optionAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  optionAtTimeQuoteWithColumns(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeQuoteOptions | undefined | null): Promise<QuoteTickWithColumns>
   /**
    * List all available index symbols.
    *
@@ -2359,6 +2547,8 @@ export declare class HistoricalView {
    * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotOHLC(symbols: string | Array<string>, options?: IndexSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Run the `indexSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexSnapshotOHLCWithColumns(symbols: string | Array<string>, options?: IndexSnapshotOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Get the latest price snapshot for one or more indices.
    *
@@ -2366,6 +2556,8 @@ export declare class HistoricalView {
    * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotPrice(symbols: string | Array<string>, options?: IndexSnapshotPriceOptions | undefined | null): Promise<Array<PriceTick>>
+  /** Run the `indexSnapshotPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexSnapshotPriceWithColumns(symbols: string | Array<string>, options?: IndexSnapshotPriceOptions | undefined | null): Promise<PriceTickWithColumns>
   /**
    * Get the latest market value snapshot for one or more indices.
    *
@@ -2373,6 +2565,8 @@ export declare class HistoricalView {
    * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotMarketValue(symbols: string | Array<string>, options?: IndexSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
+  /** Run the `indexSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexSnapshotMarketValueWithColumns(symbols: string | Array<string>, options?: IndexSnapshotMarketValueOptions | undefined | null): Promise<MarketValueTickWithColumns>
   /**
    * Fetch end-of-day index data for a date range.
    *
@@ -2381,6 +2575,8 @@ export declare class HistoricalView {
   indexHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `index_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: IndexHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
+  /** Run the `indexHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexHistoryEODWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<EodTickWithColumns>
   /**
    * Fetch intraday OHLC bars for an index.
    *
@@ -2396,6 +2592,8 @@ export declare class HistoricalView {
   indexHistoryOHLC(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `index_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryOHLC` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexHistoryOHLCStream(symbol: string, startDate: string | Date, endDate: string | Date, options: IndexHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `indexHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexHistoryOHLCWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryOhlcOptions | undefined | null): Promise<OhlcTickWithColumns>
   /**
    * Fetch intraday price history for an index.
    *
@@ -2412,6 +2610,8 @@ export declare class HistoricalView {
   indexHistoryPrice(symbol: string, date: string | Date, options?: IndexHistoryPriceOptions | undefined | null): Promise<Array<PriceTick>>
   /** Stream `index_history_price` rows into `callback` without materialising the full response in memory. `callback(chunk: PriceTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryPrice` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexHistoryPriceStream(symbol: string, date: string | Date, options: IndexHistoryPriceOptions | undefined | null, callback: ((arg: Array<PriceTick>) => void)): Promise<void>
+  /** Run the `indexHistoryPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexHistoryPriceWithColumns(symbol: string, date: string | Date, options?: IndexHistoryPriceOptions | undefined | null): Promise<PriceTickWithColumns>
   /**
    * Fetch the index price at a specific time of day across a date range.
    *
@@ -2421,6 +2621,8 @@ export declare class HistoricalView {
   indexAtTimePrice(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<Array<IndexPriceAtTimeTick>>
   /** Stream `index_at_time_price` rows into `callback` without materialising the full response in memory. `callback(chunk: IndexPriceAtTimeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexAtTimePrice` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   indexAtTimePriceStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: IndexAtTimePriceOptions | undefined | null, callback: ((arg: Array<IndexPriceAtTimeTick>) => void)): Promise<void>
+  /** Run the `indexAtTimePrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexAtTimePrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `indexPriceAtTimeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  indexAtTimePriceWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<IndexPriceAtTimeTickWithColumns>
   /**
    * Check whether the market is open today.
    *
@@ -2429,6 +2631,8 @@ export declare class HistoricalView {
    * - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
    */
   calendarOpenToday(options?: CalendarOpenTodayOptions | undefined | null): Promise<Array<CalendarDay>>
+  /** Run the `calendarOpenToday` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOpenToday` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  calendarOpenTodayWithColumns(options?: CalendarOpenTodayOptions | undefined | null): Promise<CalendarDayWithColumns>
   /**
    * Get calendar information for a specific date.
    *
@@ -2438,6 +2642,8 @@ export declare class HistoricalView {
    * - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
    */
   calendarOnDate(date: string | Date, options?: CalendarOnDateOptions | undefined | null): Promise<Array<CalendarDay>>
+  /** Run the `calendarOnDate` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOnDate` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  calendarOnDateWithColumns(date: string | Date, options?: CalendarOnDateOptions | undefined | null): Promise<CalendarDayWithColumns>
   /**
    * Get equity market holidays and early-close days for a year (vendor `year_holidays` endpoint — only non-standard days, not every trading day).
    *
@@ -2447,6 +2653,8 @@ export declare class HistoricalView {
    * - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
    */
   calendarYear(year: string, options?: CalendarYearOptions | undefined | null): Promise<Array<CalendarDay>>
+  /** Run the `calendarYear` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarYear` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  calendarYearWithColumns(year: string, options?: CalendarYearOptions | undefined | null): Promise<CalendarDayWithColumns>
   /**
    * Fetch end-of-day interest rate history.
    *
@@ -2459,6 +2667,8 @@ export declare class HistoricalView {
   interestRateHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: InterestRateHistoryEodOptions | undefined | null): Promise<Array<InterestRateTick>>
   /** Stream `interest_rate_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: InterestRateTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `interestRateHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   interestRateHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: InterestRateHistoryEodOptions | undefined | null, callback: ((arg: Array<InterestRateTick>) => void)): Promise<void>
+  /** Run the `interestRateHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `interestRateHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `interestRateTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  interestRateHistoryEODWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: InterestRateHistoryEodOptions | undefined | null): Promise<InterestRateTickWithColumns>
   /**
    * Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
    *
@@ -2471,6 +2681,8 @@ export declare class HistoricalView {
   stockHistoryOHLCRange(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryOhlcRangeOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `stock_history_ohlc_range` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryOHLCRange` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryOHLCRangeStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryOhlcRangeOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /** Run the `stockHistoryOHLCRange` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLCRange` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted. */
+  stockHistoryOHLCRangeWithColumns(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryOhlcRangeOptions | undefined | null): Promise<OhlcTickWithColumns>
 }
 
 /**
@@ -3167,6 +3379,31 @@ export declare function calendarDayToArrowIpc(rows: Array<CalendarDay>): Buffer
 export declare function calendarDayToArrowIpcProjected(rows: Array<CalendarDay>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
 /**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `calendarDayToArrowIpcProjected`.
+ */
+export interface CalendarDayWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<CalendarDay>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
+/**
  * Optional parameters for the `calendarOnDate` method. Keys are
  * the camelCase parameter names; absent keys behave exactly like an
  * omitted parameter. `timeoutMs` bounds the whole call: on expiry the
@@ -3365,6 +3602,31 @@ export declare function eodTickToArrowIpc(rows: Array<EodTick>): Buffer
  */
 export declare function eodTickToArrowIpcProjected(rows: Array<EodTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `eodTickToArrowIpcProjected`.
+ */
+export interface EodTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<EodTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Full union Greeks tick -- every Greek the v3 server publishes on the */
 export interface GreeksAllTick {
   msOfDay: number
@@ -3441,6 +3703,31 @@ export declare function greeksAllTickToArrowIpc(rows: Array<GreeksAllTick>): Buf
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function greeksAllTickToArrowIpcProjected(rows: Array<GreeksAllTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `greeksAllTickToArrowIpcProjected`.
+ */
+export interface GreeksAllTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<GreeksAllTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /** End-of-day union Greeks tick -- every Greek the v3 server publishes on */
 export interface GreeksEodTick {
@@ -3531,6 +3818,31 @@ export declare function greeksEodTickToArrowIpc(rows: Array<GreeksEodTick>): Buf
  */
 export declare function greeksEodTickToArrowIpcProjected(rows: Array<GreeksEodTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `greeksEodTickToArrowIpcProjected`.
+ */
+export interface GreeksEodTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<GreeksEodTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** First-order Greeks tick -- the strict column subset emitted by the */
 export interface GreeksFirstOrderTick {
   msOfDay: number
@@ -3594,6 +3906,31 @@ export declare function greeksFirstOrderTickToArrowIpc(rows: Array<GreeksFirstOr
  */
 export declare function greeksFirstOrderTickToArrowIpcProjected(rows: Array<GreeksFirstOrderTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `greeksFirstOrderTickToArrowIpcProjected`.
+ */
+export interface GreeksFirstOrderTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<GreeksFirstOrderTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Second-order Greeks tick -- the strict column subset emitted by the */
 export interface GreeksSecondOrderTick {
   msOfDay: number
@@ -3656,6 +3993,31 @@ export declare function greeksSecondOrderTickToArrowIpc(rows: Array<GreeksSecond
  */
 export declare function greeksSecondOrderTickToArrowIpcProjected(rows: Array<GreeksSecondOrderTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `greeksSecondOrderTickToArrowIpcProjected`.
+ */
+export interface GreeksSecondOrderTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<GreeksSecondOrderTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Third-order Greeks tick -- the strict column subset emitted by the */
 export interface GreeksThirdOrderTick {
   msOfDay: number
@@ -3716,6 +4078,31 @@ export declare function greeksThirdOrderTickToArrowIpc(rows: Array<GreeksThirdOr
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function greeksThirdOrderTickToArrowIpcProjected(rows: Array<GreeksThirdOrderTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `greeksThirdOrderTickToArrowIpcProjected`.
+ */
+export interface GreeksThirdOrderTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<GreeksThirdOrderTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /**
  * Optional parameters for the `indexAtTimePrice` method. Keys are
@@ -3881,6 +4268,31 @@ export declare function indexPriceAtTimeTickToArrowIpc(rows: Array<IndexPriceAtT
 export declare function indexPriceAtTimeTickToArrowIpcProjected(rows: Array<IndexPriceAtTimeTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
 /**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `indexPriceAtTimeTickToArrowIpcProjected`.
+ */
+export interface IndexPriceAtTimeTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<IndexPriceAtTimeTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
+/**
  * Optional parameters for the `indexSnapshotMarketValue` method. Keys are
  * the camelCase parameter names; absent keys behave exactly like an
  * omitted parameter. `timeoutMs` bounds the whole call: on expiry the
@@ -3986,6 +4398,31 @@ export declare function interestRateTickToArrowIpc(rows: Array<InterestRateTick>
  */
 export declare function interestRateTickToArrowIpcProjected(rows: Array<InterestRateTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `interestRateTickToArrowIpcProjected`.
+ */
+export interface InterestRateTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<InterestRateTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Wire string enum `Interval`. */
 export declare const enum Interval {
   Tick = 'tick',
@@ -4065,6 +4502,31 @@ export declare function ivTickToArrowIpc(rows: Array<IvTick>): Buffer
  */
 export declare function ivTickToArrowIpcProjected(rows: Array<IvTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `ivTickToArrowIpcProjected`.
+ */
+export interface IvTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<IvTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Streaming login succeeded. `permissions` is the server's opaque bundle string — diagnostic metadata only; for feature gating use the Nexus REST subscription tiers. */
 export interface LoginSuccess {
   permissions: string
@@ -4139,6 +4601,31 @@ export declare function marketValueTickToArrowIpc(rows: Array<MarketValueTick>):
  */
 export declare function marketValueTickToArrowIpcProjected(rows: Array<MarketValueTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `marketValueTickToArrowIpcProjected`.
+ */
+export interface MarketValueTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<MarketValueTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** OHLC tick. Aggregated bar data including SIP-rule VWAP. */
 export interface OhlcTick {
   msOfDay: number
@@ -4190,6 +4677,31 @@ export declare function ohlcTickToArrowIpc(rows: Array<OhlcTick>): Buffer
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function ohlcTickToArrowIpcProjected(rows: Array<OhlcTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `ohlcTickToArrowIpcProjected`.
+ */
+export interface OhlcTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<OhlcTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /** Streaming OHLCVC bar. */
 export interface Ohlcvc {
@@ -4261,6 +4773,31 @@ export declare function openInterestTickToArrowIpc(rows: Array<OpenInterestTick>
 export declare function openInterestTickToArrowIpcProjected(rows: Array<OpenInterestTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
 /**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `openInterestTickToArrowIpcProjected`.
+ */
+export interface OpenInterestTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<OpenInterestTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
+/**
  * Optional parameters for the `optionAtTimeQuote` method. Keys are
  * the camelCase parameter names; absent keys behave exactly like an
  * omitted parameter. `timeoutMs` bounds the whole call: on expiry the
@@ -4314,6 +4851,31 @@ export interface OptionContract {
   expiration: number
   strike: number
   right: string
+}
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `optionContractToArrowIpcProjected`.
+ */
+export interface OptionContractWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<OptionContract>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
 }
 
 /**
@@ -5413,6 +5975,31 @@ export declare function priceTickToArrowIpc(rows: Array<PriceTick>): Buffer
  */
 export declare function priceTickToArrowIpcProjected(rows: Array<PriceTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `priceTickToArrowIpcProjected`.
+ */
+export interface PriceTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<PriceTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Streaming Quote tick. */
 export interface Quote {
   contract: Contract
@@ -5482,6 +6069,31 @@ export declare function quoteTickToArrowIpc(rows: Array<QuoteTick>): Buffer
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function quoteTickToArrowIpcProjected(rows: Array<QuoteTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `quoteTickToArrowIpcProjected`.
+ */
+export interface QuoteTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<QuoteTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /** Wire string enum `RateType`. */
 export declare const enum RateType {
@@ -6009,6 +6621,31 @@ export declare function tradeGreeksAllTickToArrowIpc(rows: Array<TradeGreeksAllT
  */
 export declare function tradeGreeksAllTickToArrowIpcProjected(rows: Array<TradeGreeksAllTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeGreeksAllTickToArrowIpcProjected`.
+ */
+export interface TradeGreeksAllTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeGreeksAllTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon */
 export interface TradeGreeksFirstOrderTick {
   msOfDay: number
@@ -6079,6 +6716,31 @@ export declare function tradeGreeksFirstOrderTickToArrowIpc(rows: Array<TradeGre
  */
 export declare function tradeGreeksFirstOrderTickToArrowIpcProjected(rows: Array<TradeGreeksFirstOrderTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeGreeksFirstOrderTickToArrowIpcProjected`.
+ */
+export interface TradeGreeksFirstOrderTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeGreeksFirstOrderTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Per-trade implied-volatility tick (single `implied_volatility` + */
 export interface TradeGreeksImpliedVolatilityTick {
   msOfDay: number
@@ -6142,6 +6804,31 @@ export declare function tradeGreeksImpliedVolatilityTickToArrowIpc(rows: Array<T
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function tradeGreeksImpliedVolatilityTickToArrowIpcProjected(rows: Array<TradeGreeksImpliedVolatilityTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeGreeksImpliedVolatilityTickToArrowIpcProjected`.
+ */
+export interface TradeGreeksImpliedVolatilityTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeGreeksImpliedVolatilityTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /** Per-trade second-order Greeks tick (gamma / vanna / charm / vomma / */
 export interface TradeGreeksSecondOrderTick {
@@ -6212,6 +6899,31 @@ export declare function tradeGreeksSecondOrderTickToArrowIpc(rows: Array<TradeGr
  */
 export declare function tradeGreeksSecondOrderTickToArrowIpcProjected(rows: Array<TradeGreeksSecondOrderTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeGreeksSecondOrderTickToArrowIpcProjected`.
+ */
+export interface TradeGreeksSecondOrderTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeGreeksSecondOrderTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Per-trade third-order Greeks tick (speed / zomma / color / ultima) */
 export interface TradeGreeksThirdOrderTick {
   msOfDay: number
@@ -6279,6 +6991,31 @@ export declare function tradeGreeksThirdOrderTickToArrowIpc(rows: Array<TradeGre
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function tradeGreeksThirdOrderTickToArrowIpcProjected(rows: Array<TradeGreeksThirdOrderTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeGreeksThirdOrderTickToArrowIpcProjected`.
+ */
+export interface TradeGreeksThirdOrderTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeGreeksThirdOrderTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /** Combined trade + quote tick. */
 export interface TradeQuoteTick {
@@ -6353,6 +7090,31 @@ export declare function tradeQuoteTickToArrowIpc(rows: Array<TradeQuoteTick>): B
  */
 export declare function tradeQuoteTickToArrowIpcProjected(rows: Array<TradeQuoteTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
 
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeQuoteTickToArrowIpcProjected`.
+ */
+export interface TradeQuoteTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeQuoteTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
+
 /** Trade tick. Core unit of trade data. */
 export interface TradeTick {
   msOfDay: number
@@ -6422,6 +7184,31 @@ export declare function tradeTickToArrowIpc(rows: Array<TradeTick>): Buffer
  * ABI `thetadatadx_<tick>_to_arrow_ipc_projected`.
  */
 export declare function tradeTickToArrowIpcProjected(rows: Array<TradeTick>, presentColumns: Array<string>, symbol?: string | undefined | null): Buffer
+
+/**
+ * A decoded history result paired with the columns the response's wire
+ * actually carried. Returned by the `<method>WithColumns` variant so a
+ * live caller can serialize a projected Arrow-IPC frame (only the wire's
+ * columns, matching the terminal's columnar output) without hand-supplying
+ * the header list: pass `presentColumns` and `symbol` to `tradeTickToArrowIpcProjected`.
+ */
+export interface TradeTickWithColumns {
+  /**
+   * The decoded rows, identical to the `Array<Tick>` the buffered
+   * method returns.
+   */
+  rows: Array<TradeTick>
+  /**
+   * The schema-column names the response's wire carried, in schema
+   * order — the projection set for a terminal-exact Arrow frame.
+   */
+  presentColumns: Array<string>
+  /**
+   * The response's constant `symbol` (root) when the wire carried one
+   * (option and index responses), else `undefined` (stock responses).
+   */
+  symbol?: string
+}
 
 /** Streaming control variant the SDK does not yet recognise. Surfaced when a newer protocol revision adds a control event this build predates — keep dispatch logic forward-compatible by handling this variant. Carries no payload. */
 export interface UnknownControl {

--- a/thetadatadx-ts/src/_generated/historical_methods.rs
+++ b/thetadatadx-ts/src/_generated/historical_methods.rs
@@ -1474,6 +1474,420 @@ pub struct StockHistoryOHLCRangeOptions {
     pub timeout_ms: Option<f64>,
 }
 
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `ohlcTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct OhlcTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<OhlcTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `quoteTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct QuoteTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<QuoteTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `marketValueTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct MarketValueTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<MarketValueTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `eodTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct EodTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<EodTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeQuoteTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeQuoteTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeQuoteTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `optionContractToArrowIpcProjected`.
+#[napi(object)]
+pub struct OptionContractWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<OptionContract>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `openInterestTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct OpenInterestTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<OpenInterestTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `ivTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct IvTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<IvTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `greeksAllTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct GreeksAllTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<GreeksAllTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `greeksFirstOrderTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct GreeksFirstOrderTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<GreeksFirstOrderTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `greeksSecondOrderTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct GreeksSecondOrderTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<GreeksSecondOrderTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `greeksThirdOrderTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct GreeksThirdOrderTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<GreeksThirdOrderTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `greeksEodTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct GreeksEodTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<GreeksEodTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeGreeksAllTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeGreeksAllTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeGreeksAllTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeGreeksFirstOrderTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeGreeksFirstOrderTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeGreeksFirstOrderTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeGreeksSecondOrderTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeGreeksSecondOrderTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeGreeksSecondOrderTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeGreeksThirdOrderTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeGreeksThirdOrderTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeGreeksThirdOrderTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `tradeGreeksImpliedVolatilityTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct TradeGreeksImpliedVolatilityTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<TradeGreeksImpliedVolatilityTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `priceTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct PriceTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<PriceTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `indexPriceAtTimeTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct IndexPriceAtTimeTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<IndexPriceAtTimeTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `calendarDayToArrowIpcProjected`.
+#[napi(object)]
+pub struct CalendarDayWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<CalendarDay>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
+/// A decoded history result paired with the columns the response's wire
+/// actually carried. Returned by the `<method>WithColumns` variant so a
+/// live caller can serialize a projected Arrow-IPC frame (only the wire's
+/// columns, matching the terminal's columnar output) without hand-supplying
+/// the header list: pass `presentColumns` and `symbol` to `interestRateTickToArrowIpcProjected`.
+#[napi(object)]
+pub struct InterestRateTickWithColumns {
+    /// The decoded rows, identical to the `Array<Tick>` the buffered
+    /// method returns.
+    pub rows: Vec<InterestRateTick>,
+    /// The schema-column names the response's wire carried, in schema
+    /// order — the projection set for a terminal-exact Arrow frame.
+    pub present_columns: Vec<String>,
+    /// The response's constant `symbol` (root) when the wire carried one
+    /// (option and index responses), else `undefined` (stock responses).
+    pub symbol: Option<String>,
+}
+
 #[napi]
 impl HistoricalView {
     /// List all available stock ticker symbols.
@@ -1576,6 +1990,44 @@ impl HistoricalView {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `stockSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotOHLCWithColumns")]
+    pub async fn stock_snapshot_ohlc_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_ohlc(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest trade snapshot for one or more stocks.
     ///
     /// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -1615,6 +2067,44 @@ impl HistoricalView {
         })
         .await?;
         Ok(trade_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `stockSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotTradeWithColumns")]
+    pub async fn stock_snapshot_trade_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_trade(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
@@ -1658,6 +2148,44 @@ impl HistoricalView {
         Ok(quote_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `stockSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotQuoteWithColumns")]
+    pub async fn stock_snapshot_quote_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_quote(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest market value snapshot for one or more stocks.
     ///
     /// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -1697,6 +2225,44 @@ impl HistoricalView {
         })
         .await?;
         Ok(market_value_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `stockSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotMarketValueWithColumns")]
+    pub async fn stock_snapshot_market_value_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotMarketValueOptions>,
+    ) -> napi::Result<MarketValueTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_market_value(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(MarketValueTickWithColumns {
+            rows: market_value_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
@@ -1761,6 +2327,38 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryEODWithColumns")]
+    pub async fn stock_history_eod_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryEODOptions>,
+    ) -> napi::Result<EodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(EodTickWithColumns {
+            rows: eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars for a stock on a single date.
@@ -1879,6 +2477,60 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `stockHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryOHLCWithColumns")]
+    pub async fn stock_history_ohlc_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_ohlc(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch all trades for a stock on a given date.
     ///
     /// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -1983,6 +2635,56 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryTradeWithColumns")]
+    pub async fn stock_history_trade_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_trade(&symbol, date.as_str());
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
@@ -2102,6 +2804,60 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `stockHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryQuoteWithColumns")]
+    pub async fn stock_history_quote_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_quote(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
     /// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -2217,6 +2973,60 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `stockHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryTradeQuoteWithColumns")]
+    pub async fn stock_history_trade_quote_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryTradeQuoteOptions>,
+    ) -> napi::Result<TradeQuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let exclusive = options.exclusive;
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_trade_quote(&symbol, date.as_str());
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = exclusive {
+                request = request.exclusive(value);
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeQuoteTickWithColumns {
+            rows: trade_quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
@@ -2302,6 +3112,44 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `stockAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockAtTimeTradeWithColumns")]
+    pub async fn stock_at_time_trade_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockAtTimeTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let venue = options.venue;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_at_time_trade(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the quote at a specific time of day across a date range.
     ///
     /// #### Real-time request:
@@ -2385,6 +3233,44 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockAtTimeQuoteWithColumns")]
+    pub async fn stock_at_time_quote_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockAtTimeQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let venue = options.venue;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_at_time_quote(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// List all available option underlying symbols.
@@ -2594,6 +3480,44 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionListContracts` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionListContracts` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `optionContractToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionListContractsWithColumns")]
+    pub async fn option_list_contracts_with_columns(
+        &self,
+        request_type: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionListContractsOptions>,
+    ) -> napi::Result<OptionContractWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let symbol = options.symbol;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_list_contracts(&request_type, date.as_str());
+            if let Some(value) = symbol {
+                request = request.symbol(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OptionContractWithColumns {
+            rows: option_contracts_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest OHLC snapshot for an option contract.
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
@@ -2646,6 +3570,56 @@ impl HistoricalView {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotOHLCWithColumns")]
+    pub async fn option_snapshot_ohlc_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_ohlc(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest trade snapshot for an option contract.
     ///
     /// - Retrieve the real-time last trade of an option contract.
@@ -2693,6 +3667,52 @@ impl HistoricalView {
         })
         .await?;
         Ok(trade_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotTradeWithColumns")]
+    pub async fn option_snapshot_trade_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_trade(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get the latest NBBO quote snapshot for an option contract.
@@ -2746,6 +3766,56 @@ impl HistoricalView {
         })
         .await?;
         Ok(quote_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotQuoteWithColumns")]
+    pub async fn option_snapshot_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_quote(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get the latest open interest snapshot for an option contract.
@@ -2802,6 +3872,56 @@ impl HistoricalView {
         Ok(open_interest_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotOpenInterestWithColumns")]
+    pub async fn option_snapshot_open_interest_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotOpenInterestOptions>,
+    ) -> napi::Result<OpenInterestTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_open_interest(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OpenInterestTickWithColumns {
+            rows: open_interest_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest market value snapshot for an option contract.
     ///
     /// * Returns a real-time market value derived from the last NBBO quote of an option contract.
@@ -2852,6 +3972,56 @@ impl HistoricalView {
         })
         .await?;
         Ok(market_value_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotMarketValueWithColumns")]
+    pub async fn option_snapshot_market_value_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotMarketValueOptions>,
+    ) -> napi::Result<MarketValueTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_market_value(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(MarketValueTickWithColumns {
+            rows: market_value_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get implied volatility snapshot for an option contract (from ThetaData server).
@@ -2936,6 +4106,80 @@ impl HistoricalView {
         Ok(iv_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksImpliedVolatilityWithColumns")]
+    pub async fn option_snapshot_greeks_implied_volatility_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksImpliedVolatilityOptions>,
+    ) -> napi::Result<IvTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_implied_volatility(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(IvTickWithColumns {
+            rows: iv_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
@@ -3014,6 +4258,80 @@ impl HistoricalView {
         })
         .await?;
         Ok(greeks_all_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksAllWithColumns")]
+    pub async fn option_snapshot_greeks_all_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksAllOptions>,
+    ) -> napi::Result<GreeksAllTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_all(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksAllTickWithColumns {
+            rows: greeks_all_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
@@ -3096,6 +4414,80 @@ impl HistoricalView {
         Ok(greeks_first_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksFirstOrderWithColumns")]
+    pub async fn option_snapshot_greeks_first_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksFirstOrderOptions>,
+    ) -> napi::Result<GreeksFirstOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_first_order(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksFirstOrderTickWithColumns {
+            rows: greeks_first_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
@@ -3176,6 +4568,80 @@ impl HistoricalView {
         Ok(greeks_second_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksSecondOrderWithColumns")]
+    pub async fn option_snapshot_greeks_second_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksSecondOrderOptions>,
+    ) -> napi::Result<GreeksSecondOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_second_order(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksSecondOrderTickWithColumns {
+            rows: greeks_second_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
@@ -3254,6 +4720,80 @@ impl HistoricalView {
         })
         .await?;
         Ok(greeks_third_order_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksThirdOrderWithColumns")]
+    pub async fn option_snapshot_greeks_third_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksThirdOrderOptions>,
+    ) -> napi::Result<GreeksThirdOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_third_order(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksThirdOrderTickWithColumns {
+            rows: greeks_third_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day option data for a contract over a date range.
@@ -3361,6 +4901,56 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryEODWithColumns")]
+    pub async fn option_history_eod_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryEODOptions>,
+    ) -> napi::Result<EodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_eod(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(EodTickWithColumns {
+            rows: eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars for an option contract.
@@ -3500,6 +5090,70 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryOHLCWithColumns")]
+    pub async fn option_history_ohlc_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_ohlc(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch all trades for an option contract on a given date.
     ///
     /// - Returns every trade reported by OPRA. 
@@ -3635,6 +5289,70 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeWithColumns")]
+    pub async fn option_history_trade_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch NBBO quotes for an option contract on a given date.
@@ -3780,6 +5498,74 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryQuoteWithColumns")]
+    pub async fn option_history_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_quote(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch combined trade + quote ticks for an option contract.
@@ -3928,6 +5714,74 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeQuoteWithColumns")]
+    pub async fn option_history_trade_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeQuoteOptions>,
+    ) -> napi::Result<TradeQuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let exclusive = options.exclusive;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_quote(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = exclusive {
+                request = request.exclusive(value);
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeQuoteTickWithColumns {
+            rows: trade_quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch open interest history for an option contract.
     ///
     /// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
@@ -4044,6 +5898,62 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryOpenInterestWithColumns")]
+    pub async fn option_history_open_interest_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryOpenInterestOptions>,
+    ) -> napi::Result<OpenInterestTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_open_interest(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OpenInterestTickWithColumns {
+            rows: open_interest_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day Greeks history for an option contract.
@@ -4193,6 +6103,76 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryGreeksEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksEodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksEODWithColumns")]
+    pub async fn option_history_greeks_eod_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksEODOptions>,
+    ) -> napi::Result<GreeksEodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let underlyer_use_nbbo = options.underlyer_use_nbbo;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_eod(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = underlyer_use_nbbo {
+                request = request.underlyer_use_nbbo(value);
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksEodTickWithColumns {
+            rows: greeks_eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
@@ -4367,6 +6347,86 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksAllWithColumns")]
+    pub async fn option_history_greeks_all_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksAllOptions>,
+    ) -> napi::Result<GreeksAllTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_all(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksAllTickWithColumns {
+            rows: greeks_all_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
@@ -4536,6 +6596,86 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksAllWithColumns")]
+    pub async fn option_history_trade_greeks_all_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksAllOptions>,
+    ) -> napi::Result<TradeGreeksAllTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_all(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksAllTickWithColumns {
+            rows: trade_greeks_all_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch first-order Greeks history (intraday, sampled by interval).
@@ -4710,6 +6850,86 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksFirstOrderWithColumns")]
+    pub async fn option_history_greeks_first_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksFirstOrderOptions>,
+    ) -> napi::Result<GreeksFirstOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_first_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksFirstOrderTickWithColumns {
+            rows: greeks_first_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -4879,6 +7099,86 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksFirstOrderWithColumns")]
+    pub async fn option_history_trade_greeks_first_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksFirstOrderOptions>,
+    ) -> napi::Result<TradeGreeksFirstOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_first_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksFirstOrderTickWithColumns {
+            rows: trade_greeks_first_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch second-order Greeks history (intraday, sampled by interval).
@@ -5053,6 +7353,86 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksSecondOrderWithColumns")]
+    pub async fn option_history_greeks_second_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksSecondOrderOptions>,
+    ) -> napi::Result<GreeksSecondOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_second_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksSecondOrderTickWithColumns {
+            rows: greeks_second_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -5222,6 +7602,86 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksSecondOrderWithColumns")]
+    pub async fn option_history_trade_greeks_second_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksSecondOrderOptions>,
+    ) -> napi::Result<TradeGreeksSecondOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_second_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksSecondOrderTickWithColumns {
+            rows: trade_greeks_second_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch third-order Greeks history (intraday, sampled by interval).
@@ -5396,6 +7856,86 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksThirdOrderWithColumns")]
+    pub async fn option_history_greeks_third_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksThirdOrderOptions>,
+    ) -> napi::Result<GreeksThirdOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_third_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksThirdOrderTickWithColumns {
+            rows: greeks_third_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -5565,6 +8105,86 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksThirdOrderWithColumns")]
+    pub async fn option_history_trade_greeks_third_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksThirdOrderOptions>,
+    ) -> napi::Result<TradeGreeksThirdOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_third_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksThirdOrderTickWithColumns {
+            rows: trade_greeks_third_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch implied volatility history (intraday, sampled by interval).
@@ -5738,6 +8358,86 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksImpliedVolatilityWithColumns")]
+    pub async fn option_history_greeks_implied_volatility_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksImpliedVolatilityOptions>,
+    ) -> napi::Result<IvTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_implied_volatility(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(IvTickWithColumns {
+            rows: iv_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by OPRA. 
@@ -5908,6 +8608,86 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionHistoryTradeGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksImpliedVolatilityTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksImpliedVolatilityWithColumns")]
+    pub async fn option_history_trade_greeks_implied_volatility_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksImpliedVolatilityOptions>,
+    ) -> napi::Result<TradeGreeksImpliedVolatilityTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_implied_volatility(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksImpliedVolatilityTickWithColumns {
+            rows: trade_greeks_implied_volatility_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
     /// - Returns the last trade reported by OPRA at a specified millisecond of the day.
@@ -6019,6 +8799,58 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionAtTimeTradeWithColumns")]
+    pub async fn option_at_time_trade_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionAtTimeTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_at_time_trade(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
     /// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
@@ -6128,6 +8960,58 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `optionAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionAtTimeQuoteWithColumns")]
+    pub async fn option_at_time_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionAtTimeQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_at_time_quote(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// List all available index symbols.
     ///
     /// A symbol can be defined as a unique identifier for a stock / underlying asset. Common terms also include: root, ticker, and underlying. This endpoint returns all traded symbols for options. This endpoint is updated overnight.
@@ -6218,6 +9102,40 @@ impl HistoricalView {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `indexSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexSnapshotOHLCWithColumns")]
+    pub async fn index_snapshot_ohlc_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<IndexSnapshotOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().index_snapshot_ohlc(&refs);
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest price snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index price.
@@ -6251,6 +9169,40 @@ impl HistoricalView {
         Ok(price_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `indexSnapshotPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexSnapshotPriceWithColumns")]
+    pub async fn index_snapshot_price_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<IndexSnapshotPriceOptions>,
+    ) -> napi::Result<PriceTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().index_snapshot_price(&refs);
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(PriceTickWithColumns {
+            rows: price_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest market value snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index market value.
@@ -6282,6 +9234,40 @@ impl HistoricalView {
         })
         .await?;
         Ok(market_value_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `indexSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexSnapshotMarketValueWithColumns")]
+    pub async fn index_snapshot_market_value_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<IndexSnapshotMarketValueOptions>,
+    ) -> napi::Result<MarketValueTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().index_snapshot_market_value(&refs);
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(MarketValueTickWithColumns {
+            rows: market_value_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day index data for a date range.
@@ -6346,6 +9332,38 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `indexHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexHistoryEODWithColumns")]
+    pub async fn index_history_eod_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryEODOptions>,
+    ) -> napi::Result<EodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(EodTickWithColumns {
+            rows: eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars for an index.
@@ -6441,6 +9459,50 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `indexHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexHistoryOHLCWithColumns")]
+    pub async fn index_history_ohlc_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_history_ohlc(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday price history for an index.
@@ -6551,6 +9613,56 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `indexHistoryPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexHistoryPriceWithColumns")]
+    pub async fn index_history_price_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryPriceOptions>,
+    ) -> napi::Result<PriceTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_history_price(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(PriceTickWithColumns {
+            rows: price_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the index price at a specific time of day across a date range.
     ///
     /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
@@ -6620,6 +9732,40 @@ impl HistoricalView {
         .await
     }
 
+    /// Run the `indexAtTimePrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexAtTimePrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `indexPriceAtTimeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexAtTimePriceWithColumns")]
+    pub async fn index_at_time_price_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexAtTimePriceOptions>,
+    ) -> napi::Result<IndexPriceAtTimeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_at_time_price(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(IndexPriceAtTimeTickWithColumns {
+            rows: index_price_at_time_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Check whether the market is open today.
     ///
     /// - Retrieves current day equity market schedule
@@ -6645,6 +9791,33 @@ impl HistoricalView {
         })
         .await?;
         Ok(calendar_days_to_class_vec(&ticks))
+    }
+
+    /// Run the `calendarOpenToday` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOpenToday` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "calendarOpenTodayWithColumns")]
+    pub async fn calendar_open_today_with_columns(
+        &self,
+        options: Option<CalendarOpenTodayOptions>,
+    ) -> napi::Result<CalendarDayWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().calendar_open_today();
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(CalendarDayWithColumns {
+            rows: calendar_days_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get calendar information for a specific date.
@@ -6677,6 +9850,35 @@ impl HistoricalView {
         Ok(calendar_days_to_class_vec(&ticks))
     }
 
+    /// Run the `calendarOnDate` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOnDate` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "calendarOnDateWithColumns")]
+    pub async fn calendar_on_date_with_columns(
+        &self,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<CalendarOnDateOptions>,
+    ) -> napi::Result<CalendarDayWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().calendar_on_date(date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(CalendarDayWithColumns {
+            rows: calendar_days_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get equity market holidays and early-close days for a year (vendor `year_holidays` endpoint — only non-standard days, not every trading day).
     ///
     /// - Retrieves equity market holidays for a given year
@@ -6704,6 +9906,34 @@ impl HistoricalView {
         })
         .await?;
         Ok(calendar_days_to_class_vec(&ticks))
+    }
+
+    /// Run the `calendarYear` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarYear` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "calendarYearWithColumns")]
+    pub async fn calendar_year_with_columns(
+        &self,
+        year: String,
+        options: Option<CalendarYearOptions>,
+    ) -> napi::Result<CalendarDayWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().calendar_year(&year);
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(CalendarDayWithColumns {
+            rows: calendar_days_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day interest rate history.
@@ -6772,6 +10002,38 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `interestRateHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `interestRateHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `interestRateTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "interestRateHistoryEODWithColumns")]
+    pub async fn interest_rate_history_eod_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<InterestRateHistoryEODOptions>,
+    ) -> napi::Result<InterestRateTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().interest_rate_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(InterestRateTickWithColumns {
+            rows: interest_rate_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
@@ -6872,6 +10134,54 @@ impl HistoricalView {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockHistoryOHLCRange` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLCRange` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryOHLCRangeWithColumns")]
+    pub async fn stock_history_ohlc_range_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryOHLCRangeOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_ohlc_range(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
 }
@@ -6977,6 +10287,44 @@ impl HistoricalClient {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `stockSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotOHLCWithColumns")]
+    pub async fn stock_snapshot_ohlc_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_ohlc(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest trade snapshot for one or more stocks.
     ///
     /// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -7016,6 +10364,44 @@ impl HistoricalClient {
         })
         .await?;
         Ok(trade_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `stockSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotTradeWithColumns")]
+    pub async fn stock_snapshot_trade_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_trade(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
@@ -7059,6 +10445,44 @@ impl HistoricalClient {
         Ok(quote_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `stockSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotQuoteWithColumns")]
+    pub async fn stock_snapshot_quote_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_quote(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest market value snapshot for one or more stocks.
     ///
     /// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -7098,6 +10522,44 @@ impl HistoricalClient {
         })
         .await?;
         Ok(market_value_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `stockSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockSnapshotMarketValueWithColumns")]
+    pub async fn stock_snapshot_market_value_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<StockSnapshotMarketValueOptions>,
+    ) -> napi::Result<MarketValueTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let venue = options.venue;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().stock_snapshot_market_value(&refs);
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(MarketValueTickWithColumns {
+            rows: market_value_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
@@ -7162,6 +10624,38 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryEODWithColumns")]
+    pub async fn stock_history_eod_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryEODOptions>,
+    ) -> napi::Result<EodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(EodTickWithColumns {
+            rows: eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars for a stock on a single date.
@@ -7280,6 +10774,60 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `stockHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryOHLCWithColumns")]
+    pub async fn stock_history_ohlc_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_ohlc(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch all trades for a stock on a given date.
     ///
     /// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -7384,6 +10932,56 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryTradeWithColumns")]
+    pub async fn stock_history_trade_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_trade(&symbol, date.as_str());
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
@@ -7503,6 +11101,60 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `stockHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryQuoteWithColumns")]
+    pub async fn stock_history_quote_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_quote(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
     /// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
@@ -7618,6 +11270,60 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `stockHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryTradeQuoteWithColumns")]
+    pub async fn stock_history_trade_quote_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryTradeQuoteOptions>,
+    ) -> napi::Result<TradeQuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let exclusive = options.exclusive;
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_trade_quote(&symbol, date.as_str());
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = exclusive {
+                request = request.exclusive(value);
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeQuoteTickWithColumns {
+            rows: trade_quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
@@ -7703,6 +11409,44 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `stockAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockAtTimeTradeWithColumns")]
+    pub async fn stock_at_time_trade_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockAtTimeTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let venue = options.venue;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_at_time_trade(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the quote at a specific time of day across a date range.
     ///
     /// #### Real-time request:
@@ -7786,6 +11530,44 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockAtTimeQuoteWithColumns")]
+    pub async fn stock_at_time_quote_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockAtTimeQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let venue = options.venue;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_at_time_quote(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// List all available option underlying symbols.
@@ -7995,6 +11777,44 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionListContracts` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionListContracts` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `optionContractToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionListContractsWithColumns")]
+    pub async fn option_list_contracts_with_columns(
+        &self,
+        request_type: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionListContractsOptions>,
+    ) -> napi::Result<OptionContractWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let symbol = options.symbol;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_list_contracts(&request_type, date.as_str());
+            if let Some(value) = symbol {
+                request = request.symbol(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OptionContractWithColumns {
+            rows: option_contracts_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest OHLC snapshot for an option contract.
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
@@ -8047,6 +11867,56 @@ impl HistoricalClient {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotOHLCWithColumns")]
+    pub async fn option_snapshot_ohlc_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_ohlc(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest trade snapshot for an option contract.
     ///
     /// - Retrieve the real-time last trade of an option contract.
@@ -8094,6 +11964,52 @@ impl HistoricalClient {
         })
         .await?;
         Ok(trade_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotTradeWithColumns")]
+    pub async fn option_snapshot_trade_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_trade(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get the latest NBBO quote snapshot for an option contract.
@@ -8147,6 +12063,56 @@ impl HistoricalClient {
         })
         .await?;
         Ok(quote_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotQuoteWithColumns")]
+    pub async fn option_snapshot_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_quote(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get the latest open interest snapshot for an option contract.
@@ -8203,6 +12169,56 @@ impl HistoricalClient {
         Ok(open_interest_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotOpenInterestWithColumns")]
+    pub async fn option_snapshot_open_interest_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotOpenInterestOptions>,
+    ) -> napi::Result<OpenInterestTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_open_interest(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OpenInterestTickWithColumns {
+            rows: open_interest_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest market value snapshot for an option contract.
     ///
     /// * Returns a real-time market value derived from the last NBBO quote of an option contract.
@@ -8253,6 +12269,56 @@ impl HistoricalClient {
         })
         .await?;
         Ok(market_value_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotMarketValueWithColumns")]
+    pub async fn option_snapshot_market_value_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotMarketValueOptions>,
+    ) -> napi::Result<MarketValueTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_market_value(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(MarketValueTickWithColumns {
+            rows: market_value_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get implied volatility snapshot for an option contract (from ThetaData server).
@@ -8337,6 +12403,80 @@ impl HistoricalClient {
         Ok(iv_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksImpliedVolatilityWithColumns")]
+    pub async fn option_snapshot_greeks_implied_volatility_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksImpliedVolatilityOptions>,
+    ) -> napi::Result<IvTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_implied_volatility(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(IvTickWithColumns {
+            rows: iv_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
@@ -8415,6 +12555,80 @@ impl HistoricalClient {
         })
         .await?;
         Ok(greeks_all_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksAllWithColumns")]
+    pub async fn option_snapshot_greeks_all_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksAllOptions>,
+    ) -> napi::Result<GreeksAllTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_all(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksAllTickWithColumns {
+            rows: greeks_all_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
@@ -8497,6 +12711,80 @@ impl HistoricalClient {
         Ok(greeks_first_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksFirstOrderWithColumns")]
+    pub async fn option_snapshot_greeks_first_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksFirstOrderOptions>,
+    ) -> napi::Result<GreeksFirstOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_first_order(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksFirstOrderTickWithColumns {
+            rows: greeks_first_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
@@ -8577,6 +12865,80 @@ impl HistoricalClient {
         Ok(greeks_second_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `optionSnapshotGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksSecondOrderWithColumns")]
+    pub async fn option_snapshot_greeks_second_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksSecondOrderOptions>,
+    ) -> napi::Result<GreeksSecondOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_second_order(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksSecondOrderTickWithColumns {
+            rows: greeks_second_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
@@ -8655,6 +13017,80 @@ impl HistoricalClient {
         })
         .await?;
         Ok(greeks_third_order_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `optionSnapshotGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionSnapshotGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionSnapshotGreeksThirdOrderWithColumns")]
+    pub async fn option_snapshot_greeks_third_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionSnapshotGreeksThirdOrderOptions>,
+    ) -> napi::Result<GreeksThirdOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let stock_price = options.stock_price;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let min_time = normalize_optional_time(options.min_time);
+        let use_market_value = options.use_market_value;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_snapshot_greeks_third_order(&symbol, expiration.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = stock_price {
+                request = request.stock_price(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(value) = use_market_value {
+                request = request.use_market_value(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksThirdOrderTickWithColumns {
+            rows: greeks_third_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day option data for a contract over a date range.
@@ -8762,6 +13198,56 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryEODWithColumns")]
+    pub async fn option_history_eod_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryEODOptions>,
+    ) -> napi::Result<EodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_eod(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(EodTickWithColumns {
+            rows: eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars for an option contract.
@@ -8901,6 +13387,70 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryOHLCWithColumns")]
+    pub async fn option_history_ohlc_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_ohlc(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch all trades for an option contract on a given date.
     ///
     /// - Returns every trade reported by OPRA. 
@@ -9036,6 +13586,70 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeWithColumns")]
+    pub async fn option_history_trade_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch NBBO quotes for an option contract on a given date.
@@ -9181,6 +13795,74 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryQuoteWithColumns")]
+    pub async fn option_history_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_quote(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch combined trade + quote ticks for an option contract.
@@ -9329,6 +14011,74 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryTradeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeQuoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeQuoteWithColumns")]
+    pub async fn option_history_trade_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeQuoteOptions>,
+    ) -> napi::Result<TradeQuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let exclusive = options.exclusive;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_quote(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = exclusive {
+                request = request.exclusive(value);
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeQuoteTickWithColumns {
+            rows: trade_quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch open interest history for an option contract.
     ///
     /// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
@@ -9445,6 +14195,62 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryOpenInterest` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryOpenInterest` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `openInterestTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryOpenInterestWithColumns")]
+    pub async fn option_history_open_interest_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryOpenInterestOptions>,
+    ) -> napi::Result<OpenInterestTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_open_interest(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OpenInterestTickWithColumns {
+            rows: open_interest_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day Greeks history for an option contract.
@@ -9594,6 +14400,76 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryGreeksEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksEodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksEODWithColumns")]
+    pub async fn option_history_greeks_eod_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksEODOptions>,
+    ) -> napi::Result<GreeksEodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let underlyer_use_nbbo = options.underlyer_use_nbbo;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_eod(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = underlyer_use_nbbo {
+                request = request.underlyer_use_nbbo(value);
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksEodTickWithColumns {
+            rows: greeks_eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
@@ -9768,6 +14644,86 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksAllWithColumns")]
+    pub async fn option_history_greeks_all_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksAllOptions>,
+    ) -> napi::Result<GreeksAllTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_all(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksAllTickWithColumns {
+            rows: greeks_all_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
@@ -9937,6 +14893,86 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksAll` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksAll` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksAllTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksAllWithColumns")]
+    pub async fn option_history_trade_greeks_all_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksAllOptions>,
+    ) -> napi::Result<TradeGreeksAllTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_all(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksAllTickWithColumns {
+            rows: trade_greeks_all_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch first-order Greeks history (intraday, sampled by interval).
@@ -10111,6 +15147,86 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksFirstOrderWithColumns")]
+    pub async fn option_history_greeks_first_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksFirstOrderOptions>,
+    ) -> napi::Result<GreeksFirstOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_first_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksFirstOrderTickWithColumns {
+            rows: greeks_first_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -10280,6 +15396,86 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksFirstOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksFirstOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksFirstOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksFirstOrderWithColumns")]
+    pub async fn option_history_trade_greeks_first_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksFirstOrderOptions>,
+    ) -> napi::Result<TradeGreeksFirstOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_first_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksFirstOrderTickWithColumns {
+            rows: trade_greeks_first_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch second-order Greeks history (intraday, sampled by interval).
@@ -10454,6 +15650,86 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksSecondOrderWithColumns")]
+    pub async fn option_history_greeks_second_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksSecondOrderOptions>,
+    ) -> napi::Result<GreeksSecondOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_second_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksSecondOrderTickWithColumns {
+            rows: greeks_second_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -10623,6 +15899,86 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksSecondOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksSecondOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksSecondOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksSecondOrderWithColumns")]
+    pub async fn option_history_trade_greeks_second_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksSecondOrderOptions>,
+    ) -> napi::Result<TradeGreeksSecondOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_second_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksSecondOrderTickWithColumns {
+            rows: trade_greeks_second_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch third-order Greeks history (intraday, sampled by interval).
@@ -10797,6 +16153,86 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `greeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksThirdOrderWithColumns")]
+    pub async fn option_history_greeks_third_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksThirdOrderOptions>,
+    ) -> napi::Result<GreeksThirdOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_third_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(GreeksThirdOrderTickWithColumns {
+            rows: greeks_third_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -10966,6 +16402,86 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `optionHistoryTradeGreeksThirdOrder` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksThirdOrder` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksThirdOrderTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksThirdOrderWithColumns")]
+    pub async fn option_history_trade_greeks_third_order_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksThirdOrderOptions>,
+    ) -> napi::Result<TradeGreeksThirdOrderTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_third_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksThirdOrderTickWithColumns {
+            rows: trade_greeks_third_order_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch implied volatility history (intraday, sampled by interval).
@@ -11139,6 +16655,86 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ivTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryGreeksImpliedVolatilityWithColumns")]
+    pub async fn option_history_greeks_implied_volatility_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksImpliedVolatilityOptions>,
+    ) -> napi::Result<IvTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_greeks_implied_volatility(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(IvTickWithColumns {
+            rows: iv_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by OPRA. 
@@ -11309,6 +16905,86 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionHistoryTradeGreeksImpliedVolatility` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionHistoryTradeGreeksImpliedVolatility` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeGreeksImpliedVolatilityTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionHistoryTradeGreeksImpliedVolatilityWithColumns")]
+    pub async fn option_history_trade_greeks_implied_volatility_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksImpliedVolatilityOptions>,
+    ) -> napi::Result<TradeGreeksImpliedVolatilityTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_history_trade_greeks_implied_volatility(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeGreeksImpliedVolatilityTickWithColumns {
+            rows: trade_greeks_implied_volatility_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
     /// - Returns the last trade reported by OPRA at a specified millisecond of the day.
@@ -11420,6 +17096,58 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionAtTimeTrade` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeTrade` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `tradeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionAtTimeTradeWithColumns")]
+    pub async fn option_at_time_trade_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionAtTimeTradeOptions>,
+    ) -> napi::Result<TradeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_at_time_trade(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(TradeTickWithColumns {
+            rows: trade_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
     /// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
@@ -11529,6 +17257,58 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `optionAtTimeQuote` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `optionAtTimeQuote` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `quoteTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "optionAtTimeQuoteWithColumns")]
+    pub async fn option_at_time_quote_with_columns(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionAtTimeQuoteOptions>,
+    ) -> napi::Result<QuoteTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = validate_optional_nonneg_i32("maxDte", options.max_dte)?;
+        let strike_range = validate_optional_nonneg_i32("strikeRange", options.strike_range)?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().option_at_time_quote(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(QuoteTickWithColumns {
+            rows: quote_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// List all available index symbols.
     ///
     /// A symbol can be defined as a unique identifier for a stock / underlying asset. Common terms also include: root, ticker, and underlying. This endpoint returns all traded symbols for options. This endpoint is updated overnight.
@@ -11619,6 +17399,40 @@ impl HistoricalClient {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `indexSnapshotOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexSnapshotOHLCWithColumns")]
+    pub async fn index_snapshot_ohlc_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<IndexSnapshotOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().index_snapshot_ohlc(&refs);
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest price snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index price.
@@ -11652,6 +17466,40 @@ impl HistoricalClient {
         Ok(price_ticks_to_class_vec(&ticks))
     }
 
+    /// Run the `indexSnapshotPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexSnapshotPriceWithColumns")]
+    pub async fn index_snapshot_price_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<IndexSnapshotPriceOptions>,
+    ) -> napi::Result<PriceTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().index_snapshot_price(&refs);
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(PriceTickWithColumns {
+            rows: price_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get the latest market value snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index market value.
@@ -11683,6 +17531,40 @@ impl HistoricalClient {
         })
         .await?;
         Ok(market_value_ticks_to_class_vec(&ticks))
+    }
+
+    /// Run the `indexSnapshotMarketValue` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexSnapshotMarketValue` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `marketValueTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexSnapshotMarketValueWithColumns")]
+    pub async fn index_snapshot_market_value_with_columns(
+        &self,
+        symbols: Either<String, Vec<String>>,
+        options: Option<IndexSnapshotMarketValueOptions>,
+    ) -> napi::Result<MarketValueTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let symbols = normalize_symbols(symbols);
+        let min_time = normalize_optional_time(options.min_time);
+        let ticks = spawn_endpoint_task(async move {
+            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
+            let mut request = client.historical().index_snapshot_market_value(&refs);
+            if let Some(value) = min_time {
+                request = request.min_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(MarketValueTickWithColumns {
+            rows: market_value_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day index data for a date range.
@@ -11747,6 +17629,38 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `indexHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `eodTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexHistoryEODWithColumns")]
+    pub async fn index_history_eod_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryEODOptions>,
+    ) -> napi::Result<EodTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(EodTickWithColumns {
+            rows: eod_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars for an index.
@@ -11842,6 +17756,50 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `indexHistoryOHLC` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryOHLC` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexHistoryOHLCWithColumns")]
+    pub async fn index_history_ohlc_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryOHLCOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_history_ohlc(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday price history for an index.
@@ -11952,6 +17910,56 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `indexHistoryPrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexHistoryPrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `priceTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexHistoryPriceWithColumns")]
+    pub async fn index_history_price_with_columns(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryPriceOptions>,
+    ) -> napi::Result<PriceTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_history_price(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(PriceTickWithColumns {
+            rows: price_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Fetch the index price at a specific time of day across a date range.
     ///
     /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
@@ -12021,6 +18029,40 @@ impl HistoricalClient {
         .await
     }
 
+    /// Run the `indexAtTimePrice` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `indexAtTimePrice` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `indexPriceAtTimeTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "indexAtTimePriceWithColumns")]
+    pub async fn index_at_time_price_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexAtTimePriceOptions>,
+    ) -> napi::Result<IndexPriceAtTimeTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().index_at_time_price(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(IndexPriceAtTimeTickWithColumns {
+            rows: index_price_at_time_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Check whether the market is open today.
     ///
     /// - Retrieves current day equity market schedule
@@ -12046,6 +18088,33 @@ impl HistoricalClient {
         })
         .await?;
         Ok(calendar_days_to_class_vec(&ticks))
+    }
+
+    /// Run the `calendarOpenToday` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOpenToday` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "calendarOpenTodayWithColumns")]
+    pub async fn calendar_open_today_with_columns(
+        &self,
+        options: Option<CalendarOpenTodayOptions>,
+    ) -> napi::Result<CalendarDayWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().calendar_open_today();
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(CalendarDayWithColumns {
+            rows: calendar_days_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Get calendar information for a specific date.
@@ -12078,6 +18147,35 @@ impl HistoricalClient {
         Ok(calendar_days_to_class_vec(&ticks))
     }
 
+    /// Run the `calendarOnDate` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarOnDate` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "calendarOnDateWithColumns")]
+    pub async fn calendar_on_date_with_columns(
+        &self,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<CalendarOnDateOptions>,
+    ) -> napi::Result<CalendarDayWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let date = normalize_date(date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().calendar_on_date(date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(CalendarDayWithColumns {
+            rows: calendar_days_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
+    }
+
     /// Get equity market holidays and early-close days for a year (vendor `year_holidays` endpoint — only non-standard days, not every trading day).
     ///
     /// - Retrieves equity market holidays for a given year
@@ -12105,6 +18203,34 @@ impl HistoricalClient {
         })
         .await?;
         Ok(calendar_days_to_class_vec(&ticks))
+    }
+
+    /// Run the `calendarYear` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `calendarYear` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `calendarDayToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "calendarYearWithColumns")]
+    pub async fn calendar_year_with_columns(
+        &self,
+        year: String,
+        options: Option<CalendarYearOptions>,
+    ) -> napi::Result<CalendarDayWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().calendar_year(&year);
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(CalendarDayWithColumns {
+            rows: calendar_days_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch end-of-day interest rate history.
@@ -12173,6 +18299,38 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `interestRateHistoryEOD` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `interestRateHistoryEOD` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `interestRateTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "interestRateHistoryEODWithColumns")]
+    pub async fn interest_rate_history_eod_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<InterestRateHistoryEODOptions>,
+    ) -> napi::Result<InterestRateTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().interest_rate_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(InterestRateTickWithColumns {
+            rows: interest_rate_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
     /// Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
@@ -12273,6 +18431,54 @@ impl HistoricalClient {
                 .await
         })
         .await
+    }
+
+    /// Run the `stockHistoryOHLCRange` query and return the rows together with the columns the response's wire carried, so a projected Arrow-IPC frame is drivable from a live call. Same parameters and result rows as the `stockHistoryOHLCRange` method; the returned object adds `presentColumns` (the schema columns the wire sent, in schema order) and `symbol` (the response's constant root, set for option and index responses). Feed both to `ohlcTickToArrowIpcProjected` for a terminal-exact columnar export that omits the columns the wire omitted.
+    #[napi(js_name = "stockHistoryOHLCRangeWithColumns")]
+    pub async fn stock_history_ohlc_range_with_columns(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryOHLCRangeOptions>,
+    ) -> napi::Result<OhlcTickWithColumns> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let client = self.client_handle()?;
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let ticks = spawn_endpoint_task(async move {
+            let mut request = client.historical().stock_history_ohlc_range(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request.await
+        })
+        .await?;
+        Ok(OhlcTickWithColumns {
+            rows: ohlc_ticks_to_class_vec(&ticks),
+            present_columns: ticks.columns().present_names().map(String::from).collect(),
+            symbol: ticks.columns().symbol().map(String::from),
+        })
     }
 
 }


### PR DESCRIPTION
## What

Make the projected Arrow-IPC exit reachable from a live TypeScript historical call, at parity with Python's presence-carrying tick list and the C / C++ `_with_options` presence out-param.

## Why

The full-schema `<tick>ToArrowIpc(rows)` serializes every column a hand-built row vector could carry. But a live TypeScript historical call returned only `Array<Tick>` with no response headers, so a caller could not resolve the columns the wire actually sent, and the projected `<tick>ToArrowIpcProjected` exit was undrivable from a real response. The only reachable path was the full-schema serializer, which emits always-zero trade-flag columns and always-null contract-identity columns the wire never carried. TypeScript was the last binding without a presence-carrying live-call surface.

## Changes

Every columnar historical endpoint gains a generated `<method>WithColumns` variant, on both the unified `HistoricalView` and the standalone `HistoricalClient`, returning `{ rows, presentColumns, symbol? }`: the same decoded rows plus the schema-ordered columns the response carried and the broadcast root symbol when present. Feed `presentColumns` and `symbol` into `<tick>ToArrowIpcProjected` for a terminal-exact frame. The presence is read off the same core `Ticks<T>` the buffered method already decodes, so per-endpoint cost is zero. The existing `Array<Tick>` methods are byte-identical (verified by hashing a buffered method body across the change); `StringList` endpoints get no variant.

The generator extracts the shared request prelude and builder into `write_ts_request_prelude` / `write_ts_builder_request`, so the buffered method and the variant share one source of the request setup. The cross-binding parity check gains a bidirectional reachability gate: every buffered columnar endpoint must surface a `WithColumns` variant (read from the committed generated napi source), and an unexpected variant is flagged as generator drift.

New per-tick `<Tick>WithColumns` return interfaces (23), 53 endpoints across 2 classes (106 methods). Generated surfaces regenerated; `index.d.ts` regenerated by the napi build.

## Verification

`generate_sdk_surfaces --check` (zero drift); `cargo fmt --check`; workspace + TypeScript clippy with `-D warnings`; `check_binding_parity.py` clean and `--selftest` 205 passed (the reachability gate trips on a dropped variant); docs-consistency, client-facing-vocab. `index.d.ts` regenerated by a local `npm run build` (release), so CI Gate 7 finds it consistent. Full TypeScript suite 282 pass, including a new test that drives the real `tradeTickToArrowIpcProjected` from the variant's `{ rows, presentColumns, symbol }` return shape (stock projection omits flag/contract-id columns; option projection leads with `symbol`). No breaking change, no version bump.
