### PR TITLE
docs(rustdoc): drop private intra-doc links behind the internal feature set

### DIFF
--- a/thetadatadx-rs/src/fpss/ring.rs
+++ b/thetadatadx-rs/src/fpss/ring.rs
@@ -281,7 +281,7 @@ where
 ///
 /// Each cursor is padded to its own cache line so the producer's
 /// store stream never contends with the consumer's
-/// ([`CachePadded`]). Reads are cold: only operator polling touches
+/// (`CachePadded`). Reads are cold: only operator polling touches
 /// them.
 // `RingCursors` is `pub` (re-exported under `__test-helpers`) so the
 // out-of-crate streaming bench can build the shared occupancy cursor pair

--- a/thetadatadx-rs/src/grpc/channel.rs
+++ b/thetadatadx-rs/src/grpc/channel.rs
@@ -20,7 +20,7 @@
 //!
 //! # Connector
 //!
-//! TLS rides through a custom connector ([`GrpcConnector`]) so the
+//! TLS rides through a custom connector (`GrpcConnector`) so the
 //! existing single-provider rustls configuration (`ring`, webpki roots,
 //! `h2` ALPN) is reused verbatim — the underlying stack's own TLS
 //! features stay disabled and the dependency graph keeps exactly one
@@ -950,7 +950,7 @@ impl Drop for InFlightToken {
 
 // ─── Connector ──────────────────────────────────────────────────────
 
-/// TCP(+TLS) dial error produced by [`GrpcConnector`]. Wrapped into
+/// TCP(+TLS) dial error produced by `GrpcConnector`. Wrapped into
 /// the transport stack's opaque connect error; [`classify_connect_error`]
 /// recovers it by downcasting the source chain so connect failures
 /// keep their precise [`ChannelError`] taxonomy.

--- a/thetadatadx-rs/src/grpc/status.rs
+++ b/thetadatadx-rs/src/grpc/status.rs
@@ -10,7 +10,7 @@
 //! message, and the `google.rpc.RetryInfo` backoff hint — so no
 //! third-party status type crosses the module boundary. The conversion
 //! from the underlying stack's status type happens once, at
-//! [`Status::from_tonic`], inside this module.
+//! `Status::from_tonic`, inside this module.
 
 /// Fully-qualified `Any.type_url` suffix for `google.rpc.RetryInfo`.
 const RETRY_INFO_TYPE_URL_SUFFIX: &str = "google.rpc.RetryInfo";


### PR DESCRIPTION
## Problem

Building docs with the internal feature flags (`__internal` / `__test-helpers`) surfaces `private_intra_doc_links` warnings the public rustdoc gate does not see, because the target items sit behind non-public features: `RingCursors` -> `CachePadded`, the gRPC channel module -> `GrpcConnector`, and the gRPC status module -> `Status::from_tonic`. Pre-existing, non-public, no-SemVer surface, so the shipped docs are unaffected.

## Changes

Replace the three intra-doc links with plain code spans. A docs build under `config-file,__internal,__test-helpers,arrow,polars,frames` is now clean with `RUSTDOCFLAGS=-D warnings`.

## Verification

`cargo doc --no-deps --features config-file,__internal,__test-helpers,arrow,polars,frames` with `-D warnings` finishes clean; `cargo fmt --check`. Doc-comment only, no code or public surface change. Closes #1099.