### PR TITLE
fix(bench): add the required created column to the synthetic EOD payload

### DIFF
--- a/thetadatadx-rs/benches/grpc_transport_comparison.rs
+++ b/thetadatadx-rs/benches/grpc_transport_comparison.rs
@@ -305,6 +305,10 @@ fn build_rows(row_count: usize, seed: u64) -> DataTable {
                     + rng.random_range(1..=12_i32) * 100
                     + rng.random_range(1..=28_i32),
             );
+            // `created` is a required EodTick column (the EOD report creation
+            // time, a milliseconds-of-day value like `ms_of_day`), so the
+            // synthetic row must carry it or the production build rejects it.
+            let created = i64::from(rng.random_range(0..=86_400_000_i32));
             let values = [
                 ms_of_day,
                 rng.random::<i64>(), // open
@@ -314,6 +318,7 @@ fn build_rows(row_count: usize, seed: u64) -> DataTable {
                 rng.random::<i64>(), // volume
                 rng.random::<i64>(), // count
                 date,
+                created,
             ]
             .into_iter()
             .map(|n| DataValue {
@@ -333,6 +338,7 @@ fn build_rows(row_count: usize, seed: u64) -> DataTable {
             "volume",
             "count",
             "date",
+            "created",
         ]
         .iter()
         .map(|s| (*s).to_string())


### PR DESCRIPTION
## Problem

The `grpc_transport_comparison` bench synthesizes an EOD `DataTable` and decodes it through the production `EodTick` build. `EodTick` requires the `created` column (the EOD report creation time), but the synthetic payload's headers were `ms_of_day, open, high, low, close, volume, count, date` with no `created`, so the decode panicked with `MissingRequiredHeader { header: "created" }`. The bench is not a required merge check, so it stayed red on main after the EodTick required-key guard landed.

## Fix

Add `created` (a milliseconds-of-day value, generated like `ms_of_day`) to the synthetic rows and to the header list, aligned, so the bench decodes a valid EOD response.

## Verification

`THETADATADX_BENCH_QUICK=1 cargo bench -p thetadatadx --features __test-helpers --bench grpc_transport_comparison --locked` runs the full measurement with no panic (10 rows decoded). Bench-only change, no shipped code touched.