### PR TITLE
chore(release): 13.0.0-rc.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.0-rc.14] - 2026-07-03
+
 ### Added
 
 - **TypeScript projected Arrow-IPC is now drivable from a live historical call.** Every columnar historical method gains a `<method>WithColumns` variant returning `{ rows, presentColumns, symbol?, symbols? }`: the same rows as the plain method plus the columns the response's wire actually carried, the broadcast root `symbol` when the response has one constant across every row, and a per-row `symbols` array when a multi-symbol snapshot varies the symbol row to row. Feed `presentColumns` plus `symbol` / `symbols` straight to `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame that omits the columns the wire omitted and attributes each row to its symbol, without hand-supplying a header list. The existing `Array<Tick>` methods are unchanged. This brings TypeScript to parity with Python's presence-carrying tick list and the C and C++ `_with_options` presence out-param.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Py
 > The active release line is the **13.0.0 release candidate**. It carries the latest data coverage and fixes, and we recommend installing it. Grab the newest RC:
 >
 > ```bash
-> pip install --pre thetadatadx          # Python (pinned: pip install thetadatadx==13.0.0rc13)
-> npm install thetadatadx@next           # TypeScript / Node.js (pinned: npm install thetadatadx@13.0.0-rc.13)
-> cargo add thetadatadx@13.0.0-rc.13     # Rust
+> pip install --pre thetadatadx          # Python (pinned: pip install thetadatadx==13.0.0rc14)
+> npm install thetadatadx@next           # TypeScript / Node.js (pinned: npm install thetadatadx@13.0.0-rc.14)
+> cargo add thetadatadx@13.0.0-rc.14     # Rust
 > ```
 
 Point an AI client (Claude Desktop, Cursor, and others) at the MCP server, no install and no Rust toolchain:
@@ -200,7 +200,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.13"
+thetadatadx = "13.0.0-rc.14"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.13"
+thetadatadx = "13.0.0-rc.14"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.0-rc.14] - 2026-07-03
+
 ### Added
 
 - **TypeScript projected Arrow-IPC is now drivable from a live historical call.** Every columnar historical method gains a `<method>WithColumns` variant returning `{ rows, presentColumns, symbol?, symbols? }`: the same rows as the plain method plus the columns the response's wire actually carried, the broadcast root `symbol` when the response has one constant across every row, and a per-row `symbols` array when a multi-symbol snapshot varies the symbol row to row. Feed `presentColumns` plus `symbol` / `symbols` straight to `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame that omits the columns the wire omitted and attributes each row to its symbol, without hand-supplying a header list. The existing `Array<Tick>` methods are unchanged. This brings TypeScript to parity with Python's presence-carrying tick list and the C and C++ `_with_options` presence out-param.

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -97,9 +97,9 @@ println!("{} {}", rows[0].bid, rows[0].ask);
     The active release line is the **13.0.0 release candidate**. It carries the latest data coverage and fixes, and we recommend installing it. Grab the newest RC:
 
     ```bash
-    pip install --pre thetadatadx          # Python 3.12+ (pinned: pip install thetadatadx==13.0.0rc13)
-    npm install thetadatadx@next           # Node.js 20+ (pinned: npm install thetadatadx@13.0.0-rc.13)
-    cargo add thetadatadx@13.0.0-rc.13     # Rust, async over tokio
+    pip install --pre thetadatadx          # Python 3.12+ (pinned: pip install thetadatadx==13.0.0rc14)
+    npm install thetadatadx@next           # Node.js 20+ (pinned: npm install thetadatadx@13.0.0-rc.14)
+    cargo add thetadatadx@13.0.0-rc.14     # Rust, async over tokio
     ```
 
 C++ links the same C ABI: build `thetadatadx-ffi`, then include `thetadatadx-cpp/include/thetadatadx.hpp`. Full steps in the [Quickstart](/articles/getting-started).

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.13
+  version: 13.0.0-rc.14
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,14 +27,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.13"
+thetadatadx = "13.0.0-rc.14"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.13", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.14", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package-lock.json
+++ b/thetadatadx-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "13.0.0-rc.13",
+      "version": "13.0.0-rc.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
@@ -18,9 +18,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "13.0.0-rc.13",
-        "thetadatadx-linux-x64-gnu": "13.0.0-rc.13",
-        "thetadatadx-win32-x64-msvc": "13.0.0-rc.13"
+        "thetadatadx-darwin-arm64": "13.0.0-rc.14",
+        "thetadatadx-linux-x64-gnu": "13.0.0-rc.14",
+        "thetadatadx-win32-x64-msvc": "13.0.0-rc.14"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2141,8 +2141,8 @@
       }
     },
     "node_modules/thetadatadx-darwin-arm64": {
-      "version": "13.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/thetadatadx-darwin-arm64/-/thetadatadx-darwin-arm64-13.0.0-rc.13.tgz",
+      "version": "13.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/thetadatadx-darwin-arm64/-/thetadatadx-darwin-arm64-13.0.0-rc.14.tgz",
       "integrity": "sha512-c5PHspUQS3Fk3JMnqON8CZyqlD+Z42/Vj3ERjZ5v/O3eKIpjujB9QdhEYXei7FUocgRyclMoZwM6lqA8Odd5vQ==",
       "cpu": [
         "arm64"
@@ -2157,8 +2157,8 @@
       }
     },
     "node_modules/thetadatadx-linux-x64-gnu": {
-      "version": "13.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/thetadatadx-linux-x64-gnu/-/thetadatadx-linux-x64-gnu-13.0.0-rc.13.tgz",
+      "version": "13.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/thetadatadx-linux-x64-gnu/-/thetadatadx-linux-x64-gnu-13.0.0-rc.14.tgz",
       "integrity": "sha512-RQB3QlBh7FYWpfFkNFcwTNmULPpNdNwd6V3k4e8FLl0USITFg6s53ZICVHcMki8VWJGIEBK4r5S3j6rOMeIBpg==",
       "cpu": [
         "x64"
@@ -2176,8 +2176,8 @@
       }
     },
     "node_modules/thetadatadx-win32-x64-msvc": {
-      "version": "13.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/thetadatadx-win32-x64-msvc/-/thetadatadx-win32-x64-msvc-13.0.0-rc.13.tgz",
+      "version": "13.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/thetadatadx-win32-x64-msvc/-/thetadatadx-win32-x64-msvc-13.0.0-rc.14.tgz",
       "integrity": "sha512-L6/cESIEJwDyHuYy8UaBUfkJOnNqyhWMqBKM5FKj6AVAURVzbkXkuhhgxuPND7GfasvvrzZ4wZEPZDASecj6jQ==",
       "cpu": [
         "x64"

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.13",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.13",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.13"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.14",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.14",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.14"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.13",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.13",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.13",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.13",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.13"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.14",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.14",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.14",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.14",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.14"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.13",
+  "version": "13.0.0-rc.14",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.13"
+version = "13.0.0-rc.14"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
## Release 13.0.0-rc.14

Rolls the accumulated `[Unreleased]` hardening into a release candidate. Highlights since rc.13:

- FPSS I/O-thread fault surfaces to callback and binding consumers; the callback dispatcher flips the session to failed on a scope-closure panic.
- Config validated on every historical connect path; server retry hint clamped to the policy ceiling.
- Mid-stream reconnect is terminal once chunks were delivered (no duplicate leading rows).
- C/C++ column-presence out-param and TypeScript projected Arrow-IPC reachable from a live call; multi-symbol snapshot now carries the per-row symbol.
- Standalone TypeScript streaming: context-managed factory + leak-free teardown; `setReconnectCallback` no longer pins the event loop.
- FPSS subscription tracking reference-counted and every identity mutation serialized with its wire send (concurrent-duplicate, reconnect-window, reject, unsubscribe, replay all consistent).
- Python `*_stream_async` handler offloaded to the dedicated blocking pool.
- Flat-files fail loud on drifted headers; Prometheus exporter re-install returns Ok.

## Mechanics

Version bumped across every published artifact (Rust workspace, TypeScript SDK + platform packages, MCP server, Python wheel) via `scripts/release/bump_version.py`; README / docs-site / OpenAPI `info.version` pins updated; `[Unreleased]` rolled into the `[13.0.0-rc.14]` CHANGELOG heading. `check_version_sync` and `check_docs_consistency` pass.

On merge, tagging `v13.0.0-rc.14` from main fires the publish workflows (crates, wheels, npm).