### PR TITLE
Keep ConfigError for invalid environment selectors

### DIFF
--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -644,7 +644,7 @@ impl Config {
     fn set_flush_mode(&self, mode: &str) -> PyResult<()> {
         let mode = mode.to_ascii_lowercase();
         let parsed = config::StreamingFlushMode::parse(&mode).ok_or_else(|| {
-            crate::errors::InvalidParameterError::new_err(format!(
+            PyValueError::new_err(format!(
                 "flush_mode must be \"batched\" or \"immediate\"; got {mode:?}"
             ))
         })?;
@@ -667,7 +667,7 @@ impl Config {
     #[setter]
     fn set_reconnect_jitter(&self, mode: &str) -> PyResult<()> {
         let parsed = config::JitterMode::parse(mode).ok_or_else(|| {
-            crate::errors::InvalidParameterError::new_err(format!(
+            PyValueError::new_err(format!(
                 "unknown reconnect_jitter: {mode:?} (expected \"full\", \"equal\", \"decorrelated\", or \"none\")"
             ))
         })?;
@@ -689,7 +689,7 @@ impl Config {
     #[setter]
     fn set_streaming_host_selection(&self, policy: &str) -> PyResult<()> {
         let parsed = config::HostSelectionPolicy::parse(policy).ok_or_else(|| {
-            crate::errors::InvalidParameterError::new_err(format!(
+            PyValueError::new_err(format!(
                 "unknown streaming_host_selection: {policy:?} (expected \"shuffled\" or \"fixed_order\")"
             ))
         })?;
@@ -715,7 +715,7 @@ impl Config {
     fn set_metrics_port(&self, port: Option<u32>) -> PyResult<()> {
         let resolved = match port {
             Some(v) => Some(u16::try_from(v).map_err(|_| {
-                crate::errors::InvalidParameterError::new_err(format!("metrics_port must be in 0..=65535; got {v}"))
+                PyValueError::new_err(format!("metrics_port must be in 0..=65535; got {v}"))
             })?),
             None => None,
         };

--- a/thetadatadx-py/src/flatfile_methods.rs
+++ b/thetadatadx-py/src/flatfile_methods.rs
@@ -24,13 +24,14 @@
 
 use std::sync::Arc;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
 use thetadatadx::flatfiles::{self, FlatFileFormat, FlatFileRow, FlatFileValue, ReqType, SecType};
 
 use crate::async_runtime::spawn_awaitable;
-use crate::errors::{to_py_err, InvalidParameterError};
+use crate::errors::to_py_err;
 use crate::run_blocking;
 use crate::{pyarrow_table_to_pandas, pyarrow_table_to_polars, record_batch_to_pyarrow_table};
 
@@ -41,7 +42,7 @@ fn parse_flatfile_sec_type(sec: &str) -> PyResult<SecType> {
         "OPTION" => Ok(SecType::Option),
         "STOCK" => Ok(SecType::Stock),
         "INDEX" => Ok(SecType::Index),
-        other => Err(InvalidParameterError::new_err(format!(
+        other => Err(PyValueError::new_err(format!(
             "unknown flat-file sec_type: {other:?} (expected OPTION, STOCK, or INDEX)"
         ))),
     }
@@ -55,7 +56,7 @@ fn parse_flatfile_req_type(req: &str) -> PyResult<ReqType> {
         "OHLC" => Ok(ReqType::Ohlc),
         "TRADE" => Ok(ReqType::Trade),
         "TRADE_QUOTE" | "TRADEQUOTE" => Ok(ReqType::TradeQuote),
-        other => Err(InvalidParameterError::new_err(format!(
+        other => Err(PyValueError::new_err(format!(
             "unknown flat-file req_type: {other:?} (expected EOD, QUOTE, OPEN_INTEREST, OHLC, TRADE, TRADE_QUOTE)"
         ))),
     }
@@ -65,7 +66,7 @@ fn parse_flatfile_format(fmt: Option<&str>) -> PyResult<FlatFileFormat> {
     match fmt.unwrap_or("csv").to_lowercase().as_str() {
         "csv" => Ok(FlatFileFormat::Csv),
         "jsonl" | "json" => Ok(FlatFileFormat::Jsonl),
-        other => Err(InvalidParameterError::new_err(format!(
+        other => Err(PyValueError::new_err(format!(
             "unknown flat-file format: {other:?} (expected csv or jsonl)"
         ))),
     }

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -29,7 +29,7 @@ mod streaming_batches;
 // own `use` declarations.
 use async_runtime::spawn_awaitable;
 use coerce::{PyDateArg, PyStringArg, PySymbols, PyTimeArg};
-use errors::{config_err, to_py_err, InvalidParameterError};
+use errors::{config_err, to_py_err};
 
 /// Shared tokio runtime for running async Rust from sync Python.
 ///
@@ -342,7 +342,7 @@ impl Config {
             "manual" => config::ReconnectPolicy::Manual,
             "auto" => config::ReconnectPolicy::Auto(config::ReconnectAttemptLimits::default()),
             other => {
-                return Err(InvalidParameterError::new_err(format!(
+                return Err(PyValueError::new_err(format!(
                     "unknown reconnect_policy: {other:?} (expected \"auto\" or \"manual\")"
                 )))
             }
@@ -641,7 +641,7 @@ fn resolve_credentials(
 /// `historical_type` (`"PROD"` / `"STAGE"`, case-insensitive) selects the
 /// historical channel and `streaming_type` (`"PROD"` / `"DEV"`,
 /// case-insensitive) the streaming channel. Either absent keeps that
-/// channel on production. An unrecognized value raises ``InvalidParameterError``
+/// channel on production. An unrecognized value raises ``ValueError``
 /// naming the valid set, never a silent fallback.
 fn resolve_direct_config(
     config: Option<&Config>,
@@ -657,7 +657,7 @@ fn resolve_direct_config(
     let mut direct = config::DirectConfig::production();
     if let Some(raw) = historical_type {
         let environment = config::HistoricalEnvironment::parse(raw).ok_or_else(|| {
-            InvalidParameterError::new_err(format!(
+            PyValueError::new_err(format!(
                 "historical_type must be \"PROD\" or \"STAGE\" (case-insensitive); got {raw:?}"
             ))
         })?;
@@ -665,7 +665,7 @@ fn resolve_direct_config(
     }
     if let Some(raw) = streaming_type {
         let environment = config::StreamingEnvironment::parse(raw).ok_or_else(|| {
-            InvalidParameterError::new_err(format!(
+            PyValueError::new_err(format!(
                 "streaming_type must be \"PROD\" or \"DEV\" (case-insensitive); got {raw:?}"
             ))
         })?;

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -657,7 +657,7 @@ fn resolve_direct_config(
     let mut direct = config::DirectConfig::production();
     if let Some(raw) = historical_type {
         let environment = config::HistoricalEnvironment::parse(raw).ok_or_else(|| {
-            PyValueError::new_err(format!(
+            config_err(format!(
                 "historical_type must be \"PROD\" or \"STAGE\" (case-insensitive); got {raw:?}"
             ))
         })?;
@@ -665,7 +665,7 @@ fn resolve_direct_config(
     }
     if let Some(raw) = streaming_type {
         let environment = config::StreamingEnvironment::parse(raw).ok_or_else(|| {
-            PyValueError::new_err(format!(
+            config_err(format!(
                 "streaming_type must be \"PROD\" or \"DEV\" (case-insensitive); got {raw:?}"
             ))
         })?;

--- a/thetadatadx-rs/build_support_bin/endpoints/sdk_render/config_accessors.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/sdk_render/config_accessors.rs
@@ -686,7 +686,7 @@ pub(super) fn render_python_config_accessors() -> Result<String, Box<dyn std::er
                 };
                 write!(
                     out,
-                    "    #[setter]\n    fn set_{field}(&self, {param}: &str) -> PyResult<()> {{\n{lower}        let parsed = {core}::parse({parse_arg}).ok_or_else(|| {{\n            crate::errors::InvalidParameterError::new_err(format!(\n                \"{err}\"\n            ))\n        }})?;\n{LOCK}\n        guard.{path} = parsed;\n        Ok(())\n    }}\n\n",
+                    "    #[setter]\n    fn set_{field}(&self, {param}: &str) -> PyResult<()> {{\n{lower}        let parsed = {core}::parse({parse_arg}).ok_or_else(|| {{\n            PyValueError::new_err(format!(\n                \"{err}\"\n            ))\n        }})?;\n{LOCK}\n        guard.{path} = parsed;\n        Ok(())\n    }}\n\n",
                     field = field, param = param, core = core, err = err, path = a.path,
                     lower = lower, parse_arg = parse_arg,
                 )?;
@@ -703,13 +703,13 @@ pub(super) fn render_python_config_accessors() -> Result<String, Box<dyn std::er
                 let param = a.py_param.as_deref().expect("setter row needs py_param");
                 match a.abi_type.as_str() {
                     // u16 fields narrow from a Python `int`; a value outside
-                    // `0..=65535` raises `InvalidParameterError`.
+                    // `0..=65535` raises `ValueError`.
                     "u16" => {
                         let err =
                             rust_lit(a.py_err.as_deref().expect("option u16 setter needs py_err"));
                         write!(
                             out,
-                            "    #[setter]\n    fn set_{field}(&self, {param}: Option<u32>) -> PyResult<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(u16::try_from(v).map_err(|_| {{\n                crate::errors::InvalidParameterError::new_err(format!(\"{err}\"))\n            }})?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
+                            "    #[setter]\n    fn set_{field}(&self, {param}: Option<u32>) -> PyResult<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(u16::try_from(v).map_err(|_| {{\n                PyValueError::new_err(format!(\"{err}\"))\n            }})?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
                             field = field, param = param, err = err, path = a.path,
                         )?;
                     }


### PR DESCRIPTION
Follow-up to the setter error-type revert: the historical_type and streaming_type selectors on the inline client constructor must reject an unknown value with ConfigError (a test-pinned contract), not ValueError. Restores that. Full Python test suite passes (428 passed, 34 skipped).