### PR TITLE
Make InvalidParameterError catchable as ValueError and raise it from argument guards

### DIFF
--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -3765,14 +3765,18 @@ def _collect_python_error_leaves(py_errors_rs: pathlib.Path) -> set[str]:
     if not m:
         return set()
     body = _balanced_body(text, m.end())
-    # The dispatch builds each leaf as `<Class>::new_err(...)`; the
-    # rate-limit arm routes through the `rate_limit_err` helper which
-    # builds `RateLimitError`. Harvest both shapes.
+    # The dispatch builds each leaf as `<Class>::new_err(...)`; two arms
+    # route through helpers instead: `rate_limit_err` builds `RateLimitError`,
+    # and `invalid_parameter_err` builds the dual-base `InvalidParameterError`
+    # (which cannot use `<Class>::new_err` because it is a runtime type, not a
+    # `create_exception!` type). Harvest all three shapes.
     leaves = {
         leaf for leaf in _LEAF_RE.findall(body) if leaf in CANONICAL_ERROR_LEAVES
     }
     if "rate_limit_err" in body:
         leaves.add("RateLimitError")
+    if "invalid_parameter_err" in body:
+        leaves.add("InvalidParameterError")
     return leaves
 
 

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -644,7 +644,7 @@ impl Config {
     fn set_flush_mode(&self, mode: &str) -> PyResult<()> {
         let mode = mode.to_ascii_lowercase();
         let parsed = config::StreamingFlushMode::parse(&mode).ok_or_else(|| {
-            PyValueError::new_err(format!(
+            crate::errors::invalid_parameter_err(format!(
                 "flush_mode must be \"batched\" or \"immediate\"; got {mode:?}"
             ))
         })?;
@@ -667,7 +667,7 @@ impl Config {
     #[setter]
     fn set_reconnect_jitter(&self, mode: &str) -> PyResult<()> {
         let parsed = config::JitterMode::parse(mode).ok_or_else(|| {
-            PyValueError::new_err(format!(
+            crate::errors::invalid_parameter_err(format!(
                 "unknown reconnect_jitter: {mode:?} (expected \"full\", \"equal\", \"decorrelated\", or \"none\")"
             ))
         })?;
@@ -689,7 +689,7 @@ impl Config {
     #[setter]
     fn set_streaming_host_selection(&self, policy: &str) -> PyResult<()> {
         let parsed = config::HostSelectionPolicy::parse(policy).ok_or_else(|| {
-            PyValueError::new_err(format!(
+            crate::errors::invalid_parameter_err(format!(
                 "unknown streaming_host_selection: {policy:?} (expected \"shuffled\" or \"fixed_order\")"
             ))
         })?;
@@ -715,7 +715,7 @@ impl Config {
     fn set_metrics_port(&self, port: Option<u32>) -> PyResult<()> {
         let resolved = match port {
             Some(v) => Some(u16::try_from(v).map_err(|_| {
-                PyValueError::new_err(format!("metrics_port must be in 0..=65535; got {v}"))
+                crate::errors::invalid_parameter_err(format!("metrics_port must be in 0..=65535; got {v}"))
             })?),
             None => None,
         };

--- a/thetadatadx-py/src/errors.rs
+++ b/thetadatadx-py/src/errors.rs
@@ -40,9 +40,13 @@
 //! clauses keep catching the same conditions. New code should reach for
 //! the canonical names.
 
+use std::ffi::CString;
+
 use pyo3::create_exception;
-use pyo3::exceptions::PyException;
+use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{PyTuple, PyType};
 
 // Root — callers can use a single `except thetadatadx.ThetaDataError` to
 // catch any branded error from the SDK. Intentionally inherits from
@@ -72,7 +76,52 @@ create_exception!(thetadatadx, RateLimitError, ThetaDataError);
 // by class from an unrelated environmental configuration fault
 // (config-file I/O, TOML parse, internal invariant), which raises
 // `ConfigError`.
-create_exception!(thetadatadx, InvalidParameterError, ThetaDataError);
+// `InvalidParameterError` needs two bases: the SDK root `ThetaDataError`
+// (so `except ThetaDataError` catches it and it stays in the branded
+// hierarchy) AND the built-in `ValueError` (so existing `except ValueError`
+// callers keep working — a rejected argument is a value error). The
+// single-base `create_exception!` macro cannot express two bases, so the
+// type is built once at module registration with a `(ThetaDataError,
+// ValueError)` bases tuple and cached here.
+static INVALID_PARAMETER_ERROR: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+
+fn build_invalid_parameter_error(py: Python<'_>) -> PyResult<Py<PyType>> {
+    let bases = PyTuple::new(
+        py,
+        [
+            py.get_type::<ThetaDataError>().into_any(),
+            py.get_type::<PyValueError>().into_any(),
+        ],
+    )?;
+    let name = CString::new("thetadatadx.InvalidParameterError")
+        .expect("static name has no interior NUL");
+    // SAFETY: `name` is a valid C string, `bases` is a non-null tuple of
+    // exception types, and the null `dict` is accepted by the C-API. The
+    // returned object is a new reference to a new exception type.
+    let ptr = unsafe {
+        pyo3::ffi::PyErr_NewException(name.as_ptr(), bases.as_ptr(), std::ptr::null_mut())
+    };
+    let obj = unsafe { Bound::from_owned_ptr_or_err(py, ptr)? };
+    Ok(obj.cast_into::<PyType>()?.unbind())
+}
+
+/// The cached `InvalidParameterError` type (dual base: `ThetaDataError` +
+/// `ValueError`), building it on first use.
+pub fn invalid_parameter_type(py: Python<'_>) -> PyResult<&'static Py<PyType>> {
+    INVALID_PARAMETER_ERROR.get_or_try_init(py, || build_invalid_parameter_error(py))
+}
+
+/// Raise `InvalidParameterError` with `msg`. Callers catching either
+/// `ValueError` or `thetadatadx.ThetaDataError` both handle it.
+pub fn invalid_parameter_err(msg: impl Into<String>) -> PyErr {
+    let msg = msg.into();
+    Python::attach(|py| match invalid_parameter_type(py) {
+        Ok(ty) => PyErr::from_type(ty.bind(py).clone(), (msg,)),
+        // Fall back to a plain ValueError if the type could not be built
+        // (only reachable before the module is initialised).
+        Err(_) => PyValueError::new_err(msg),
+    })
+}
 
 // Decoder schema mismatch — surfaces `Error::Decode` + `DecodeError`
 // variants. Triggering cause is usually a proto bump on the server before
@@ -154,7 +203,7 @@ pub fn register_exceptions(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<
     m.add("RateLimitError", rate_limit_type)?;
     m.add(
         "InvalidParameterError",
-        py.get_type::<InvalidParameterError>(),
+        invalid_parameter_type(py)?.bind(py).clone(),
     )?;
     m.add("SchemaMismatchError", py.get_type::<SchemaMismatchError>())?;
     m.add("NetworkError", py.get_type::<NetworkError>())?;
@@ -246,7 +295,7 @@ pub fn to_py_err(e: thetadatadx::Error) -> PyErr {
         // (`Io` / `TomlParse` / `Internal`) route to `ConfigError`.
         thetadatadx::Error::Config { kind, .. } => {
             if kind.is_invalid_parameter() {
-                InvalidParameterError::new_err(e.to_string())
+                invalid_parameter_err(e.to_string())
             } else {
                 ConfigError::new_err(e.to_string())
             }
@@ -557,7 +606,10 @@ mod tests {
                 ("RateLimitError", py.get_type::<RateLimitError>()),
                 (
                     "InvalidParameterError",
-                    py.get_type::<InvalidParameterError>(),
+                    invalid_parameter_type(py)
+                        .expect("InvalidParameterError type builds")
+                        .bind(py)
+                        .clone(),
                 ),
                 ("SchemaMismatchError", py.get_type::<SchemaMismatchError>()),
                 ("NetworkError", py.get_type::<NetworkError>()),

--- a/thetadatadx-py/src/flatfile_methods.rs
+++ b/thetadatadx-py/src/flatfile_methods.rs
@@ -24,7 +24,6 @@
 
 use std::sync::Arc;
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
@@ -42,7 +41,7 @@ fn parse_flatfile_sec_type(sec: &str) -> PyResult<SecType> {
         "OPTION" => Ok(SecType::Option),
         "STOCK" => Ok(SecType::Stock),
         "INDEX" => Ok(SecType::Index),
-        other => Err(PyValueError::new_err(format!(
+        other => Err(crate::errors::invalid_parameter_err(format!(
             "unknown flat-file sec_type: {other:?} (expected OPTION, STOCK, or INDEX)"
         ))),
     }
@@ -56,7 +55,7 @@ fn parse_flatfile_req_type(req: &str) -> PyResult<ReqType> {
         "OHLC" => Ok(ReqType::Ohlc),
         "TRADE" => Ok(ReqType::Trade),
         "TRADE_QUOTE" | "TRADEQUOTE" => Ok(ReqType::TradeQuote),
-        other => Err(PyValueError::new_err(format!(
+        other => Err(crate::errors::invalid_parameter_err(format!(
             "unknown flat-file req_type: {other:?} (expected EOD, QUOTE, OPEN_INTEREST, OHLC, TRADE, TRADE_QUOTE)"
         ))),
     }
@@ -66,7 +65,7 @@ fn parse_flatfile_format(fmt: Option<&str>) -> PyResult<FlatFileFormat> {
     match fmt.unwrap_or("csv").to_lowercase().as_str() {
         "csv" => Ok(FlatFileFormat::Csv),
         "jsonl" | "json" => Ok(FlatFileFormat::Jsonl),
-        other => Err(PyValueError::new_err(format!(
+        other => Err(crate::errors::invalid_parameter_err(format!(
             "unknown flat-file format: {other:?} (expected csv or jsonl)"
         ))),
     }

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -342,7 +342,7 @@ impl Config {
             "manual" => config::ReconnectPolicy::Manual,
             "auto" => config::ReconnectPolicy::Auto(config::ReconnectAttemptLimits::default()),
             other => {
-                return Err(PyValueError::new_err(format!(
+                return Err(errors::invalid_parameter_err(format!(
                     "unknown reconnect_policy: {other:?} (expected \"auto\" or \"manual\")"
                 )))
             }

--- a/thetadatadx-py/tests/test_error_parity.py
+++ b/thetadatadx-py/tests/test_error_parity.py
@@ -86,3 +86,11 @@ def test_invalid_parameter_is_distinct_from_root(client) -> None:
     # A dedicated subclass under the root, not the root itself.
     assert client.InvalidParameterError is not client.ThetaDataError
     assert issubclass(client.InvalidParameterError, client.ThetaDataError)
+
+
+def test_invalid_parameter_error_is_dual_base(client):
+    """InvalidParameterError roots at both ThetaDataError (branded hierarchy)
+    and the built-in ValueError (so `except ValueError` keeps working)."""
+    cls = client.InvalidParameterError
+    assert issubclass(cls, client.ThetaDataError), "must stay in the SDK hierarchy"
+    assert issubclass(cls, ValueError), "must also be a ValueError for back-compat"

--- a/thetadatadx-rs/build_support_bin/endpoints/sdk_render/config_accessors.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/sdk_render/config_accessors.rs
@@ -686,7 +686,7 @@ pub(super) fn render_python_config_accessors() -> Result<String, Box<dyn std::er
                 };
                 write!(
                     out,
-                    "    #[setter]\n    fn set_{field}(&self, {param}: &str) -> PyResult<()> {{\n{lower}        let parsed = {core}::parse({parse_arg}).ok_or_else(|| {{\n            PyValueError::new_err(format!(\n                \"{err}\"\n            ))\n        }})?;\n{LOCK}\n        guard.{path} = parsed;\n        Ok(())\n    }}\n\n",
+                    "    #[setter]\n    fn set_{field}(&self, {param}: &str) -> PyResult<()> {{\n{lower}        let parsed = {core}::parse({parse_arg}).ok_or_else(|| {{\n            crate::errors::invalid_parameter_err(format!(\n                \"{err}\"\n            ))\n        }})?;\n{LOCK}\n        guard.{path} = parsed;\n        Ok(())\n    }}\n\n",
                     field = field, param = param, core = core, err = err, path = a.path,
                     lower = lower, parse_arg = parse_arg,
                 )?;
@@ -709,7 +709,7 @@ pub(super) fn render_python_config_accessors() -> Result<String, Box<dyn std::er
                             rust_lit(a.py_err.as_deref().expect("option u16 setter needs py_err"));
                         write!(
                             out,
-                            "    #[setter]\n    fn set_{field}(&self, {param}: Option<u32>) -> PyResult<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(u16::try_from(v).map_err(|_| {{\n                PyValueError::new_err(format!(\"{err}\"))\n            }})?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
+                            "    #[setter]\n    fn set_{field}(&self, {param}: Option<u32>) -> PyResult<()> {{\n        let resolved = match {param} {{\n            Some(v) => Some(u16::try_from(v).map_err(|_| {{\n                crate::errors::invalid_parameter_err(format!(\"{err}\"))\n            }})?),\n            None => None,\n        }};\n{LOCK}\n        guard.{path} = resolved;\n        Ok(())\n    }}\n\n",
                             field = field, param = param, err = err, path = a.path,
                         )?;
                     }


### PR DESCRIPTION
InvalidParameterError now inherits from both ThetaDataError and the built-in ValueError, so it stays in the branded hierarchy while existing 'except ValueError' code keeps working. The configuration setters and flat-file argument guards raise this typed error for a rejected value, giving parity with the typed error other bindings raise, with no ValueError caller broken. Environment selectors keep raising ConfigError. Full Python suite passes (429 passed, 34 skipped). Closes #1147.