### PR TITLE
Trim redundant and no-signal CI work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,32 +516,17 @@ jobs:
       - uses: ./.github/actions/setup-rust-deps
       - name: Run tracked benches (mock-backed, no live creds)
         run: |
-          THETADATADX_BENCH_QUICK=1 cargo bench -p thetadatadx --features __test-helpers \
-              --bench grpc_transport_comparison --locked
+          # Only the gated throughput benches run here. Non-baselined benches
+          # (grpc_transport_comparison, disruptor_production_ctor,
+          # bench_fpss_event) produce no regression signal — the gate compares
+          # baseline-listed rows only — so running them in CI is pure runner
+          # cost. Run those locally when profiling their paths.
           cargo bench -p thetadatadx --bench streaming_channels --locked -- \
               "streaming_channels/direct_callback/100k_events" --quick
           cargo bench -p thetadatadx --bench streaming_channels --locked -- \
               "streaming_channels/disruptor_consumer_panic_isolated/100k_events" --quick # VOCAB-OK: bench function name from bench crate
           cargo bench -p thetadatadx --bench streaming_channels --locked -- \
               "streaming_channels/disruptor_cross_thread/100k_events" --quick # VOCAB-OK: bench function name from bench crate
-          # Production-constructor variant: routes the pipeline through
-          # `build_poller_producer` so the sequence-recording producer
-          # adapter is measured. Needs `__test-helpers` for the
-          # crate-internal constructor re-export; its baseline is deferred
-          # (see `_deferred` in `benches/baseline/criterion.json`) until a
-          # first sample lands on `main`, mirroring the bench-gate rule
-          # that a value is blessed only against the hosted-runner profile.
-          cargo bench -p thetadatadx --features __test-helpers --bench streaming_channels --locked -- \
-              "streaming_channels/disruptor_production_ctor/100k_events" --quick # VOCAB-OK: bench function name from bench crate
-          # Gate 10 (#553) expansion: FPSS event clone + match dispatch
-          # benches. The bench files already exist
-          # (`bench_fpss_event.rs`); this step exercises them in CI so
-          # the data is generated. They will be added to
-          # `benches/baseline/criterion.json` in a follow-up commit once
-          # a first sample lands on `main` — the baseline JSON is
-          # captured locally and we do not bless a value against the
-          # GitHub-hosted runner without one observed sample.
-          cargo bench -p thetadatadx --bench bench_fpss_event --locked -- --quick
       - name: Validate the regression gate's own threshold logic
         run: python3 scripts/ci/check_bench_regression.py --selftest
       - name: Compare against checked-in baseline

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,14 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
+    # Only deploy when docs actually change. The generated docs are committed
+    # to `docs-site/` (enforced by the docs-consistency drift gate), so a docs
+    # change always shows here — a code-only merge no longer redeploys Pages,
+    # which is what piled deployments onto the shared `pages` concurrency group.
+    paths:
+      - "docs-site/**"
+      - ".github/workflows/docs.yml"
+      - ".github/workflows/paths.yml"
   pull_request:
     paths:
       - "docs-site/**"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,7 +68,10 @@ jobs:
             macos312='{"os":"macos-latest","python":"3.12","label":"macos py3.12"}'
             windows312='{"os":"windows-latest","python":"3.12","label":"windows py3.12"}'
             build="[${ubuntu312},${macos312},${windows312},${ubuntu314t}]"
-            compat='[{"os":"ubuntu-latest","python":"3.12"},{"os":"ubuntu-latest","python":"3.14"},{"os":"macos-latest","python":"3.12"},{"os":"macos-latest","python":"3.14"},{"os":"windows-latest","python":"3.12"},{"os":"windows-latest","python":"3.14"}]'
+            # 3.12 legs dropped: the `build` job already import-smokes the
+            # 3.12 abi3 wheel on all three OSes, so a 3.12 compat re-import is
+            # redundant. The 3.14 legs are the real forward-ABI signal.
+            compat='[{"os":"ubuntu-latest","python":"3.14"},{"os":"macos-latest","python":"3.14"},{"os":"windows-latest","python":"3.14"}]'
           fi
           {
             echo "build_matrix={\"include\":${build}}"
@@ -379,11 +382,9 @@ jobs:
           if ratio >= 1.8:
               sys.exit(f"nogil overhead ratio {ratio:.3f}x ≥ 1.8x — GIL may be held on hot path")
           PY
-      - name: Pytest suite on freethreaded
-        shell: bash
-        run: |
-          python -m pip install pytest
-          python -m pytest thetadatadx-py/tests/ -v
+      # The full pytest suite already runs on the 3.14t wheel in the `build`
+      # job; this job's unique value is the GIL-stays-disabled assert and the
+      # nogil overhead ratio above, so it does not re-run the suite.
 
   sdist:
     name: Build source distribution

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -169,9 +169,8 @@ jobs:
       - name: Emit TypeScript shape manifest
         if: matrix.os == 'ubuntu-latest'
         run: node thetadatadx-ts/scripts/emit_validator_manifest.mjs
-      - name: Validator self-test (Python diff engine)
-        if: matrix.os == 'ubuntu-latest'
-        run: python3 scripts/ci/tests/test_check_agreement.py
+      # The agreement validator's self-test runs in the fast-lane `agreement`
+      # job on every PR; no need to re-run it inside the TypeScript build.
       - name: Upload TypeScript shape manifest
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Five lean cuts, each loses no real coverage: stop running three non-baselined benches that produce no gate signal; path-filter the docs deploy so code-only merges do not redeploy Pages; drop the redundant 3.12 Python compat legs (the build job already import-smokes that wheel); drop the freethreaded job's duplicate pytest (the suite already runs on the 3.14t wheel in build); and drop the duplicate agreement self-test from the TypeScript build (the fast-lane job runs it). The load-bearing gates (parity, leak/vocab scans, version-sync, wire-drift, SDK build+test, ABI completeness, tag preflights, throughput benches, the deterministic allocation perf-gate) are untouched.