### PR TITLE
chore(release): 13.0.0-rc.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.0-rc.14] - 2026-07-03
+## [13.0.0-rc.15] - 2026-07-04
 
 ### Added
 
 - **The MCP server now advertises only the tools the account's subscription grants.** `tools/list` previously offered every endpoint once a client connected, so an account without an options subscription still saw every option tool and the model wasted calls on tools that only ever return a not-subscribed error. Once authenticated, the server reads the per-asset-class subscription captured at connect and advertises a tool only when its asset class (stock, options, indices, interest-rate) is subscribed; a class the subscription omits contributes no tools. FREE-tier classes stay advertised because FREE grants delayed data, and the account-agnostic tools (`ping`, the trading calendar, the multi-asset flat-file dispatcher) are always offered. Each tool's description names the subscription it needs. Offline mode is unchanged: with no client, only `ping` is advertised. Gating is per asset class; finer per-endpoint minimum-tier gating is a follow-up. Closes #1123.
+
+### Fixed
+
+- **Calendar endpoints keep every column in the projected frame.** `calendar_year(...)`, `calendar_on_date(...)`, and `calendar_open_today(...)` resolved their projected column set against schema field names that the calendar wire never sends, so `to_arrow()` / `to_polars()` collapsed to a date-only frame or an empty one while the decoded response carried the full session data. The calendar column resolver now maps the wire headers to every exposed column, and a fixture-headers test pins the calendar column set.
+- **Streamed historical chunks carry the columns the wire sent, not the full schema.** A handler on `stock_history_trade(...).stream(...)` that converted a chunk to a DataFrame received fabricated columns the response never carried (seed-zeroed flag and contract-identity columns that read as data), while the buffered path for the same endpoint projected the wire's exact columns. The streaming path now derives the present columns and response symbol from each chunk's headers, so a streamed frame matches the buffered one.
+- **The C and C++ projected Arrow export includes the `symbol` column for option and index history.** The FFI column-presence carrier dropped a response's single constant root symbol, so a C or C++ projected export omitted the leading `symbol` column that Rust, Python, and TypeScript all emit for the same response. The carrier now carries the constant symbol alongside the per-row symbols, so every binding's projected frame is terminal-exact.
+- **A rejected argument raises a typed error that is still a `ValueError`.** `InvalidParameterError` now inherits from both the SDK's `ThetaDataError` root and the built-in `ValueError`, and the configuration setters and flat-file guards raise it for a rejected value. Existing `except ValueError` code keeps working unchanged, and the same argument fault is now catchable through the branded hierarchy for parity with the other bindings. An unknown `historical_type` / `streaming_type` environment selector continues to raise `ConfigError`.
+- **The Python standalone streaming client supports the context-manager protocol without blocking the event loop.** `StreamingClient` gains `with` and `async with` support that stops the stream and drains on scope exit, mirroring the TypeScript client. The async exit runs the drain on a worker thread rather than inline, so `async with` teardown no longer parks the asyncio event loop while a slow callback drains.
+- **Streaming reconnect honors a server-sent rate-limit or restart signal.** An in-session `DISCONNECTED` reason from the server (too-many-requests, server-restarting) now reaches the reconnect classifier, so the client waits out the rate-limit cooldown instead of redialing on the fast transient ladder, uses the correct reconnect budget for a server restart, and no longer sits half-open after a transient disconnect the peer did not close.
+- **Memory-safety and lifecycle hardening across the bindings.** The C++ client destructor routes through the drained teardown path so stopping a stream from inside its own callback can no longer read a destroyed callback; the record-batch stream's free contract is corrected to require serialization with a concurrent read; and the Node.js streaming client no longer deadlocks on close when a callback has fallen behind the event rate, nor leaves a silently dead stream after a `reconnect()` whose callback queue could not drain in time.
+
+## [13.0.0-rc.14] - 2026-07-03
+
+### Added
+
 - **TypeScript projected Arrow-IPC is now drivable from a live historical call.** Every columnar historical method gains a `<method>WithColumns` variant returning `{ rows, presentColumns, symbol?, symbols? }`: the same rows as the plain method plus the columns the response's wire actually carried, the broadcast root `symbol` when the response has one constant across every row, and a per-row `symbols` array when a multi-symbol snapshot varies the symbol row to row. Feed `presentColumns` plus `symbol` / `symbols` straight to `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame that omits the columns the wire omitted and attributes each row to its symbol, without hand-supplying a header list. The existing `Array<Tick>` methods are unchanged. This brings TypeScript to parity with Python's presence-carrying tick list and the C and C++ `_with_options` presence out-param.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Py
 >
 > ```bash
 > pip install --pre thetadatadx          # Python (pinned: pip install thetadatadx==13.0.0rc14)
-> npm install thetadatadx@next           # TypeScript / Node.js (pinned: npm install thetadatadx@13.0.0-rc.14)
-> cargo add thetadatadx@13.0.0-rc.14     # Rust
+> npm install thetadatadx@next           # TypeScript / Node.js (pinned: npm install thetadatadx@13.0.0-rc.15)
+> cargo add thetadatadx@13.0.0-rc.15     # Rust
 > ```
 
 Point an AI client (Claude Desktop, Cursor, and others) at the MCP server, no install and no Rust toolchain:
@@ -200,7 +200,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.14"
+thetadatadx = "13.0.0-rc.15"
 ```
 
 ```rust

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "13.0.0-rc.14"
+thetadatadx = "13.0.0-rc.15"
 ```
 
 The historical client is async; call it from your application's async runtime.

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,11 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.0-rc.14] - 2026-07-03
+## [13.0.0-rc.15] - 2026-07-04
 
 ### Added
 
 - **The MCP server now advertises only the tools the account's subscription grants.** `tools/list` previously offered every endpoint once a client connected, so an account without an options subscription still saw every option tool and the model wasted calls on tools that only ever return a not-subscribed error. Once authenticated, the server reads the per-asset-class subscription captured at connect and advertises a tool only when its asset class (stock, options, indices, interest-rate) is subscribed; a class the subscription omits contributes no tools. FREE-tier classes stay advertised because FREE grants delayed data, and the account-agnostic tools (`ping`, the trading calendar, the multi-asset flat-file dispatcher) are always offered. Each tool's description names the subscription it needs. Offline mode is unchanged: with no client, only `ping` is advertised. Gating is per asset class; finer per-endpoint minimum-tier gating is a follow-up. Closes #1123.
+
+### Fixed
+
+- **Calendar endpoints keep every column in the projected frame.** `calendar_year(...)`, `calendar_on_date(...)`, and `calendar_open_today(...)` resolved their projected column set against schema field names that the calendar wire never sends, so `to_arrow()` / `to_polars()` collapsed to a date-only frame or an empty one while the decoded response carried the full session data. The calendar column resolver now maps the wire headers to every exposed column, and a fixture-headers test pins the calendar column set.
+- **Streamed historical chunks carry the columns the wire sent, not the full schema.** A handler on `stock_history_trade(...).stream(...)` that converted a chunk to a DataFrame received fabricated columns the response never carried (seed-zeroed flag and contract-identity columns that read as data), while the buffered path for the same endpoint projected the wire's exact columns. The streaming path now derives the present columns and response symbol from each chunk's headers, so a streamed frame matches the buffered one.
+- **The C and C++ projected Arrow export includes the `symbol` column for option and index history.** The FFI column-presence carrier dropped a response's single constant root symbol, so a C or C++ projected export omitted the leading `symbol` column that Rust, Python, and TypeScript all emit for the same response. The carrier now carries the constant symbol alongside the per-row symbols, so every binding's projected frame is terminal-exact.
+- **A rejected argument raises a typed error that is still a `ValueError`.** `InvalidParameterError` now inherits from both the SDK's `ThetaDataError` root and the built-in `ValueError`, and the configuration setters and flat-file guards raise it for a rejected value. Existing `except ValueError` code keeps working unchanged, and the same argument fault is now catchable through the branded hierarchy for parity with the other bindings. An unknown `historical_type` / `streaming_type` environment selector continues to raise `ConfigError`.
+- **The Python standalone streaming client supports the context-manager protocol without blocking the event loop.** `StreamingClient` gains `with` and `async with` support that stops the stream and drains on scope exit, mirroring the TypeScript client. The async exit runs the drain on a worker thread rather than inline, so `async with` teardown no longer parks the asyncio event loop while a slow callback drains.
+- **Streaming reconnect honors a server-sent rate-limit or restart signal.** An in-session `DISCONNECTED` reason from the server (too-many-requests, server-restarting) now reaches the reconnect classifier, so the client waits out the rate-limit cooldown instead of redialing on the fast transient ladder, uses the correct reconnect budget for a server restart, and no longer sits half-open after a transient disconnect the peer did not close.
+- **Memory-safety and lifecycle hardening across the bindings.** The C++ client destructor routes through the drained teardown path so stopping a stream from inside its own callback can no longer read a destroyed callback; the record-batch stream's free contract is corrected to require serialization with a concurrent read; and the Node.js streaming client no longer deadlocks on close when a callback has fallen behind the event rate, nor leaves a silently dead stream after a `reconnect()` whose callback queue could not drain in time.
+
+## [13.0.0-rc.14] - 2026-07-03
+
+### Added
+
 - **TypeScript projected Arrow-IPC is now drivable from a live historical call.** Every columnar historical method gains a `<method>WithColumns` variant returning `{ rows, presentColumns, symbol?, symbols? }`: the same rows as the plain method plus the columns the response's wire actually carried, the broadcast root `symbol` when the response has one constant across every row, and a per-row `symbols` array when a multi-symbol snapshot varies the symbol row to row. Feed `presentColumns` plus `symbol` / `symbols` straight to `<tick>ToArrowIpcProjected` for a terminal-exact columnar frame that omits the columns the wire omitted and attributes each row to its symbol, without hand-supplying a header list. The existing `Array<Tick>` methods are unchanged. This brings TypeScript to parity with Python's presence-carrying tick list and the C and C++ `_with_options` presence out-param.
 
 ### Fixed

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -98,8 +98,8 @@ The active release line is the **13.0.0 release candidate**. It carries the late
 
 ```bash
 pip install --pre thetadatadx          # Python 3.12+ (pinned: pip install thetadatadx==13.0.0rc14)
-npm install thetadatadx@next           # Node.js 20+ (pinned: npm install thetadatadx@13.0.0-rc.14)
-cargo add thetadatadx@13.0.0-rc.14     # Rust async client
+npm install thetadatadx@next           # Node.js 20+ (pinned: npm install thetadatadx@13.0.0-rc.15)
+cargo add thetadatadx@13.0.0-rc.15     # Rust async client
 ```
 
 :::

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 13.0.0-rc.14
+  version: 13.0.0-rc.15
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arrow",
  "disruptor",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,13 +27,13 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.14"
+thetadatadx = "13.0.0-rc.15"
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "13.0.0-rc.14", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.15", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.14",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.14",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.14"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.15",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.15",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.15"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-arm64",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-darwin-x64",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "thetadatadx-mcp prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-arm64",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "thetadatadx-mcp prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-linux-x64",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "thetadatadx-mcp prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-linux-x64": "13.0.0-rc.14",
-    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.14",
-    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.14",
-    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.14",
-    "thetadatadx-mcp-win32-x64": "13.0.0-rc.14"
+    "thetadatadx-mcp-linux-x64": "13.0.0-rc.15",
+    "thetadatadx-mcp-linux-arm64": "13.0.0-rc.15",
+    "thetadatadx-mcp-darwin-x64": "13.0.0-rc.15",
+    "thetadatadx-mcp-darwin-arm64": "13.0.0-rc.15",
+    "thetadatadx-mcp-win32-x64": "13.0.0-rc.15"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-win32-x64",
-  "version": "13.0.0-rc.14",
+  "version": "13.0.0-rc.15",
   "description": "thetadatadx-mcp prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.14"
+version = "13.0.0-rc.15"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Version bump 13.0.0-rc.14 to 13.0.0-rc.15 across every pin (Cargo manifests + lockfiles, npm package.json, doc install snippets, OpenAPI version, READMEs) via scripts/release/bump_version.py plus the three prose pins the script's version= regex does not cover, with the CHANGELOG rc.15 section and its docs-site mirror. Version-sync and docs-consistency pass. Do not merge or tag until the release is approved.