### PR TITLE
Gate publishing on tag push, link greeks docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,7 +886,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     needs: [test, surfaces, sdk-bindings, build-ffi]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -936,7 +936,7 @@ jobs:
     name: GitHub Release
     runs-on: ubuntu-latest
     needs: [publish-crate, build-ffi, build-server]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -428,7 +428,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build, stubtest, fresh-install-smoke, compatibility, freethreaded, sdist]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v7
       - name: Preflight - tag matches package version

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,13 +17,13 @@ for critical issues.
 
 ## Supported Versions
 
-Security fixes land on the current major line only. Older majors are not patched; upgrade to the latest `12.x` release.
+Security fixes land on the current major line only. Older majors are not patched; upgrade to the latest `13.x` release.
 
 | Version | Supported          | Notes |
 | ------- | ------------------ | ----- |
-| 12.x    | :white_check_mark: | Current release |
-| 9.x-11.x | :x:               | Upgrade to 12.x |
-| < 9.0   | :x:                | Upgrade to 12.x |
+| 13.x    | :white_check_mark: | Current release |
+| 10.x-12.x | :x:              | Upgrade to 13.x |
+| < 10.0  | :x:                | Upgrade to 13.x |
 
 ## Security Design
 

--- a/docs-site/docs/reference/option/history/greeks/all.md
+++ b/docs-site/docs/reference/option/history/greeks/all.md
@@ -30,7 +30,7 @@ Fetch all Greeks history for an option contract (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/greeks/first-order.md
@@ -30,7 +30,7 @@ Fetch first-order Greeks history (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/greeks/implied-volatility.md
@@ -29,7 +29,7 @@ const cfg = {
 Fetch implied volatility history (intraday, sampled by interval).
 
 - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/greeks/second-order.md
@@ -30,7 +30,7 @@ Fetch second-order Greeks history (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/greeks/third-order.md
@@ -30,7 +30,7 @@ Fetch third-order Greeks history (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/trade-greeks/all.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/all.md
@@ -30,7 +30,7 @@ Fetch all Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/trade-greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/first-order.md
@@ -28,7 +28,7 @@ Fetch first-order Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
@@ -29,7 +29,7 @@ const cfg = {
 Fetch implied volatility on each trade for an option contract.
 
 - Returns implied volatilies calculated using the trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/trade-greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/second-order.md
@@ -28,7 +28,7 @@ Fetch second-order Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/history/trade-greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/third-order.md
@@ -28,7 +28,7 @@ Fetch third-order Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <RequestBuilder :cfg="cfg" />

--- a/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
@@ -28,8 +28,7 @@ Get implied volatility snapshot for an option contract (from ThetaData server).
 
 Returns implied volatilies calculated using the national best bid, mid, and ask price
 of the option respectively. The underlying price represents whatever the last underlying price was at the
-`underlying_timestamp` field. You can read more about how Theta Data calculates greeks
-here.
+`underlying_timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 
 <RequestBuilder :cfg="cfg" />
 

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -2561,8 +2561,7 @@ class HistoricalView:
 
         Returns implied volatilies calculated using the national best bid, mid, and ask price
         of the option respectively. The underlying price represents whatever the last underlying price was at the
-        ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-        here.
+        ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 
         Defaults (upstream):
         - `strike`: `"*"`
@@ -2595,8 +2594,7 @@ class HistoricalView:
 
         Returns implied volatilies calculated using the national best bid, mid, and ask price
         of the option respectively. The underlying price represents whatever the last underlying price was at the
-        ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-        here.
+        ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 
         Defaults (upstream):
         - `strike`: `"*"`
@@ -3452,7 +3450,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -3490,7 +3488,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -3540,7 +3538,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -3577,7 +3575,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -3626,7 +3624,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -3664,7 +3662,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -3714,7 +3712,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -3751,7 +3749,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -3800,7 +3798,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -3838,7 +3836,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -3888,7 +3886,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -3925,7 +3923,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -3974,7 +3972,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -4012,7 +4010,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration. 
         - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -4062,7 +4060,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -4099,7 +4097,7 @@ class HistoricalView:
 
         - Returns the data for all contracts that share the same provided symbol and expiration.
         - Calculates greeks for every trade reported by OPRA.
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -4147,7 +4145,7 @@ class HistoricalView:
         """Fetch implied volatility history (intraday, sampled by interval).
 
         - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -4184,7 +4182,7 @@ class HistoricalView:
         """Fetch implied volatility history (intraday, sampled by interval).
 
         - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data.
 
         Defaults (upstream):
@@ -4233,7 +4231,7 @@ class HistoricalView:
         """Fetch implied volatility on each trade for an option contract.
 
         - Returns implied volatilies calculated using the trade reported by OPRA. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):
@@ -4269,7 +4267,7 @@ class HistoricalView:
         """Fetch implied volatility on each trade for an option contract.
 
         - Returns implied volatilies calculated using the trade reported by OPRA. 
-        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+        - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
         - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
         Defaults (upstream):

--- a/thetadatadx-py/src/_generated/historical_methods.rs
+++ b/thetadatadx-py/src/_generated/historical_methods.rs
@@ -3735,8 +3735,7 @@ impl OptionSnapshotMarketValueBuilder {
 ///
 /// Returns implied volatilies calculated using the national best bid, mid, and ask price
 /// of the option respectively. The underlying price represents whatever the last underlying price was at the
-/// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-/// here.
+/// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 ///
 /// Defaults (upstream):
 /// - `strike`: `"*"`
@@ -7616,7 +7615,7 @@ impl OptionHistoryGreeksEodBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -8101,7 +8100,7 @@ impl OptionHistoryGreeksAllBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
 /// - Calculates greeks for every trade reported by OPRA.
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -8585,7 +8584,7 @@ impl OptionHistoryTradeGreeksAllBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -9070,7 +9069,7 @@ impl OptionHistoryGreeksFirstOrderBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
 /// - Calculates greeks for every trade reported by OPRA.
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -9554,7 +9553,7 @@ impl OptionHistoryTradeGreeksFirstOrderBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -10039,7 +10038,7 @@ impl OptionHistoryGreeksSecondOrderBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
 /// - Calculates greeks for every trade reported by OPRA.
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -10523,7 +10522,7 @@ impl OptionHistoryTradeGreeksSecondOrderBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -11008,7 +11007,7 @@ impl OptionHistoryGreeksThirdOrderBuilder {
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
 /// - Calculates greeks for every trade reported by OPRA.
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -11491,7 +11490,7 @@ impl OptionHistoryTradeGreeksThirdOrderBuilder {
 /// Fetch implied volatility history (intraday, sampled by interval).
 ///
 /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -11975,7 +11974,7 @@ impl OptionHistoryGreeksImpliedVolatilityBuilder {
 /// Fetch implied volatility on each trade for an option contract.
 ///
 /// - Returns implied volatilies calculated using the trade reported by OPRA. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -17454,8 +17453,7 @@ impl HistoricalView {
     ///
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
-    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// here.
+    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -17527,8 +17525,7 @@ impl HistoricalView {
     ///
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
-    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// here.
+    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -19444,7 +19441,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19524,7 +19521,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19645,7 +19642,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -19724,7 +19721,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -19844,7 +19841,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19924,7 +19921,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20045,7 +20042,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20124,7 +20121,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20244,7 +20241,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20324,7 +20321,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20445,7 +20442,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20524,7 +20521,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20644,7 +20641,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20724,7 +20721,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20845,7 +20842,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20924,7 +20921,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -21043,7 +21040,7 @@ impl HistoricalView {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -21122,7 +21119,7 @@ impl HistoricalView {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -21242,7 +21239,7 @@ impl HistoricalView {
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by OPRA. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -21320,7 +21317,7 @@ impl HistoricalView {
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by OPRA. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):

--- a/thetadatadx-rs/endpoint_surface.toml
+++ b/thetadatadx-rs/endpoint_surface.toml
@@ -1386,8 +1386,7 @@ description = "Get implied volatility snapshot for an option contract (from Thet
 vendor_docstring = """
 Returns implied volatilies calculated using the national best bid, mid, and ask price
 of the option respectively. The underlying price represents whatever the last underlying price was at the
-``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-here.
+``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 """
 rest_path = "/v3/option/snapshot/greeks/implied_volatility"
 returns = "IvTicks"
@@ -1530,7 +1529,7 @@ description = "Fetch all Greeks history for an option contract (intraday, sample
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/all"
@@ -1543,7 +1542,7 @@ description = "Fetch all Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/all"
@@ -1556,7 +1555,7 @@ description = "Fetch first-order Greeks history (intraday, sampled by interval).
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/first_order"
@@ -1569,7 +1568,7 @@ description = "Fetch first-order Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/first_order"
@@ -1582,7 +1581,7 @@ description = "Fetch second-order Greeks history (intraday, sampled by interval)
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/second_order"
@@ -1595,7 +1594,7 @@ description = "Fetch second-order Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/second_order"
@@ -1608,7 +1607,7 @@ description = "Fetch third-order Greeks history (intraday, sampled by interval).
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
 - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/third_order"
@@ -1621,7 +1620,7 @@ description = "Fetch third-order Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
 - Calculates greeks for every trade reported by OPRA.
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/third_order"
@@ -1633,7 +1632,7 @@ template = "option_history_greeks"
 description = "Fetch implied volatility history (intraday, sampled by interval)."
 vendor_docstring = """
 - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/implied_volatility"
@@ -1645,7 +1644,7 @@ template = "option_history_trade_greeks"
 description = "Fetch implied volatility on each trade for an option contract."
 vendor_docstring = """
 - Returns implied volatilies calculated using the trade reported by OPRA. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/implied_volatility"

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -1149,8 +1149,7 @@ export declare class HistoricalClient {
    *
    * Returns implied volatilies calculated using the national best bid, mid, and ask price
    * of the option respectively. The underlying price represents whatever the last underlying price was at the
-   * ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks
-   * here.
+   * ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -1360,7 +1359,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1382,7 +1381,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1403,7 +1402,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1425,7 +1424,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1446,7 +1445,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1468,7 +1467,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1489,7 +1488,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1511,7 +1510,7 @@ export declare class HistoricalClient {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1531,7 +1530,7 @@ export declare class HistoricalClient {
    * Fetch implied volatility history (intraday, sampled by interval).
    *
    * - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1552,7 +1551,7 @@ export declare class HistoricalClient {
    * Fetch implied volatility on each trade for an option contract.
    *
    * - Returns implied volatilies calculated using the trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2077,8 +2076,7 @@ export declare class HistoricalView {
    *
    * Returns implied volatilies calculated using the national best bid, mid, and ask price
    * of the option respectively. The underlying price represents whatever the last underlying price was at the
-   * ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks
-   * here.
+   * ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -2288,7 +2286,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2310,7 +2308,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2331,7 +2329,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2353,7 +2351,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2374,7 +2372,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2396,7 +2394,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2417,7 +2415,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2439,7 +2437,7 @@ export declare class HistoricalView {
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
    * - Calculates greeks for every trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2459,7 +2457,7 @@ export declare class HistoricalView {
    * Fetch implied volatility history (intraday, sampled by interval).
    *
    * - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2480,7 +2478,7 @@ export declare class HistoricalView {
    * Fetch implied volatility on each trade for an option contract.
    *
    * - Returns implied volatilies calculated using the trade reported by OPRA.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):

--- a/thetadatadx-ts/src/_generated/historical_methods.rs
+++ b/thetadatadx-ts/src/_generated/historical_methods.rs
@@ -4351,8 +4351,7 @@ impl HistoricalView {
     ///
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
-    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// here.
+    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -6661,7 +6660,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -6935,7 +6934,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -7208,7 +7207,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -7482,7 +7481,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -7755,7 +7754,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -8029,7 +8028,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -8302,7 +8301,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -8576,7 +8575,7 @@ impl HistoricalView {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -8848,7 +8847,7 @@ impl HistoricalView {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -9121,7 +9120,7 @@ impl HistoricalView {
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by OPRA. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -13394,8 +13393,7 @@ impl HistoricalClient {
     ///
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
-    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// here.
+    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -15704,7 +15702,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15978,7 +15976,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -16251,7 +16249,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -16525,7 +16523,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -16798,7 +16796,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -17072,7 +17070,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -17345,7 +17343,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -17619,7 +17617,7 @@ impl HistoricalClient {
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
     /// - Calculates greeks for every trade reported by OPRA.
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -17891,7 +17889,7 @@ impl HistoricalClient {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -18164,7 +18162,7 @@ impl HistoricalClient {
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by OPRA. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):


### PR DESCRIPTION
## Summary

Two small fixes found while going over the tree ahead of the 13.0 line. Neither touches the streaming or historical data path.

## CI: publish only on a real tag push

`publish-crate`, the GitHub Release job, and the PyPI publish job gated only on `refs/tags/v*`. A `workflow_dispatch` run pointed at a tag ref would satisfy that condition and could ship an irreversible crates.io or PyPI upload outside a tag push. These now also require `github.event_name == 'push'`, matching the guard the TypeScript and MCP-npm publish jobs already carry.

## Docs

The generated greeks reference pages ended on "read more ... here" with no link, though the option-greeks article exists. They now link to it, fixed at the endpoint-surface source and regenerated across every binding and doc page. The security policy's supported-versions line moves to 13.x.

## Verification

- SDK-surface and docs-site generators report no drift.
- Rustdoc intra-doc link gate passes on the regenerated greeks pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
