### PR TITLE
Make thetadatadx-server an exact terminal drop-in: rate limiting, system routes, WebSocket wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **`thetadatadx-server` no longer applies its own per-IP request rate limit.** The bundled REST and WebSocket server is a drop-in for a terminal that does no per-IP rate limiting, and request limits are enforced upstream by the data service, so the server no longer adds its own. The opt-in general governor (`THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`) and the shutdown-route attempt limiter are gone; `/v3/system/shutdown` stays guarded by the `X-Shutdown-Token` header, and the request body-size and in-flight concurrency caps are unchanged.
+
 ## [13.0.0-rc.15] - 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`thetadatadx-server` system routes now mirror the ThetaData terminal 1:1.** The server exposes exactly the terminal's three unauthenticated `GET /v3/terminal/*` routes — `shutdown` (returns the plain text `OK` and kills the process), `fpss/status`, and `mdds/status` (one-word `text/plain` channel health) — so a client written against the documented terminal surface works unchanged. The previously invented `/v3/system/*` status routes, the token-gated `POST /v3/system/shutdown`, the `X-Shutdown-Token` machinery, and the non-terminal `/v3/terminal/{streaming,historical}/status` aliases are removed.
+
 ### Removed
 
-- **`thetadatadx-server` no longer applies its own per-IP request rate limit.** The bundled REST and WebSocket server is a drop-in for a terminal that does no per-IP rate limiting, and request limits are enforced upstream by the data service, so the server no longer adds its own. The opt-in general governor (`THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`) and the shutdown-route attempt limiter are gone; `/v3/system/shutdown` stays guarded by the `X-Shutdown-Token` header, and the request body-size and in-flight concurrency caps are unchanged.
+- **`thetadatadx-server` no longer applies its own per-IP request rate limit.** The bundled REST and WebSocket server is a drop-in for a terminal that does no per-IP rate limiting, and request limits are enforced upstream by the data service, so the server no longer adds its own. The opt-in general governor (`THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`) and the shutdown-route attempt limiter are gone; the request body-size and in-flight concurrency caps are unchanged.
 
 ## [13.0.0-rc.15] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`thetadatadx-server`'s WebSocket wire format now matches the terminal 1:1.** On the WebSocket, an option `strike` defaults to the terminal's 1/10-cent integer (a $570 strike is `570000`) on both the subscribe input and the event output; the new `--strike-format dollars` flag switches it back to a dollar value for the SDK's convenience form. Every message header now carries the streaming-channel connectivity `status` (`CONNECTED` / `DISCONNECTED`), not only the per-second `STATUS` heartbeat. The native SDK bindings still expose `strike` in dollars on `event.contract` — only the server's WebSocket wire changed.
 - **`thetadatadx-server` system routes now mirror the ThetaData terminal 1:1.** The server exposes exactly the terminal's three unauthenticated `GET /v3/terminal/*` routes — `shutdown` (returns the plain text `OK` and kills the process), `fpss/status`, and `mdds/status` (one-word `text/plain` channel health) — so a client written against the documented terminal surface works unchanged. The previously invented `/v3/system/*` status routes, the token-gated `POST /v3/system/shutdown`, the `X-Shutdown-Token` machinery, and the non-terminal `/v3/terminal/{streaming,historical}/status` aliases are removed.
 
 ### Removed

--- a/docs-site/docs/articles/error-codes.md
+++ b/docs-site/docs/articles/error-codes.md
@@ -55,5 +55,4 @@ The [HTTP server](/server/http) reports every failure with one envelope shape an
 |---|---|---|
 | 400 | `bad_request` | Missing or invalid parameter; the message names it. |
 | 404 | `not_found` | Unknown route. |
-| 429 | — | Opt-in per-IP rate limit (off by default; enabled via `THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`); carries `Retry-After`. |
 | 503 | `upstream_exhausted` | Upstream capacity exhausted after retries; carries `Retry-After`. |

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **`thetadatadx-server` no longer applies its own per-IP request rate limit.** The bundled REST and WebSocket server is a drop-in for a terminal that does no per-IP rate limiting, and request limits are enforced upstream by the data service, so the server no longer adds its own. The opt-in general governor (`THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`) and the shutdown-route attempt limiter are gone; `/v3/system/shutdown` stays guarded by the `X-Shutdown-Token` header, and the request body-size and in-flight concurrency caps are unchanged.
+
 ## [13.0.0-rc.15] - 2026-07-04
 
 ### Added

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`thetadatadx-server` system routes now mirror the ThetaData terminal 1:1.** The server exposes exactly the terminal's three unauthenticated `GET /v3/terminal/*` routes — `shutdown` (returns the plain text `OK` and kills the process), `fpss/status`, and `mdds/status` (one-word `text/plain` channel health) — so a client written against the documented terminal surface works unchanged. The previously invented `/v3/system/*` status routes, the token-gated `POST /v3/system/shutdown`, the `X-Shutdown-Token` machinery, and the non-terminal `/v3/terminal/{streaming,historical}/status` aliases are removed.
+
 ### Removed
 
-- **`thetadatadx-server` no longer applies its own per-IP request rate limit.** The bundled REST and WebSocket server is a drop-in for a terminal that does no per-IP rate limiting, and request limits are enforced upstream by the data service, so the server no longer adds its own. The opt-in general governor (`THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`) and the shutdown-route attempt limiter are gone; `/v3/system/shutdown` stays guarded by the `X-Shutdown-Token` header, and the request body-size and in-flight concurrency caps are unchanged.
+- **`thetadatadx-server` no longer applies its own per-IP request rate limit.** The bundled REST and WebSocket server is a drop-in for a terminal that does no per-IP rate limiting, and request limits are enforced upstream by the data service, so the server no longer adds its own. The opt-in general governor (`THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE`) and the shutdown-route attempt limiter are gone; the request body-size and in-flight concurrency caps are unchanged.
 
 ## [13.0.0-rc.15] - 2026-07-04
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`thetadatadx-server`'s WebSocket wire format now matches the terminal 1:1.** On the WebSocket, an option `strike` defaults to the terminal's 1/10-cent integer (a $570 strike is `570000`) on both the subscribe input and the event output; the new `--strike-format dollars` flag switches it back to a dollar value for the SDK's convenience form. Every message header now carries the streaming-channel connectivity `status` (`CONNECTED` / `DISCONNECTED`), not only the per-second `STATUS` heartbeat. The native SDK bindings still expose `strike` in dollars on `event.contract` — only the server's WebSocket wire changed.
 - **`thetadatadx-server` system routes now mirror the ThetaData terminal 1:1.** The server exposes exactly the terminal's three unauthenticated `GET /v3/terminal/*` routes — `shutdown` (returns the plain text `OK` and kills the process), `fpss/status`, and `mdds/status` (one-word `text/plain` channel health) — so a client written against the documented terminal surface works unchanged. The previously invented `/v3/system/*` status routes, the token-gated `POST /v3/system/shutdown`, the `X-Shutdown-Token` machinery, and the non-terminal `/v3/terminal/{streaming,historical}/status` aliases are removed.
 
 ### Removed

--- a/docs-site/docs/migration/v12-to-v13.md
+++ b/docs-site/docs/migration/v12-to-v13.md
@@ -23,7 +23,7 @@ v13 renames the client-facing surface to role-based names, sorts every endpoint 
 | Env vars | `THETADATA_MDDS_*` / `THETADATA_FPSS_*` → `THETADATA_HISTORICAL_*` / `THETADATA_STREAMING_*` | Rename the exported variables |
 | Environment selector | One combined selector → `HistoricalEnvironment` (`Prod`/`Stage`) + `StreamingEnvironment` (`Prod`/`Dev`); `THETADATA_MDDS_TYPE` / `FPSS_TYPE` → `THETADATA_HISTORICAL_TYPE` / `STREAMING_TYPE` | Select per channel (`stage()` / `dev()` presets or `with_historical_environment` / `with_streaming_environment`); invalid/cross-channel values now error |
 | Server region flags | `--mdds-region` / `--fpss-region` → `--historical-region` / `--streaming-region` | Update server invocations; `--streaming-region` drops `stage` |
-| System status routes | `/v3/system/mdds/status` / `/v3/system/fpss/status` → `/v3/system/historical/status` / `/v3/system/streaming/status` | Repoint health checks |
+| Server system routes | The `/v3/system/*` status and shutdown routes are removed; the server now mirrors the terminal's `/v3/terminal/*` surface 1:1 | Repoint health checks to `GET /v3/terminal/fpss/status` / `mdds/status`; shut down via `GET /v3/terminal/shutdown` (unauthenticated, no `X-Shutdown-Token`) |
 | Streaming error variant | Rust `Error::Fpss` → `Error::Stream`; C constants `THETADATADX_FPSS_*` → `THETADATADX_STREAM_*` | Rename match arms / `switch` labels; recompile |
 | Flat-file surface | Restricted to the 5 vendor datasets | Drop `option_quote` / `option_trade` / `option_ohlc` / `stock_quote` / `stock_trade`; use the historical endpoints |
 | `Contract.option(...)` | Three positional strings → one named form | Pass an `OptionLeg` / named object / designated initializer |
@@ -309,9 +309,9 @@ The selector environment variables follow the same split: `THETADATA_HISTORICAL_
 
 The bundled server CLI renames its region flags to match: `--historical-region {production,stage}` and `--streaming-region {production,dev}` (were `--mdds-region` / `--fpss-region`); `--streaming-region` no longer accepts `stage`.
 
-## System status routes are named by channel
+## Server system routes mirror the terminal 1:1
 
-The server's per-channel status routes are renamed to the channel they report: `GET /v3/system/historical/status` and `GET /v3/system/streaming/status` (were `/v3/system/mdds/status` and `/v3/system/fpss/status`). Repoint any health-check or monitoring that polls them; the combined `GET /v3/system/status` is unchanged.
+The bundled server now exposes exactly the JVM terminal's system surface and nothing else: `GET /v3/terminal/shutdown` (kills the process, returns the plain text `OK`), `GET /v3/terminal/fpss/status` (streaming-channel health), and `GET /v3/terminal/mdds/status` (historical-channel health), all unauthenticated with bare `text/plain` bodies. The previous `/v3/system/*` status routes and the token-gated `POST /v3/system/shutdown` are removed. Repoint any health-check or monitoring that polled the `/v3/system/*` routes to the `/v3/terminal/*` equivalents, and shut the server down with `GET /v3/terminal/shutdown` (no `X-Shutdown-Token` header).
 
 ## The streaming error variant is named by channel
 

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -3221,7 +3221,6 @@ paths:
         Initiates a graceful shutdown of the thetadatadx server.
         Requires a valid `X-Shutdown-Token` header (a 128-bit hex token, 32
         lowercase hex characters, printed to stderr on server startup).
-        Rate-limited to ~3 attempts per hour per client IP.
       security:
         - shutdownToken: []
       responses:
@@ -3229,8 +3228,6 @@ paths:
           description: Shutdown initiated
         '401':
           description: Missing or invalid token
-        '429':
-          description: Too many attempts (rate-limited)
 
   # =========================================================================
   # TERMINAL (drop-in management compatibility)
@@ -3514,8 +3511,7 @@ components:
       name: X-Shutdown-Token
       description: |
         A 128-bit hex token (32 lowercase hex characters) printed to stderr on
-        server startup. Required on the `/v3/system/shutdown` POST endpoint.
-        Rate-limited to ~3 attempts per hour per client IP. See
+        server startup. Required on the `/v3/system/shutdown` POST endpoint. See
         `tools/server/README.md`.
 
   schemas:

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -65,10 +65,9 @@ tags:
   - name: Flat Files
     description: Whole-universe daily flat-file downloads (CSV or JSON Lines)
 
-# No global security requirement: the server authenticates its upstream
-# connection once at startup, and request paths carry no per-request
-# credential. The only route-scoped requirement is the shutdown token on
-# POST /v3/system/shutdown.
+# No security requirement: the server authenticates its upstream connection
+# once at startup, and request paths carry no per-request credential — matching
+# the terminal, whose local routes (including shutdown) are all unauthenticated.
 
 # ---------------------------------------------------------------------------
 # Reusable anchors for common parameter/schema objects
@@ -3118,163 +3117,66 @@ paths:
             auto rates = client.historical().interest_rate_history_eod("SOFR", "20240101", "20240301");
 
   # =========================================================================
-  # SYSTEM
+  # TERMINAL SYSTEM
   # =========================================================================
+  # Mirrored 1:1 from the JVM terminal this server replaces: three
+  # unauthenticated GET routes with bare `text/plain` bodies, so operator
+  # tooling written against the terminal's mgmt surface works unchanged.
 
-  /v3/system/status:
+  /v3/terminal/shutdown:
     get:
-      operationId: systemStatus
-      tags: [System]
-      summary: Server status
+      operationId: terminalShutdown
+      tags: [Terminal]
+      summary: Shut down the server
       description: |
-        Reports overall server health: the upstream data connection state and
-        the running server version.
+        Kills the server process, matching the JVM terminal. Unauthenticated;
+        returns the plain-text body `OK`.
       parameters: []
       responses:
         '200':
-          description: Server status
+          description: Shutdown initiated.
           content:
-            application/json:
+            text/plain:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    enum: [CONNECTED, DISCONNECTED]
-                    description: Upstream data connection state.
-                  version:
-                    type: string
-                    description: Running server version.
+                type: string
+                enum: [OK]
 
-  /v3/system/historical/status:
-    get:
-      operationId: systemHistoricalStatus
-      tags: [System]
-      summary: Historical data connection status
-      description: |
-        Reports the historical data connection state wrapped in the standard
-        response envelope.
-      parameters: []
-      responses:
-        '200':
-          description: Historical data connection status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  header:
-                    type: object
-                    properties:
-                      format:
-                        type: string
-                        enum: [json]
-                      error_type:
-                        type: string
-                        enum: ['null']
-                  response:
-                    type: array
-                    items:
-                      type: string
-                      enum: [CONNECTED, DISCONNECTED]
-                    description: Single-element array with the connection state.
-
-  /v3/system/streaming/status:
-    get:
-      operationId: systemStreamingStatus
-      tags: [System]
-      summary: Streaming connection status
-      description: |
-        Reports the streaming connection state, the running server version, and
-        two back-pressure counters operators can scrape to detect dropped
-        events without tailing logs.
-      parameters: []
-      responses:
-        '200':
-          description: Streaming connection status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    enum: [CONNECTED, DISCONNECTED]
-                    description: Streaming connection state.
-                  version:
-                    type: string
-                    description: Running server version.
-                  broadcast_dropped:
-                    type: integer
-                    format: int64
-                    description: Total streaming events dropped on the internal handoff since startup.
-                  json_serialize_failures:
-                    type: integer
-                    format: int64
-                    description: Total streaming-event serialization failures since startup.
-
-  /v3/system/shutdown:
-    post:
-      tags: [System]
-      summary: Graceful server shutdown
-      description: |
-        Initiates a graceful shutdown of the thetadatadx server.
-        Requires a valid `X-Shutdown-Token` header (a 128-bit hex token, 32
-        lowercase hex characters, printed to stderr on server startup).
-      security:
-        - shutdownToken: []
-      responses:
-        '200':
-          description: Shutdown initiated
-        '401':
-          description: Missing or invalid token
-
-  # =========================================================================
-  # TERMINAL (drop-in management compatibility)
-  # =========================================================================
-  # These routes mirror the management status paths the Theta Terminal serves,
-  # so operator tooling that scrapes the terminal's mgmt surface works against
-  # this server unchanged. Each returns a one-word `text/plain` body
-  # (CONNECTED / DISCONNECTED) — the plain-text sibling of the JSON
-  # /v3/system/{streaming,historical}/status routes above.
-
-  /v3/terminal/streaming/status:
+  /v3/terminal/fpss/status:
     get:
       operationId: terminalStreamingStatus
       tags: [Terminal]
-      summary: Streaming connection status (text/plain)
+      summary: Streaming channel status (text/plain)
       description: |
-        Terminal-compatible streaming connection status as a bare `text/plain`
-        body. Returns `CONNECTED` or `DISCONNECTED` — the plain-text sibling of
-        the JSON `/v3/system/streaming/status` route.
+        Streaming channel health as the terminal's one-word `text/plain`
+        body.
       parameters: []
       responses:
         '200':
-          description: Streaming connection state as a one-word plain-text body.
+          description: Streaming channel state as a one-word plain-text body.
           content:
             text/plain:
               schema:
                 type: string
                 enum: [CONNECTED, DISCONNECTED]
 
-  /v3/terminal/historical/status:
+  /v3/terminal/mdds/status:
     get:
       operationId: terminalHistoricalStatus
       tags: [Terminal]
-      summary: Historical connection status (text/plain)
+      summary: Historical channel status (text/plain)
       description: |
-        Terminal-compatible historical connection status as a bare `text/plain`
-        body. Returns `CONNECTED` or `DISCONNECTED` — the plain-text sibling of
-        the JSON `/v3/system/historical/status` route.
+        Historical channel health as the terminal's one-word `text/plain`
+        body.
       parameters: []
       responses:
         '200':
-          description: Historical connection state as a one-word plain-text body.
+          description: Historical channel state as a one-word plain-text body.
           content:
             text/plain:
               schema:
                 type: string
                 enum: [CONNECTED, DISCONNECTED]
+
 
   # =========================================================================
   # FLAT FILES
@@ -3504,15 +3406,6 @@ paths:
 # COMPONENTS
 # ---------------------------------------------------------------------------
 components:
-  securitySchemes:
-    shutdownToken:
-      type: apiKey
-      in: header
-      name: X-Shutdown-Token
-      description: |
-        A 128-bit hex token (32 lowercase hex characters) printed to stderr on
-        server startup. Required on the `/v3/system/shutdown` POST endpoint. See
-        `tools/server/README.md`.
 
   schemas:
     OhlcTick: *ohlc-tick

--- a/docs-site/docs/server/http.md
+++ b/docs-site/docs/server/http.md
@@ -61,14 +61,15 @@ curl -X POST 'http://127.0.0.1:25503/v3/flatfile/request' \
 
 See [Flat Files](/articles/flat-files) for sizing guidance.
 
-## System routes
+## Terminal system routes
+
+Mirrored 1:1 from the JVM terminal — unauthenticated `GET`, bare `text/plain` bodies.
 
 | Method | Route | Description |
 |---|---|---|
-| `GET` | `/v3/system/status` | Combined server status. |
-| `GET` | `/v3/system/historical/status` | Historical-channel connection status. |
-| `GET` | `/v3/system/streaming/status` | Streaming connection status. |
-| `POST` | `/v3/system/shutdown` | Graceful shutdown; requires the `X-Shutdown-Token` header printed at startup. |
+| `GET` | `/v3/terminal/shutdown` | Kills the server process; returns the plain text `OK`. |
+| `GET` | `/v3/terminal/fpss/status` | Streaming-channel health: `CONNECTED` / `DISCONNECTED`. |
+| `GET` | `/v3/terminal/mdds/status` | Historical-channel health: `CONNECTED` / `DISCONNECTED`. |
 
 ## Concurrency behavior
 

--- a/docs-site/docs/server/index.md
+++ b/docs-site/docs/server/index.md
@@ -85,8 +85,6 @@ thetadatadx-server --creds creds.txt
 | `THETADATA_API_KEY` | — | API key used for authentication when `--api-key` is not passed. An explicit `--api-key` flag wins over this; both win over the email/password path. The key is never logged or echoed. |
 | `THETADATA_EMAIL` | — | Account email. With `THETADATA_PASSWORD`, authenticates the server when no API key is supplied. Outranked by `--api-key` and `THETADATA_API_KEY`; wins over the `--creds` file. |
 | `THETADATA_PASSWORD` | — | Account password, paired with `THETADATA_EMAIL`. Never logged or echoed. |
-| `THETADATADX_RATE_LIMIT_PER_SECOND` | — (off) | Opt into per-IP rate limiting at this many requests per second. Setting either rate-limit variable turns the limiter on; see [Security defaults](#security-defaults). |
-| `THETADATADX_RATE_LIMIT_BURST_SIZE` | — (off) | Burst size for the per-IP rate limiter. If you set only one of the two rate-limit variables, the other falls back to `20` req/s / `40` burst. |
 | `THETADATADX_WS_CLIENT_CAPACITY` | `4096` | Per-client WebSocket send-buffer capacity in events. A larger buffer trades memory for more headroom before a slow consumer starts dropping events; invalid or zero values keep the default. |
 
 ## Logging
@@ -97,6 +95,6 @@ thetadatadx-server --creds creds.txt
 
 ## Security defaults
 
-- Binds all interfaces by default; pass `--bind 127.0.0.1` for loopback-only exposure. Per-IP rate limiting is **off by default** — the server imposes no per-IP limit, matching the terminal it replaces. Operators exposing the server as a relay opt in by setting `THETADATADX_RATE_LIMIT_PER_SECOND` and/or `THETADATADX_RATE_LIMIT_BURST_SIZE`; once on, excess traffic from a single IP is answered with `429` and `Retry-After`, on both the HTTP routes and the WebSocket upgrade.
+- Binds all interfaces by default; pass `--bind 127.0.0.1` for loopback-only exposure. The server imposes no per-IP rate limit, matching the terminal it replaces — request limits are enforced upstream by the data service.
 - `POST /v3/system/shutdown` requires the `X-Shutdown-Token` header — a random token printed once to stderr at startup; there is no flag or environment variable to set it.
 - Request bodies are capped at 64 KiB and query strings at 32 parameters.

--- a/docs-site/docs/server/index.md
+++ b/docs-site/docs/server/index.md
@@ -96,5 +96,5 @@ thetadatadx-server --creds creds.txt
 ## Security defaults
 
 - Binds all interfaces by default; pass `--bind 127.0.0.1` for loopback-only exposure. The server imposes no per-IP rate limit, matching the terminal it replaces — request limits are enforced upstream by the data service.
-- `POST /v3/system/shutdown` requires the `X-Shutdown-Token` header — a random token printed once to stderr at startup; there is no flag or environment variable to set it.
+- The system routes mirror the terminal 1:1 and are unauthenticated, including `GET /v3/terminal/shutdown` — exactly as the terminal exposes them.
 - Request bodies are capped at 64 KiB and query strings at 32 parameters.

--- a/docs-site/docs/server/index.md
+++ b/docs-site/docs/server/index.md
@@ -77,6 +77,7 @@ thetadatadx-server --creds creds.txt
 | `--log-file <path>` | — | Also write logs to `<path>.YYYY-MM-DD`, rotated daily. |
 | `--log-format <fmt>` | `text` | `text`, `json` (one object per line), or `legacy` (`[YYYY-MM-DD HH:MM:SS] LEVEL: message`, UTC). |
 | `--no-streaming` | — | Skip streaming startup (HTTP only). |
+| `--strike-format <fmt>` | `terminal` | WebSocket option-strike encoding: `terminal` (the terminal's 1/10-cent integer, the exact drop-in) or `dollars` (a dollar value, the SDK's convenience form). |
 
 ## Environment variables
 

--- a/docs-site/docs/server/websocket.md
+++ b/docs-site/docs/server/websocket.md
@@ -28,10 +28,10 @@ The server bridges [streaming](/streaming/) onto a local WebSocket at `ws://127.
 | `id` | Your request id; echoed in the acknowledgement |
 | `contract` | Omit for `FULL_*` streams |
 
-Option contracts carry the four-tuple, with the strike in **dollars** (a JSON number, e.g. `570` or `570.0`):
+Option contracts carry the four-tuple. By default the `strike` is the terminal's 1/10-cent integer (a JSON integer, e.g. `570000` for a $570 strike); pass the server's `--strike-format dollars` flag to take a dollar value (`570`) instead:
 
 ```json
-{"symbol": "SPY", "expiration": 20250321, "strike": 570, "right": "C"}
+{"symbol": "SPY", "expiration": 20250321, "strike": 570000, "right": "C"}
 ```
 
 `{"msg_type": "STOP", "id": 2}` removes every active stream at once. Each command is acknowledged with a stream-request verification value in the `response` field:
@@ -50,7 +50,7 @@ Events arrive as JSON with a `header.type` of `QUOTE`, `TRADE`, or `OHLC`, plus 
 
 ```bash
 websocat ws://127.0.0.1:25520/v1/events
-{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "TRADE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20250321, "strike": 570, "right": "C"}}
+{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "TRADE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20250321, "strike": 570000, "right": "C"}}
 ```
 
 ## Limits

--- a/docs-site/docs/streaming/events.md
+++ b/docs-site/docs/streaming/events.md
@@ -139,7 +139,7 @@ Data events carry a resolved, typed contract — read identity straight off the 
 | `sec_type` | string | `STOCK` / `OPTION` / `INDEX` / `RATE`. |
 | `expiration` | int? | `YYYYMMDD`; options only. |
 | `right` | string? | `C` / `P`; options only. |
-| `strike` | float? | Strike in dollars; options only — the same unit historical rows carry under the same name (Rust exposes `strike_dollars()` over the codec integer; the C ABI field is dollars). |
+| `strike` | int? | Over the server's WebSocket, the terminal's 1/10-cent integer (a $570 strike is `570000`), matching the terminal wire; options only. The native SDK bindings resolve it to dollars on `event.contract` (Rust `strike_dollars()`; the C ABI field is dollars). |
 
 ## Control events
 

--- a/docs-site/docs/streaming/options/full-trade.md
+++ b/docs-site/docs/streaming/options/full-trade.md
@@ -162,7 +162,7 @@ quote  QQQ 20231110 P 360.00  (next NBBO)
 ```
 
 
-The `Ohlcvc` bar and the trailing `Quote` updates carry the same `contract`. On the wire ThetaData encodes the option strike in tenths of a cent (a $360.00 strike as `3600000`); the SDK resolves it to the dollar strike on `event.contract`.
+The `Ohlcvc` bar and the trailing `Quote` updates carry the same `contract`. ThetaData encodes the option strike in tenths of a cent (a $360.00 strike as `360000`); the server's WebSocket emits that integer verbatim by default, while the native SDK resolves it to the dollar strike on `event.contract`.
 
 ## OHLC bars
 
@@ -172,7 +172,7 @@ The `Ohlcvc` bars on this stream come from upstream automatically — one is sen
 
 - This stream requires an Options Pro subscription.
 - Each new stream request must use a higher `id` than the last; reusing an `id` stops the terminal from automatically resubscribing your earlier streams after a reconnect. The SDK manages the `id` for you; the WebSocket envelope sets it explicitly.
-- The WebSocket envelope and the SDK builders take the option strike in dollars; the tenths-of-a-cent wire encoding is internal.
+- The server's WebSocket envelope takes the option strike as the terminal's 1/10-cent integer by default (`--strike-format dollars` switches to a dollar value); the native SDK builders take dollars.
 
 ## `Quote` event fields
 

--- a/docs-site/docs/streaming/options/market-value.md
+++ b/docs-site/docs/streaming/options/market-value.md
@@ -106,10 +106,10 @@ WebSocket streaming from the bundled [server binary](/server/). Send one JSON en
 
 ```bash
 websocat ws://127.0.0.1:25520/v1/events
-{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "MARKET_VALUE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}}
+{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "MARKET_VALUE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}}
 ```
 
-The WebSocket envelope takes the strike in dollars (`570` = $570.00), the same as the SDKs.
+The WebSocket envelope takes the strike as the terminal's 1/10-cent integer (`570000` = $570.00) by default, matching the terminal wire; pass the server's `--strike-format dollars` flag to use a dollar value instead. The native SDK builders take dollars.
 
 </template>
 

--- a/docs-site/docs/streaming/options/open-interest.md
+++ b/docs-site/docs/streaming/options/open-interest.md
@@ -112,10 +112,10 @@ WebSocket streaming from the bundled [server binary](/server/). Send one JSON en
 
 ```bash
 websocat ws://127.0.0.1:25520/v1/events
-{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "OPEN_INTEREST", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}}
+{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "OPEN_INTEREST", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}}
 ```
 
-The WebSocket envelope takes the strike in dollars (`570` = $570.00), the same as the SDKs.
+The WebSocket envelope takes the strike as the terminal's 1/10-cent integer (`570000` = $570.00) by default, matching the terminal wire; pass the server's `--strike-format dollars` flag to use a dollar value instead. The native SDK builders take dollars.
 
 </template>
 

--- a/docs-site/docs/streaming/options/quote.md
+++ b/docs-site/docs/streaming/options/quote.md
@@ -106,10 +106,10 @@ WebSocket streaming from the bundled [server binary](/server/). Send one JSON en
 
 ```bash
 websocat ws://127.0.0.1:25520/v1/events
-{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "QUOTE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}}
+{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "QUOTE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}}
 ```
 
-The WebSocket envelope takes the strike in dollars (`570` = $570.00), the same as the SDKs.
+The WebSocket envelope takes the strike as the terminal's 1/10-cent integer (`570000` = $570.00) by default, matching the terminal wire; pass the server's `--strike-format dollars` flag to use a dollar value instead. The native SDK builders take dollars.
 
 </template>
 

--- a/docs-site/docs/streaming/options/trade.md
+++ b/docs-site/docs/streaming/options/trade.md
@@ -106,10 +106,10 @@ WebSocket streaming from the bundled [server binary](/server/). Send one JSON en
 
 ```bash
 websocat ws://127.0.0.1:25520/v1/events
-{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "TRADE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}}
+{"msg_type": "STREAM", "sec_type": "OPTION", "req_type": "TRADE", "id": 1, "add": true, "contract": {"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}}
 ```
 
-The WebSocket envelope takes the strike in dollars (`570` = $570.00), the same as the SDKs.
+The WebSocket envelope takes the strike as the terminal's 1/10-cent integer (`570000` = $570.00) by default, matching the terminal wire; pass the server's `--strike-format dollars` flag to use a dollar value instead. The native SDK builders take dollars.
 
 </template>
 

--- a/scripts/ci/check_client_facing_vocab.py
+++ b/scripts/ci/check_client_facing_vocab.py
@@ -125,6 +125,14 @@ EXEMPT_LINE_PATTERNS = (
     re.compile(r"mdds-stage\.thetadata\.us", re.IGNORECASE),
     # Operator metric namespace (renaming breaks dashboards / alerts).
     re.compile(r"thetadatadx\.fpss\.", re.IGNORECASE),
+    # The bundled server is an exact drop-in for the JVM terminal, which
+    # publishes these two system routes verbatim (docs.thetadata.us). The
+    # server mirrors them 1:1, so the literal route paths are permitted on the
+    # public surface — exclusively as the route path. Any other fpss/mdds
+    # occurrence on the line (a bare descriptor) still trips, so descriptions
+    # use "streaming" / "historical", not the codename.
+    re.compile(r"/v3/terminal/fpss/status", re.IGNORECASE),
+    re.compile(r"/v3/terminal/mdds/status", re.IGNORECASE),
 )
 
 

--- a/scripts/ci/check_docs_consistency.py
+++ b/scripts/ci/check_docs_consistency.py
@@ -124,22 +124,11 @@ def served_v3_routes() -> set[str]:
     return routes
 
 
-# Served routes that are deliberately NOT documented in the public OpenAPI
-# contract: the two terminal management-status paths whose path segment is the
-# vendor's transport codename. The server mounts them only for drop-in parity
-# with the JVM terminal's mgmt surface (router.rs registers them to the SAME
-# handlers as the documented `/v3/terminal/{streaming,historical}/status`
-# routes), so a generated client never needs them — the documented aliases
-# cover the identical behaviour. They are kept out of the spec because those
-# codenames are banned client-facing vocabulary (enforced by
-# `check_client_facing_vocab.py`, which sweeps this YAML): writing them into the
-# public contract would leak an internal transport name into a client-rendered
-# surface. This allowlist is intentionally exactly these two paths; it does not
-# loosen the served-vs-documented equality for anything else.
-OPENAPI_UNDOCUMENTED_PARITY_ALIASES = {
-    "/v3/terminal/fpss/status",
-    "/v3/terminal/mdds/status",
-}
+# The server mirrors the JVM terminal's system surface 1:1, so every served
+# `/v3/terminal/*` route is documented verbatim in the OpenAPI contract — the
+# terminal publishes these exact paths (docs.thetadata.us) and the server is a
+# drop-in for it. Nothing is served-but-undocumented here, so this set is empty.
+OPENAPI_UNDOCUMENTED_PARITY_ALIASES: set[str] = set()
 
 # Routes the server serves beyond the upstream-tracking registry endpoints:
 # the system status / lifecycle routes and the flat-file download routes. These
@@ -158,13 +147,14 @@ SERVER_ONLY_PATHS = (
 # slip in. `/v3/system/shutdown` carries no operationId (it never has), so it
 # contributes none.
 SERVER_ONLY_OPERATION_IDS = {
-    "systemStatus",
-    "systemHistoricalStatus",
-    "systemStreamingStatus",
     "flatfileGet",
     "flatfileRequest",
-    # Terminal-compatible plain-text status routes. Distinct ids from the JSON
-    # `system*Status` siblings because they are separate operations.
+    # Terminal system routes, mirrored 1:1 from the JVM terminal: an
+    # unauthenticated shutdown plus the two plain-text channel-health probes.
+    # The route paths carry the vendor's codenames verbatim; the operationIds
+    # describe the channel (streaming / historical) to keep generated client
+    # method names free of the transport codename.
+    "terminalShutdown",
     "terminalStreamingStatus",
     "terminalHistoricalStatus",
     # Path-segment / renamed `/v3` aliases mounted at the server level for

--- a/scripts/ci/check_docs_consistency.py
+++ b/scripts/ci/check_docs_consistency.py
@@ -319,31 +319,38 @@ def check_static_docs() -> None:
         expect_not_contains(path, "&exp=")
         expect_not_contains(path, "&ivl=")
 
-    # Strikes are dollars on every client-facing surface, with no
-    # exception. The WebSocket subscribe envelope takes the strike in
-    # dollars exactly like the SDKs; the scaled-integer wire form never
-    # surfaces in the docs. The thousandths vocabulary (and the literal
-    # 570000 example it travelled with) must never reappear: a client
-    # who copies a thousandths example subscribes to a $570,000 strike.
-    streaming_option_pages = sorted(
-        (DOCS_SITE / "streaming/options").glob("*.md")
-    )
-    strike_docs = list((DOCS_SITE / "reference/option").rglob("*.md")) + [
+    # Strike is dollars on the REST surface everywhere: the REST reference
+    # pages, the server README, the REST server pages (index / http), and the
+    # OpenAPI spec must never show the scaled-integer strike form. A client
+    # who copies a `500000` / `570000` thousandths example on a REST surface
+    # would subscribe to a $500,000 / $570,000 strike.
+    #
+    # The server's WebSocket, by contrast, defaults to the terminal's
+    # 1/10-cent integer (a `$570` strike is `570000`) and is configurable to
+    # dollars via `--strike-format`. So server/websocket.md and the
+    # streaming/** docs legitimately show the terminal form and are EXEMPT
+    # from the dollars-only strike rule below.
+    rest_strike_docs = list((DOCS_SITE / "reference/option").rglob("*.md")) + [
         ROOT / "tools/server/README.md",
-        *server_pages,
-        *streaming_option_pages,
+        DOCS_SITE / "server/index.md",
+        DOCS_SITE / "server/http.md",
         OPENAPI_YAML,
     ]
-    for path in strike_docs:
+    for path in rest_strike_docs:
         expect_not_contains(path, "scaled integer")
         # Word-bounded: capture-backed sample tables legitimately carry
         # timestamps like `34500000` that embed the digit string.
         if re.search(r"\b500000\b", path.read_text()):
             fail(f"{path.relative_to(ROOT)} contains stale text: '500000'")
-    # The thousandths strike claim is the exact defect a contributor
-    # caught; ban its vocabulary and literal example from every page
-    # that carries a WS subscribe envelope.
-    for path in [*server_pages, *streaming_option_pages, DOCS_SITE / "articles/symbology.md"]:
+    # Ban the thousandths vocabulary and the literal `570000` example from
+    # the dollars-only REST-facing strike pages (the REST server pages and
+    # the symbology article). The WebSocket page and the streaming docs are
+    # exempt — they show the terminal's 1/10-cent form by default.
+    for path in [
+        DOCS_SITE / "server/index.md",
+        DOCS_SITE / "server/http.md",
+        DOCS_SITE / "articles/symbology.md",
+    ]:
         expect_not_contains(path, "thousandths")
         if re.search(r"\b570000\b", path.read_text()):
             fail(f"{path.relative_to(ROOT)} contains stale strike text: '570000'")

--- a/thetadatadx-rs/build_support_bin/endpoints/docs_render/streaming.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/docs_render/streaming.rs
@@ -234,7 +234,7 @@ const STREAMS: &[StreamSpec] = &[
         cpp_sub: "thetadatadx::Contract::option(\"SPY\", {.expiration = \"20260618\", .strike = \"570\", .right = \"C\"}).quote()",
         ws_req_type: "QUOTE",
         ws_sec_type: "OPTION",
-        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}"#),
+        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}"#),
         group: "Options",
         label: "Quote",
         warning: None,
@@ -251,7 +251,7 @@ const STREAMS: &[StreamSpec] = &[
         cpp_sub: "thetadatadx::Contract::option(\"SPY\", {.expiration = \"20260618\", .strike = \"570\", .right = \"C\"}).trade()",
         ws_req_type: "TRADE",
         ws_sec_type: "OPTION",
-        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}"#),
+        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}"#),
         group: "Options",
         label: "Trade",
         warning: None,
@@ -268,7 +268,7 @@ const STREAMS: &[StreamSpec] = &[
         cpp_sub: "thetadatadx::Contract::option(\"SPY\", {.expiration = \"20260618\", .strike = \"570\", .right = \"C\"}).open_interest()",
         ws_req_type: "OPEN_INTEREST",
         ws_sec_type: "OPTION",
-        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}"#),
+        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}"#),
         group: "Options",
         label: "Open Interest",
         warning: Some("Streaming open interest is not live on the upstream feed yet, so this subscription does not deliver ticks. For open interest today, use the [flat files](/articles/flat-files) (last 7 days) or the [historical open-interest endpoint](/reference/option/history/open-interest)."),
@@ -319,7 +319,7 @@ const STREAMS: &[StreamSpec] = &[
         cpp_sub: "thetadatadx::Contract::option(\"SPY\", {.expiration = \"20260618\", .strike = \"570\", .right = \"C\"}).market_value()",
         ws_req_type: "MARKET_VALUE",
         ws_sec_type: "OPTION",
-        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570, "right": "C"}"#),
+        ws_contract: Some(r#"{"symbol": "SPY", "expiration": 20260618, "strike": 570000, "right": "C"}"#),
         group: "Options",
         label: "Market Value",
         warning: None,
@@ -539,7 +539,7 @@ fn http_tab(spec: &StreamSpec) -> String {
     );
     if spec.ws_contract.is_some_and(|c| c.contains("strike")) {
         out.push_str(
-            "\nThe WebSocket envelope takes the strike in dollars (`570` = $570.00), the same as the SDKs.\n",
+            "\nThe WebSocket envelope takes the strike as the terminal's 1/10-cent integer (`570000` = $570.00) by default, matching the terminal wire; pass the server's `--strike-format dollars` flag to use a dollar value instead. The native SDK builders take dollars.\n",
         );
     }
     out
@@ -578,7 +578,7 @@ fn full_trade_delivery(spec: &StreamSpec) -> String {
             "QQQ 20231110 P 360.00",
             // TD encodes the strike in 1/10-cent on the wire; the SDK
             // surfaces it in dollars on the resolved contract.
-            "\n\nThe `Ohlcvc` bar and the trailing `Quote` updates carry the same `contract`. On the wire ThetaData encodes the option strike in tenths of a cent (a $360.00 strike as `3600000`); the SDK resolves it to the dollar strike on `event.contract`.\n",
+            "\n\nThe `Ohlcvc` bar and the trailing `Quote` updates carry the same `contract`. ThetaData encodes the option strike in tenths of a cent (a $360.00 strike as `360000`); the server's WebSocket emits that integer verbatim by default, while the native SDK resolves it to the dollar strike on `event.contract`.\n",
         )
     } else {
         ("QQQ", "\n")
@@ -612,7 +612,7 @@ fn full_trade_delivery(spec: &StreamSpec) -> String {
     );
     if is_option {
         out.push_str(
-            "- The WebSocket envelope and the SDK builders take the option strike in dollars; the tenths-of-a-cent wire encoding is internal.\n",
+            "- The server's WebSocket envelope takes the option strike as the terminal's 1/10-cent integer by default (`--strike-format dollars` switches to a dollar value); the native SDK builders take dollars.\n",
         );
     }
     out.push('\n');

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -25,12 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,17 +122,6 @@ name = "asn1-rs-impl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -425,20 +408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,28 +541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "forwarded-header-value"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
-dependencies = [
- "nonempty",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -622,12 +575,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -670,11 +617,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -687,29 +632,6 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "governor"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.9.4",
- "smallvec",
- "spinning_top",
- "web-time",
 ]
 
 [[package]]
@@ -733,28 +655,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1242,18 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,21 +1419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,15 +1501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2169,15 +2038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,7 +2163,6 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
- "tower_governor",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2533,11 +2392,8 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-trait",
- "axum",
  "base64",
  "bytes",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2546,7 +2402,6 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -2616,23 +2471,6 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tower_governor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
-dependencies = [
- "axum",
- "forwarded-header-value",
- "governor",
- "http",
- "pin-project",
- "thiserror 2.0.18",
- "tonic",
- "tower",
- "tracing",
-]
 
 [[package]]
 name = "tracing"
@@ -2902,16 +2740,6 @@ name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -29,13 +29,10 @@ tokio = { version = "1.52.1", features = ["full"] }
 sonic-rs = "0.5.8"
 serde = { version = "1.0.228", features = ["derive"] }
 # `tower` is already in the tree as a transitive dep of axum 0.8; we depend
-# on it directly for `ConcurrencyLimitLayer`. `tower_governor` (per-IP rate
-# limiting) extends this with keyed quotas -- see `router::build()` for the
-# composition.
+# on it directly for `ConcurrencyLimitLayer`.
 tower = { version = "0.5.3", features = ["limit"] }
 # `trace` powers the per-request access log mounted in `router::build`.
 tower-http = { version = "0.6.8", features = ["cors", "trace"] }
-tower_governor = "0.8.0"
 # Streaming flatfile bytes back to clients via `ReaderStream` (issue #432).
 # Transitive dep of axum already; declared directly so the route module's
 # `tokio_util::io::ReaderStream` import is sourced from a pinned version.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -67,15 +67,13 @@ Credentials resolve in this order, highest first: the `--api-key` flag, then `TH
 
 ### Environment variables
 
-These variables are read from the environment. The credential variables (`THETADATA_API_KEY`, and the `THETADATA_EMAIL` + `THETADATA_PASSWORD` pair) authenticate the server; the rate-limit knobs have no flag. Per-IP rate limiting is off by default (matching the terminal it replaces); setting either rate-limit variable opts in. Full descriptions live in [`docs-site/docs/server/index.md`](../../docs-site/docs/server/index.md).
+These variables are read from the environment. The credential variables (`THETADATA_API_KEY`, and the `THETADATA_EMAIL` + `THETADATA_PASSWORD` pair) authenticate the server. Full descriptions live in [`docs-site/docs/server/index.md`](../../docs-site/docs/server/index.md).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `THETADATA_API_KEY` | | API key for authentication when `--api-key` is not passed. An explicit `--api-key` flag wins over this; both win over the email/password path. The key is never logged or echoed. |
 | `THETADATA_EMAIL` | | Account email. With `THETADATA_PASSWORD`, authenticates the server when no API key is supplied. Outranked by `--api-key` and `THETADATA_API_KEY`; wins over the `--creds` file. |
 | `THETADATA_PASSWORD` | | Account password, paired with `THETADATA_EMAIL`. Never logged or echoed. |
-| `THETADATADX_RATE_LIMIT_PER_SECOND` | off | Opt into per-IP rate limiting at this many requests per second. Setting either rate-limit variable turns the limiter on. |
-| `THETADATADX_RATE_LIMIT_BURST_SIZE` | off | Burst size for the per-IP rate limiter. If only one of the two rate-limit variables is set, the other falls back to `20` req/s / `40` burst. |
 | `THETADATADX_WS_CLIENT_CAPACITY` | `4096` | Per-client WebSocket send-buffer capacity in events. A larger buffer trades memory for more headroom before a slow consumer drops events; invalid or zero values keep the default. |
 
 ## REST API
@@ -130,7 +128,7 @@ JSON responses carry the v3 body `{ "response": [ ... ] }` (no `header` key), `C
 
 Timestamps are ISO strings (the v2 `ms_of_day` / `date` columns are folded into them) and the option `right` is `CALL` / `PUT`.
 
-Failures on the data routes return the HTTP status with a plain-text (`text/plain`) description. Framework-level rejections (rate-limit `429`, malformed requests, the shutdown token) still return a JSON `{ "header": { "error_type", "error_msg" }, "response": [] }` envelope.
+Failures on the data routes return the HTTP status with a plain-text (`text/plain`) description. Framework-level rejections (malformed requests, the shutdown token) still return a JSON `{ "header": { "error_type", "error_msg" }, "response": [] }` envelope.
 
 ## WebSocket
 
@@ -157,8 +155,7 @@ Send JSON commands to manage subscriptions:
 
 ## Hardening
 
-- **`POST /v3/system/shutdown`** requires a 128-bit random hex `X-Shutdown-Token` header (32 hex chars) printed once to stderr at startup. Token is compared in constant time so response latency does not leak the secret one byte at a time; no env var or CLI flag sets it externally. A route-scoped per-IP limiter caps attempts at roughly 3 per hour.
-- **Opt-in global per-IP rate limit** via `tower_governor::GovernorLayer` keyed on `PeerIpKeyExtractor` (peer TCP socket, **not** `X-Forwarded-For`). The general limiter is **off by default on every bind regardless of address**; operators opt in by setting `THETADATADX_RATE_LIMIT_PER_SECOND` and/or `THETADATADX_RATE_LIMIT_BURST_SIZE` (setting either turns it on; a partially-set pair falls back to 20 rps / burst 40). Once on, excess traffic from a single IP is rejected as `429` with the canonical error envelope and a `Retry-After` header, on both the HTTP routes and the WS upgrade. The shutdown-route limiter stays active on every bind. The server runs without a trusted reverse proxy, so forwarded-header extractors would let an attacker cycle fake IPs.
+- **`POST /v3/system/shutdown`** requires a 128-bit random hex `X-Shutdown-Token` header (32 hex chars) printed once to stderr at startup. Token is compared in constant time so response latency does not leak the secret one byte at a time; no env var or CLI flag sets it externally.
 - **256 concurrent in-flight requests** — requests past the cap queue on the layer's semaphore (they are not rejected), then queue again on the SDK's tier-sized request semaphore that matches the upstream concurrency cap. Bursts absorb as latency, not errors; see the Concurrency Model section in `docs-site/docs/server/http.md`. Upstream capacity rejections that survive the SDK's retry budget surface as `503` + `Retry-After`, not 500. **64 KiB body limit**, **4 KiB WebSocket `Message::Text` cap**.
 - **`BoundedQuery<32>` extractor** counts `&`-delimited query-string pairs BEFORE `serde_urlencoded` runs, so a `?a=1&b=2&...` flood is rejected at parse time rather than after HashMap rehashing allocates MB+.
 - **CSV output defuses formula injection** — cells whose first byte is `=` / `+` / `-` / `@` / `\t` are prefixed with a single-quote `'` and CSV-quoted.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -98,13 +98,14 @@ GET /v3/rate/history/eod?symbol=SOFR&start_date=20240101&end_date=20240301
 
 Endpoint query parameters follow the registry names (`symbol`, `expiration`, `strike`, `right`, `interval`, etc.), not the legacy shorthand aliases (`root`, `exp`, `ivl`). Date parameters (`date`, `start_date`, `end_date`, `expiration`) accept both `YYYYMMDD` and ISO `YYYY-MM-DD`.
 
-### System Routes (4)
+### Terminal system routes (3)
+
+Mirrored 1:1 from the JVM terminal — unauthenticated `GET`, bare `text/plain` bodies.
 
 ```
-GET  /v3/system/status          # {"status":"CONNECTED","version":"<crate version>"}
-GET  /v3/system/historical/status    # envelope: {"header":{...},"response":["CONNECTED"]}
-GET  /v3/system/streaming/status     # {"status":"CONNECTED","version":"<crate version>","broadcast_dropped":0,"json_serialize_failures":0}
-POST /v3/system/shutdown        # requires X-Shutdown-Token header
+GET /v3/terminal/shutdown       # "OK"; kills the server process
+GET /v3/terminal/fpss/status    # streaming channel health: CONNECTED / DISCONNECTED
+GET /v3/terminal/mdds/status    # historical channel health: CONNECTED / DISCONNECTED
 ```
 
 ### Response format
@@ -155,21 +156,16 @@ Send JSON commands to manage subscriptions:
 
 ## Hardening
 
-- **`POST /v3/system/shutdown`** requires a 128-bit random hex `X-Shutdown-Token` header (32 hex chars) printed once to stderr at startup. Token is compared in constant time so response latency does not leak the secret one byte at a time; no env var or CLI flag sets it externally.
 - **256 concurrent in-flight requests** — requests past the cap queue on the layer's semaphore (they are not rejected), then queue again on the SDK's tier-sized request semaphore that matches the upstream concurrency cap. Bursts absorb as latency, not errors; see the Concurrency Model section in `docs-site/docs/server/http.md`. Upstream capacity rejections that survive the SDK's retry budget surface as `503` + `Retry-After`, not 500. **64 KiB body limit**, **4 KiB WebSocket `Message::Text` cap**.
 - **`BoundedQuery<32>` extractor** counts `&`-delimited query-string pairs BEFORE `serde_urlencoded` runs, so a `?a=1&b=2&...` flood is rejected at parse time rather than after HashMap rehashing allocates MB+.
 - **CSV output defuses formula injection** — cells whose first byte is `=` / `+` / `-` / `@` / `\t` are prefixed with a single-quote `'` and CSV-quoted.
 - **Streaming TLS** verifies every peer against a captured SubjectPublicKeyInfo pin (`PinnedVerifier`, constant-time SHA-256 compare); MITM presenting any other cert is rejected even if it chains to a trusted CA. See `docs-site/docs/streaming/index.md`.
 - **Dropped-events observability** — per-client mpsc channels surface a monotonic `AtomicU64` counter through every SDK (`client.dropped_events()` Python, `droppedEvents(): bigint` TS, `thetadatadx_streaming_dropped_events` / `thetadatadx_client_dropped_events` FFI) plus `tracing::debug!` on `thetadatadx::sdk::streaming`.
 
-Example — initiating a graceful shutdown from the same machine:
+Example — shutting the server down, exactly as with the JVM terminal:
 
 ```bash
-# Server prints these lines once at startup on stderr (TOKEN is a
-# 128-bit random hex string, 32 hex chars):
-#   Shutdown token: <TOKEN>
-#     curl -X POST http://127.0.0.1:25503/v3/system/shutdown -H 'X-Shutdown-Token: <TOKEN>'
-curl -X POST -H "X-Shutdown-Token: <TOKEN>" http://127.0.0.1:25503/v3/system/shutdown
+curl http://127.0.0.1:25503/v3/terminal/shutdown
 ```
 
 ## Architecture

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use axum::extract::{FromRequestParts, State};
 use axum::http::request::Parts;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use sonic_rs::prelude::*;
 
@@ -759,51 +759,25 @@ pub async fn list_by_request_type(
 }
 
 // ---------------------------------------------------------------------------
-//  System endpoints
+//  Terminal system endpoints
 // ---------------------------------------------------------------------------
 
-/// GET /v3/system/status -- matches JVM terminal system status.
-pub async fn system_status(State(state): State<AppState>) -> Response {
-    let mut body = sonic_rs::json!({
-        "status": state.mdds_status(),
-        "version": env!("CARGO_PKG_VERSION")
-    });
-    json_response(&mut body)
+/// GET /v3/terminal/shutdown -- kills the server process, matching the JVM
+/// terminal. Unauthenticated, returns the plain-text body `OK`, exactly as
+/// the terminal documents it.
+pub async fn terminal_shutdown(State(state): State<AppState>) -> Response {
+    tracing::info!("shutdown requested via /v3/terminal/shutdown");
+    state.shutdown();
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, TEXT_PLAIN_CONTENT_TYPE)],
+        "OK",
+    )
+        .into_response()
 }
 
-/// GET /v3/system/historical/status
-pub async fn system_historical_status(State(state): State<AppState>) -> Response {
-    let mut body = format::ok_envelope(vec![sonic_rs::Value::from(state.mdds_status())]);
-    json_response(&mut body)
-}
-
-/// GET /v3/system/streaming/status
-pub async fn system_streaming_status(State(state): State<AppState>) -> Response {
-    let mut body = sonic_rs::json!({
-        "status": state.fpss_status(),
-        "version": env!("CARGO_PKG_VERSION"),
-        // Expose the bounded callback->broadcast drop counter so operators
-        // can scrape one number to detect WS-side back-pressure without
-        // tailing logs. Mirrors the FPSS SDK's `dropped_events()` surface.
-        "broadcast_dropped": state.fpss_broadcast_dropped(),
-        // M1 fix: surface the JSON-serialization-failure counter so a
-        // sonic_rs::to_string regression on the hot path is visible
-        // alongside the broadcast drop counter rather than swallowed.
-        "json_serialize_failures": crate::ws::json_serialize_failure_count(),
-    });
-    json_response(&mut body)
-}
-
-/// GET /v3/terminal/streaming/status -- terminal-compatible streaming
-/// connection status as a bare `text/plain` body.
-///
-/// The JVM terminal exposes the streaming (FPSS) channel health at
-/// `/v3/terminal/fpss/status` as a one-word `text/plain` response
-/// (`CONNECTED` / `DISCONNECTED`); this is the client-facing alias of that
-/// route (the wire codename stays out of the public path). It mirrors the
-/// JSON `/v3/system/streaming/status` route but in the terminal's plain-text
-/// shape so operator tooling that scrapes the terminal's mgmt surface keeps
-/// working unchanged.
+/// GET /v3/terminal/fpss/status -- FPSS (streaming) channel health as the
+/// terminal's one-word `text/plain` body (`CONNECTED` / `DISCONNECTED`).
 pub async fn terminal_streaming_status(State(state): State<AppState>) -> Response {
     (
         StatusCode::OK,
@@ -813,13 +787,8 @@ pub async fn terminal_streaming_status(State(state): State<AppState>) -> Respons
         .into_response()
 }
 
-/// GET /v3/terminal/historical/status -- terminal-compatible historical
-/// connection status as a bare `text/plain` body.
-///
-/// The terminal-compatible alias of the historical (MDDS) channel health,
-/// which the JVM terminal serves at `/v3/terminal/mdds/status` as a one-word
-/// `text/plain` response (`CONNECTED` / `DISCONNECTED`). Plain-text sibling
-/// of the JSON `/v3/system/historical/status` route.
+/// GET /v3/terminal/mdds/status -- MDDS (historical) channel health as the
+/// terminal's one-word `text/plain` body (`CONNECTED` / `DISCONNECTED`).
 pub async fn terminal_historical_status(State(state): State<AppState>) -> Response {
     (
         StatusCode::OK,
@@ -827,31 +796,6 @@ pub async fn terminal_historical_status(State(state): State<AppState>) -> Respon
         state.mdds_status(),
     )
         .into_response()
-}
-
-/// POST /v3/system/shutdown -- requires `X-Shutdown-Token` header.
-/// Changed from GET in #377 review: shutdown mutates server state, so it
-/// belongs on an idempotent non-cacheable verb. GET would be cached /
-/// prefetched / CSRF-triggered; POST requires an explicit, intentional
-/// client action.
-pub async fn system_shutdown(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    let token = headers
-        .get("X-Shutdown-Token")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-
-    if !state.validate_shutdown_token(token) {
-        return error_response(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "invalid or missing X-Shutdown-Token header",
-        );
-    }
-
-    tracing::info!("shutdown requested via REST API with valid token");
-    state.shutdown();
-    let mut body = format::ok_envelope(vec![sonic_rs::Value::from("OK")]);
-    json_response(&mut body)
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/server/src/logging.rs
+++ b/tools/server/src/logging.rs
@@ -265,7 +265,8 @@ mod tests {
         );
 
         tracing::subscriber::with_default(subscriber, || {
-            let span = tracing::info_span!("request", method = "GET", uri = "/v3/system/status");
+            let span =
+                tracing::info_span!("request", method = "GET", uri = "/v3/terminal/mdds/status");
             let _e = span.enter();
             tracing::info!(status = 200, "finished processing request");
         });
@@ -274,7 +275,7 @@ mod tests {
         assert!(out.contains("request{"), "span name present: {out}");
         assert!(out.contains("method=\"GET\""), "method present: {out}");
         assert!(
-            out.contains("uri=\"/v3/system/status\""),
+            out.contains("uri=\"/v3/terminal/mdds/status\""),
             "uri present: {out}"
         );
         assert!(out.contains("status=200"), "event fields present: {out}");

--- a/tools/server/src/main.rs
+++ b/tools/server/src/main.rs
@@ -228,9 +228,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // log lines are lost on shutdown.
     let _log_guard = logging::init(&args.log_level, args.log_format, args.log_file.as_deref())?;
 
-    // Generate a random shutdown token and print it.
-    let shutdown_token = random_hex_token();
-
     // Startup banner. Named after the binary so operator automation
     // matching the banner string keys on the same identifier as the
     // process list and the docs.
@@ -244,18 +241,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("REST API: http://{}:{}/", args.bind, args.http_port);
     eprintln!("WebSocket: ws://{}:{}/v1/events", args.bind, args.ws_port);
     eprintln!();
-    eprintln!("Shutdown token: {shutdown_token}");
-    eprintln!(
-        "  curl -X POST http://{}:{}/v3/system/shutdown -H 'X-Shutdown-Token: {}'",
-        args.bind, args.http_port, shutdown_token
-    );
 
-    // The shutdown token is deliberately NOT part of the structured log --
-    // structured logs flow to aggregators / SIEMs / persisted buffers and
-    // the token is a bearer credential for the shutdown endpoint. The
-    // eprintln! banner above already prints it once to stderr for the
-    // operator starting the process; keeping it out of `tracing::info!`
-    // means it never reaches a log pipeline.
     tracing::info!(
         version,
         http_port = args.http_port,
@@ -387,7 +373,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("MDDS connected");
 
     // Step 4: Build shared state.
-    let state = AppState::new(client, shutdown_token);
+    let state = AppState::new(client);
 
     // Step 5: Start FPSS streaming bridge.
     if !args.no_streaming {
@@ -407,13 +393,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // Permissive by design, matching the legacy terminal: browser-based
     // dashboards on any local origin must be able to call both the GET
-    // data routes and the POST routes (`/v3/system/shutdown`,
-    // `/v3/flatfile/request`). The previous configuration pinned
+    // data routes and the POST flat-file request route
+    // (`/v3/flatfile/request`). The previous configuration pinned
     // `allow_origin` to the server's own listener address — a client
     // running on the server's origin IS the server, so the restriction
     // blocked every real browser client while protecting nothing — and
-    // `allow_methods=[GET]` failed every POST preflight. Real protection
-    // for the mutating route is the `X-Shutdown-Token` header, not CORS.
+    // `allow_methods=[GET]` failed every POST preflight.
     let cors = CorsLayer::new()
         .allow_origin(tower_http::cors::Any)
         .allow_methods([axum::http::Method::GET, axum::http::Method::POST])

--- a/tools/server/src/main.rs
+++ b/tools/server/src/main.rs
@@ -413,38 +413,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // running on the server's origin IS the server, so the restriction
     // blocked every real browser client while protecting nothing — and
     // `allow_methods=[GET]` failed every POST preflight. Real protection
-    // for the mutating route is the `X-Shutdown-Token` header plus the
-    // route-scoped rate limiter, not CORS.
+    // for the mutating route is the `X-Shutdown-Token` header, not CORS.
     let cors = CorsLayer::new()
         .allow_origin(tower_http::cors::Any)
         .allow_methods([axum::http::Method::GET, axum::http::Method::POST])
         .allow_headers(tower_http::cors::Any);
 
-    // The terminal this server replaces does no per-IP rate limiting, so
-    // the default must not either: with neither rate-limit env var set the
-    // general per-IP governor is attached nowhere, regardless of the bind
-    // address. An operator exposing the server as a relay opts in by
-    // setting THETADATADX_RATE_LIMIT_PER_SECOND and/or
-    // THETADATADX_RATE_LIMIT_BURST_SIZE. The same resolved pair drives both
-    // the HTTP general governor and the WS upgrade governor; the tighter
-    // shutdown-route limiter stays active on every bind regardless.
-    let rate_limit = router::resolve_rate_limit();
-    match rate_limit {
-        Some((per_second, burst_size)) => tracing::info!(
-            per_second,
-            burst_size,
-            "general per-IP rate limiter enabled by operator (opt-in)"
-        ),
-        None => tracing::info!(
-            "general per-IP rate limiter disabled (default; shutdown-route limiter stays active)"
-        ),
-    }
-
-    let http_app = router::build(state.clone(), rate_limit).layer(cors);
+    let http_app = router::build(state.clone()).layer(cors);
     let http_addr: SocketAddr = format!("{}:{}", args.bind, args.http_port).parse()?;
 
     // Step 7: Build WebSocket server.
-    let ws_app = ws::router(state.clone(), rate_limit);
+    let ws_app = ws::router(state.clone());
     let ws_addr: SocketAddr = format!("{}:{}", args.bind, args.ws_port).parse()?;
 
     // Step 8: Start both servers concurrently.
@@ -452,21 +431,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!(%ws_addr, "WebSocket server starting");
 
     let shutdown_state = state.clone();
-    // `into_make_service_with_connect_info::<SocketAddr>()` is required for
-    // the per-IP rate limiter (`tower_governor::PeerIpKeyExtractor`) to
-    // read the peer address on each request. Without it, the PeerIp key
-    // extractor falls back to rejecting every request as "no client IP".
-    // The extractor uses PeerIp (not SmartIp) so downstream clients
-    // can't bypass the rate limit by forging `X-Forwarded-For`.
     let http_server = axum::serve(
         tokio::net::TcpListener::bind(http_addr).await?,
-        http_app.into_make_service_with_connect_info::<SocketAddr>(),
+        http_app.into_make_service(),
     )
     .with_graceful_shutdown(shutdown_signal(shutdown_state.clone()));
 
     let ws_server = axum::serve(
         tokio::net::TcpListener::bind(ws_addr).await?,
-        ws_app.into_make_service_with_connect_info::<SocketAddr>(),
+        ws_app.into_make_service(),
     )
     .with_graceful_shutdown(shutdown_signal(shutdown_state));
 

--- a/tools/server/src/main.rs
+++ b/tools/server/src/main.rs
@@ -41,7 +41,7 @@ use zeroize::Zeroizing;
 use thetadatadx::config::{HistoricalEnvironment, StreamingEnvironment};
 use thetadatadx::{Client, Credentials, DirectConfig};
 
-use crate::state::AppState;
+use crate::state::{AppState, StrikeFormat};
 
 /// A random 128-bit token as 32 lowercase hex chars. Backs the shutdown
 /// token and the flat-file scratch-path suffix — both want an unguessable,
@@ -131,6 +131,12 @@ struct Args {
     /// Skip the streaming connection at startup.
     #[arg(long)]
     no_streaming: bool,
+
+    /// WebSocket option-strike encoding: `terminal` (the JVM terminal's
+    /// 1/10-cent integer, e.g. 570000 for $570; default, exact drop-in) or
+    /// `dollars` (a dollar value, e.g. 570; the SDK's convenience form).
+    #[arg(long, value_enum, default_value_t = StrikeFormat::Terminal)]
+    strike_format: StrikeFormat,
 }
 
 /// Canonical environment variable names, shared with the SDK, the CLI, and
@@ -373,7 +379,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("MDDS connected");
 
     // Step 4: Build shared state.
-    let state = AppState::new(client);
+    let state = AppState::new(client, args.strike_format);
 
     // Step 5: Start FPSS streaming bridge.
     if !args.no_streaming {

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -7,7 +7,7 @@
 //!
 //! # Hardening layers
 //!
-//! `build()` composes three security-relevant layers on top of the registry
+//! `build()` composes two generic admission layers on top of the registry
 //! routes:
 //!
 //! 1. `DefaultBodyLimit` (64 KB) caps total request-body size -- primary
@@ -19,45 +19,21 @@
 //!    runtime's task slots. Requests past the cap QUEUE on the layer's
 //!    semaphore (they are not rejected) — see the doc on
 //!    [`GLOBAL_CONCURRENCY_LIMIT`].
-//! 3. `tower_governor::GovernorLayer` enforces a per-IP rate limit on
-//!    every route — **only when the operator opts in**. The terminal this
-//!    server replaces does no per-IP rate limiting, so the default must
-//!    not either: with neither rate-limit env var set, the general
-//!    governor layer is never attached, regardless of bind address. An
-//!    operator exposing the server as a relay opts in by setting
-//!    `THETADATADX_RATE_LIMIT_PER_SECOND` and/or
-//!    `THETADATADX_RATE_LIMIT_BURST_SIZE`. The shutdown endpoint keeps an
-//!    independent, tighter `route_layer` (~3 attempts per hour per IP) on
-//!    every bind so token-guessing costs real wall-clock time.
 //!
-//! Layer order matters: `GovernorLayer` (outer) sees the request first and
-//! rejects with 429 before `ConcurrencyLimitLayer` acquires a runtime slot.
-//!
-//! # Trust model
-//!
-//! The server is NOT deployed behind a trusted reverse proxy. It binds to
-//! `0.0.0.0` by default (all interfaces, matching the JVM terminal it
-//! replaces) and accepts connections directly from clients; an operator who
-//! wants loopback-only exposure passes `--bind 127.0.0.1`. The rate-limit
-//! key extractor uses the peer connect-info IP
-//! only: `X-Forwarded-For`, `X-Real-IP`, and `Forwarded` headers are
-//! **explicitly ignored**. Trusting any of them would let a malicious
-//! local process rotate a synthetic IP on every request to obtain a fresh
-//! token bucket, defeating both the general 20 rps cap and the shutdown-
-//! token guessing limit. Revisit only if a deployment introduces a
-//! validated proxy in front of this server.
+//! The terminal this server replaces does no per-IP rate limiting, and
+//! neither does this server — real request limits are enforced upstream by
+//! the data service. The mutating `/v3/system/shutdown` route is guarded by
+//! an `X-Shutdown-Token` header (a 128-bit random token), not by a rate
+//! limit. The server binds to `0.0.0.0` by default (all interfaces,
+//! matching the JVM terminal it replaces); pass `--bind 127.0.0.1` for
+//! loopback-only exposure.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::extract::DefaultBodyLimit;
-use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::Router;
 use tower::limit::ConcurrencyLimitLayer;
-use tower_governor::governor::GovernorConfigBuilder;
-use tower_governor::key_extractor::PeerIpKeyExtractor;
-use tower_governor::{GovernorError, GovernorLayer};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tower_http::LatencyUnit;
 use tracing::Level;
@@ -94,134 +70,15 @@ pub(crate) const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
 /// client.
 pub(crate) const BODY_LIMIT_BYTES: usize = 64 * 1024;
 
-/// Fallback general per-IP quota applied only when the operator opts into
-/// rate limiting by setting one of the two rate-limit env vars but not the
-/// other: 20 requests per second with a burst of 40. Tuned for backtest
-/// fetches (bursty metadata pulls followed by idle time). When NEITHER env
-/// var is set, no general governor is attached at all — the terminal this
-/// server replaces does no per-IP rate limiting, so the default must not
-/// either.
-pub(crate) const GENERAL_PER_SECOND: u64 = 20;
-pub(crate) const GENERAL_BURST_SIZE: u32 = 40;
-
-/// Shutdown endpoint quota: ~3 attempts per IP per hour.
-///
-/// `tower_governor::GovernorConfigBuilder::per_second(n)` treats `n` as
-/// "requests allowed per second" — passing 3600 would allow 3600 rps,
-/// which is the opposite of what we want. The crate's `period(Duration)`
-/// setter instead sets the INTERVAL between token replenishments: one
-/// token per `SHUTDOWN_REPLENISH_PERIOD`. Combined with `burst_size(3)`,
-/// a single IP can issue at most three attempts before the bucket empties
-/// and must wait one full hour for each subsequent slot. The 128-bit
-/// random hex token already makes brute-force infeasible, but this pins
-/// an upper bound on guess rate regardless of token length.
-const SHUTDOWN_REPLENISH_PERIOD: Duration = Duration::from_secs(3600);
-const SHUTDOWN_BURST_SIZE: u32 = 3;
-
 // ---------------------------------------------------------------------------
 //  Router construction
 // ---------------------------------------------------------------------------
 
-/// Map a `tower_governor` rejection onto the canonical error envelope.
-///
-/// The crate's default responder emits `429` with a plain-text body and
-/// a non-standard `x-ratelimit-after` header; clients that parse
-/// `header.error_type` to drive retry logic broke on the only path that
-/// did not emit JSON. This handler emits the same
-/// `{"header":{"error_type","error_msg"},"response":[]}` envelope as
-/// every other failure, plus a standards-compliant `Retry-After` header
-/// in seconds (RFC 9110) — the field every HTTP retry helper reads
-/// natively. Shared by the REST shutdown limiter, the opt-in general
-/// per-IP limiter, and the WS upgrade limiter.
-pub(crate) fn governor_error_response(error: GovernorError) -> axum::response::Response {
-    match error {
-        GovernorError::TooManyRequests { wait_time, .. } => {
-            let mut resp = handler::error_response(
-                StatusCode::TOO_MANY_REQUESTS,
-                "rate_limited",
-                &format!("too many requests; retry after {wait_time}s"),
-            );
-            if let Ok(value) = axum::http::HeaderValue::from_str(&wait_time.to_string()) {
-                resp.headers_mut()
-                    .insert(axum::http::header::RETRY_AFTER, value);
-            }
-            resp
-        }
-        GovernorError::UnableToExtractKey => handler::error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "server_error",
-            "rate limiter could not determine the client address",
-        ),
-        GovernorError::Other { code, msg, .. } => handler::error_response(
-            code,
-            "server_error",
-            msg.as_deref()
-                .unwrap_or("rate limiter rejected the request"),
-        ),
-    }
-}
-
-/// Opt-in per-IP rate-limit setting: `(per_second, burst_size)`.
-///
-/// The general `GovernorLayer` (on both the HTTP general routes and the WS
-/// upgrade) is attached only when this is `Some`. It is `Some` only when the
-/// operator sets at least one of the two rate-limit env vars; otherwise the
-/// server runs with no general per-IP limit, matching the terminal it
-/// replaces.
-pub type RateLimit = (u64, u32);
-
-/// Environment variable names for the opt-in per-IP rate limit.
-pub(crate) const ENV_RATE_LIMIT_PER_SECOND: &str = "THETADATADX_RATE_LIMIT_PER_SECOND";
-pub(crate) const ENV_RATE_LIMIT_BURST_SIZE: &str = "THETADATADX_RATE_LIMIT_BURST_SIZE";
-
-/// Resolve the opt-in per-IP rate limit from the process environment.
-///
-/// The terminal this server replaces does no per-IP rate limiting, so the
-/// default is OFF: with NEITHER `THETADATADX_RATE_LIMIT_PER_SECOND` nor
-/// `THETADATADX_RATE_LIMIT_BURST_SIZE` set, this returns `None` and no
-/// general governor is attached anywhere. Operators exposing the server as
-/// a relay opt in by setting one or both.
-///
-/// When at least one is set the limiter is enabled; a value that is absent
-/// or unparseable falls back to the documented default constant for that
-/// field ([`GENERAL_PER_SECOND`] / [`GENERAL_BURST_SIZE`]), so a single env
-/// var is enough to turn the limiter on with sane companion settings.
-pub fn resolve_rate_limit() -> Option<RateLimit> {
-    resolve_rate_limit_from(
-        std::env::var(ENV_RATE_LIMIT_PER_SECOND).ok().as_deref(),
-        std::env::var(ENV_RATE_LIMIT_BURST_SIZE).ok().as_deref(),
-    )
-}
-
-/// Pure core of [`resolve_rate_limit`], split out so the opt-in / partial-set
-/// semantics can be tested without mutating process-global env state.
-pub(crate) fn resolve_rate_limit_from(
-    per_second: Option<&str>,
-    burst_size: Option<&str>,
-) -> Option<RateLimit> {
-    // Default-OFF: neither knob present means no governor anywhere.
-    if per_second.is_none() && burst_size.is_none() {
-        return None;
-    }
-    let per_second = per_second
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(GENERAL_PER_SECOND);
-    let burst_size = burst_size
-        .and_then(|v| v.trim().parse::<u32>().ok())
-        .unwrap_or(GENERAL_BURST_SIZE);
-    Some((per_second, burst_size))
-}
-
 /// Build the full REST API router with routes dynamically generated from
 /// the endpoint registry plus hand-written system routes.
 ///
-/// `rate_limit` mounts the per-IP general rate limiter only when `Some`
-/// (see [`resolve_rate_limit`]); the terminal this server replaces does no
-/// per-IP rate limiting, so the default `None` attaches no general governor.
-/// The tighter shutdown-route limiter is mounted unconditionally.
-///
 /// Default port: 25503 (matching ThetaData v3 terminal).
-pub fn build(state: AppState, rate_limit: Option<RateLimit>) -> Router {
+pub fn build(state: AppState) -> Router {
     let mut app = Router::new();
     let mut registered = 0usize;
 
@@ -250,20 +107,9 @@ pub fn build(state: AppState, rate_limit: Option<RateLimit>) -> Router {
     // call as its query-form sibling.
     app = register_v3_path_routes(app);
 
-    // Build the per-route governor for the shutdown endpoint. Must be
-    // attached with `route_layer` so it only applies to `/v3/system/shutdown`
-    // and not to the sibling system-status routes.
-    let shutdown_governor = Arc::new(
-        GovernorConfigBuilder::default()
-            .key_extractor(PeerIpKeyExtractor)
-            .period(SHUTDOWN_REPLENISH_PERIOD)
-            .burst_size(SHUTDOWN_BURST_SIZE)
-            .finish()
-            .expect("shutdown governor config invariants hold at build time"),
-    );
-
-    // System routes. The shutdown route gets a tighter, route-scoped
-    // governor; the rest fall under the global governor attached below.
+    // System routes. The mutating shutdown route is guarded by the
+    // `X-Shutdown-Token` header (checked in `handler::system_shutdown`); the
+    // status routes are read-only.
     app = app
         .route("/v3/system/status", get(handler::system_status))
         .route(
@@ -274,12 +120,7 @@ pub fn build(state: AppState, rate_limit: Option<RateLimit>) -> Router {
             "/v3/system/streaming/status",
             get(handler::system_streaming_status),
         )
-        .route(
-            "/v3/system/shutdown",
-            post(handler::system_shutdown).route_layer(
-                GovernorLayer::new(shutdown_governor).error_handler(governor_error_response),
-            ),
-        );
+        .route("/v3/system/shutdown", post(handler::system_shutdown));
 
     // Terminal-compatible management status routes. The JVM terminal this
     // server replaces serves channel health under `/v3/terminal/<channel>/
@@ -317,46 +158,14 @@ pub fn build(state: AppState, rate_limit: Option<RateLimit>) -> Router {
     app = crate::flatfile_routes::add_flatfile_routes(app);
 
     // `.layer(X).layer(Y)` in axum/tower makes Y wrap X (outer wraps inner),
-    // so the LAST `.layer(...)` call is the outermost request wrapper. We
-    // want the governor to reject rate-exceeded requests BEFORE they
-    // consume a concurrency permit or body-limit slot, so it lives last.
-    let mut app = app
+    // so the LAST `.layer(...)` call is the outermost request wrapper.
+    let app = app
         .layer(ConcurrencyLimitLayer::new(GLOBAL_CONCURRENCY_LIMIT))
         .layer(DefaultBodyLimit::max(BODY_LIMIT_BYTES));
 
-    // Global per-IP governor (outermost rate limit), an opt-in DoS guard.
-    // The terminal this server replaces does no per-IP rate limiting, so
-    // the default attaches no general governor; an operator exposing the
-    // server as a relay opts in via the rate-limit env vars. The shutdown
-    // route's tighter governor above stays active on every bind regardless.
-    if let Some((per_second, burst_size)) = rate_limit {
-        let global_governor = Arc::new(
-            GovernorConfigBuilder::default()
-                .key_extractor(PeerIpKeyExtractor)
-                .per_second(per_second)
-                .burst_size(burst_size)
-                .finish()
-                .expect("general governor config invariants hold at build time"),
-        );
-
-        // `GovernorLayer` needs a background task that periodically purges
-        // stale per-IP buckets to keep the map from growing unbounded under
-        // churn.
-        let global_cleanup = Arc::clone(&global_governor);
-        tokio::spawn(async move {
-            let interval = Duration::from_secs(60);
-            loop {
-                tokio::time::sleep(interval).await;
-                global_cleanup.limiter().retain_recent();
-            }
-        });
-
-        app = app.layer(GovernorLayer::new(global_governor).error_handler(governor_error_response));
-    }
-
     // Per-request access log: one INFO line per request with method +
     // URI (span fields) and status + latency (event fields). Outermost
-    // layer so rate-limit rejections are logged too. Operators silence
+    // layer so it captures every response. Operators silence
     // it with `--log-level info,tower_http=off`.
     let app = app.layer(
         TraceLayer::new_for_http()
@@ -482,197 +291,11 @@ fn registry_route_handler(
 mod tests {
     use super::*;
 
-    use std::net::SocketAddr;
-
     use axum::body::Body;
-    use axum::extract::ConnectInfo;
-    use axum::http::Request;
+    use axum::http::{Request, StatusCode};
     use axum::routing::get;
     use axum::Router;
     use tower::ServiceExt;
-
-    async fn body_string(resp: axum::response::Response) -> String {
-        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .expect("body collect");
-        String::from_utf8(bytes.to_vec()).expect("body utf8")
-    }
-
-    /// Build a minimal router that mounts the general governor exactly as
-    /// `build()` does — same `GovernorConfigBuilder`, `PeerIpKeyExtractor`,
-    /// and `governor_error_response` — over a trivial `200 OK` route, so the
-    /// opt-in / default-off wiring can be exercised at the wire level without
-    /// constructing a live `AppState`.
-    fn governor_probe_router(rate_limit: Option<RateLimit>) -> Router {
-        let app = Router::new().route("/probe", get(|| async { StatusCode::OK }));
-        let Some((per_second, burst_size)) = rate_limit else {
-            return app;
-        };
-        let governor = Arc::new(
-            GovernorConfigBuilder::default()
-                .key_extractor(PeerIpKeyExtractor)
-                .per_second(per_second)
-                .burst_size(burst_size)
-                .finish()
-                .expect("general governor config invariants hold at build time"),
-        );
-        app.layer(GovernorLayer::new(governor).error_handler(governor_error_response))
-    }
-
-    /// Fire one `/probe` request carrying a peer `ConnectInfo` so the
-    /// `PeerIpKeyExtractor` resolves a key, returning the response status.
-    async fn probe_once(app: &Router, peer: SocketAddr) -> StatusCode {
-        let mut req = Request::builder()
-            .uri("/probe")
-            .body(Body::empty())
-            .expect("request builds");
-        req.extensions_mut().insert(ConnectInfo(peer));
-        app.clone()
-            .oneshot(req)
-            .await
-            .expect("router responds")
-            .status()
-    }
-
-    /// Default-OFF: with no rate limit resolved, a burst far exceeding the
-    /// old 20 rps / burst 40 ceiling is never `429`'d — the server imposes
-    /// no per-IP limit, matching the terminal it replaces.
-    #[tokio::test]
-    async fn no_governor_when_rate_limit_unset_never_429s_a_burst() {
-        let app = governor_probe_router(None);
-        let peer: SocketAddr = "203.0.113.7:9000".parse().unwrap();
-        for _ in 0..100 {
-            assert_eq!(
-                probe_once(&app, peer).await,
-                StatusCode::OK,
-                "default-off server must not rate-limit any request"
-            );
-        }
-    }
-
-    /// Opt-in: with a tuned ceiling, traffic up to the burst passes and the
-    /// next same-IP request in the same instant is rejected with `429`.
-    #[tokio::test]
-    async fn governor_enforces_tuned_ceiling_when_rate_limit_set() {
-        // burst_size 3 with a low refill: the 4th immediate request from the
-        // same peer must be shed.
-        let app = governor_probe_router(Some((1, 3)));
-        let peer: SocketAddr = "203.0.113.8:9000".parse().unwrap();
-
-        for n in 0..3 {
-            assert_eq!(
-                probe_once(&app, peer).await,
-                StatusCode::OK,
-                "request {n} within the burst must pass"
-            );
-        }
-        assert_eq!(
-            probe_once(&app, peer).await,
-            StatusCode::TOO_MANY_REQUESTS,
-            "request past the tuned burst must be rate-limited"
-        );
-    }
-
-    /// 429 rejections carry the canonical envelope, the bare JSON
-    /// content type, and an RFC 9110 `Retry-After` header in seconds —
-    /// the shape every HTTP retry helper consumes natively.
-    #[tokio::test]
-    async fn rate_limit_rejection_is_canonical_envelope_with_retry_after() {
-        let resp = governor_error_response(GovernorError::TooManyRequests {
-            wait_time: 3,
-            headers: None,
-        });
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        assert_eq!(
-            resp.headers()
-                .get(axum::http::header::RETRY_AFTER)
-                .and_then(|v| v.to_str().ok()),
-            Some("3"),
-            "Retry-After must carry the bucket-refill wait in seconds"
-        );
-        assert_eq!(
-            resp.headers()
-                .get(axum::http::header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok()),
-            Some("application/json")
-        );
-
-        let body = body_string(resp).await;
-        assert!(
-            body.contains("\"error_type\":\"rate_limited\""),
-            "envelope must carry the rate_limited error type: {body}"
-        );
-        assert!(
-            body.contains("retry after 3s"),
-            "error_msg must state the wait: {body}"
-        );
-        assert!(
-            body.contains("\"response\":[]"),
-            "envelope must carry the empty response array: {body}"
-        );
-    }
-
-    #[tokio::test]
-    async fn key_extraction_failure_maps_to_structured_500() {
-        let resp = governor_error_response(GovernorError::UnableToExtractKey);
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        let body = body_string(resp).await;
-        assert!(body.contains("\"error_type\":\"server_error\""), "{body}");
-    }
-
-    #[tokio::test]
-    async fn other_governor_errors_keep_their_status_and_envelope() {
-        let resp = governor_error_response(GovernorError::Other {
-            code: StatusCode::SERVICE_UNAVAILABLE,
-            msg: Some("limiter offline".to_string()),
-            headers: None,
-        });
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-        let body = body_string(resp).await;
-        assert!(body.contains("limiter offline"), "{body}");
-    }
-
-    /// Default-OFF: with neither env var set the limiter resolves to
-    /// `None`, so no general governor is attached on any bind — the
-    /// terminal this server replaces imposes no per-IP rate limit.
-    #[test]
-    fn rate_limit_is_off_when_neither_env_var_is_set() {
-        assert_eq!(resolve_rate_limit_from(None, None), None);
-    }
-
-    /// Both env vars set: the operator's tuned pair is used verbatim.
-    #[test]
-    fn rate_limit_uses_both_operator_values_when_set() {
-        assert_eq!(resolve_rate_limit_from(Some("5"), Some("9")), Some((5, 9)));
-    }
-
-    /// Only one of the pair set still turns the limiter ON; the absent
-    /// field falls back to its documented default constant.
-    #[test]
-    fn rate_limit_partial_set_falls_back_to_defaults() {
-        assert_eq!(
-            resolve_rate_limit_from(Some("7"), None),
-            Some((7, GENERAL_BURST_SIZE))
-        );
-        assert_eq!(
-            resolve_rate_limit_from(None, Some("11")),
-            Some((GENERAL_PER_SECOND, 11))
-        );
-    }
-
-    /// A present-but-unparseable value falls back to its default rather
-    /// than disabling the limiter the operator asked for.
-    #[test]
-    fn rate_limit_unparseable_value_falls_back_to_default() {
-        assert_eq!(
-            resolve_rate_limit_from(Some("not-a-number"), Some("9")),
-            Some((GENERAL_PER_SECOND, 9))
-        );
-        assert_eq!(
-            resolve_rate_limit_from(Some("5"), Some("oops")),
-            Some((5, GENERAL_BURST_SIZE))
-        );
-    }
 
     // -----------------------------------------------------------------------
     //  v3 path-form routes (C6 / H1) — registry wiring + matchit coexistence

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -22,16 +22,15 @@
 //!
 //! The terminal this server replaces does no per-IP rate limiting, and
 //! neither does this server — real request limits are enforced upstream by
-//! the data service. The mutating `/v3/system/shutdown` route is guarded by
-//! an `X-Shutdown-Token` header (a 128-bit random token), not by a rate
-//! limit. The server binds to `0.0.0.0` by default (all interfaces,
-//! matching the JVM terminal it replaces); pass `--bind 127.0.0.1` for
-//! loopback-only exposure.
+//! the data service. The system routes mirror the terminal 1:1, including its
+//! unauthenticated `GET /v3/terminal/shutdown`. The server binds to `0.0.0.0`
+//! by default (all interfaces, matching the JVM terminal it replaces); pass
+//! `--bind 127.0.0.1` for loopback-only exposure.
 
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
-use axum::routing::{get, post};
+use axum::routing::get;
 use axum::Router;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
@@ -107,41 +106,16 @@ pub fn build(state: AppState) -> Router {
     // call as its query-form sibling.
     app = register_v3_path_routes(app);
 
-    // System routes. The mutating shutdown route is guarded by the
-    // `X-Shutdown-Token` header (checked in `handler::system_shutdown`); the
-    // status routes are read-only.
+    // Terminal system routes, mirrored 1:1 from the JVM terminal this server
+    // replaces. The terminal serves exactly three unauthenticated GET routes
+    // under `/v3/terminal/`: `shutdown` (kills the process, returns the plain
+    // text `OK`), plus one-word channel-health probes for the FPSS (streaming)
+    // and MDDS (historical) transports. The transport codenames are the vendor
+    // terminal's own public wire paths, not client-facing prose. Bodies are the
+    // terminal's bare `text/plain` shape so operator tooling that scrapes the
+    // terminal's mgmt surface works unchanged.
     app = app
-        .route("/v3/system/status", get(handler::system_status))
-        .route(
-            "/v3/system/historical/status",
-            get(handler::system_historical_status),
-        )
-        .route(
-            "/v3/system/streaming/status",
-            get(handler::system_streaming_status),
-        )
-        .route("/v3/system/shutdown", post(handler::system_shutdown));
-
-    // Terminal-compatible management status routes. The JVM terminal this
-    // server replaces serves channel health under `/v3/terminal/<channel>/
-    // status` as a one-word `text/plain` body; replicating the terminal's
-    // literal paths verbatim is what lets operator tooling that scrapes the
-    // terminal's mgmt surface keep working without changes. The transport
-    // codenames in these two paths are the vendor terminal's own wire path,
-    // not client-facing prose. The mutating `/v3/terminal/shutdown` GET the
-    // terminal also exposes is deliberately NOT mirrored: this server gates
-    // shutdown behind a token on a non-cacheable POST (`/v3/system/shutdown`)
-    // — an unauthenticated GET that any prefetch / CSRF could trip would
-    // regress that hardening.
-    app = app
-        .route(
-            "/v3/terminal/streaming/status",
-            get(handler::terminal_streaming_status),
-        )
-        .route(
-            "/v3/terminal/historical/status",
-            get(handler::terminal_historical_status),
-        )
+        .route("/v3/terminal/shutdown", get(handler::terminal_shutdown))
         .route(
             "/v3/terminal/fpss/status",
             get(handler::terminal_streaming_status),

--- a/tools/server/src/state.rs
+++ b/tools/server/src/state.rs
@@ -10,26 +10,6 @@ use std::sync::Arc;
 use thetadatadx::Client;
 use tokio::sync::{mpsc, RwLock};
 
-/// Constant-time byte-slice equality.
-///
-/// Compares every byte regardless of where the first difference sits,
-/// preventing a remote attacker from probing a secret one byte at a time
-/// via response-latency measurements (timing oracle). A length mismatch
-/// returns `false` immediately — this leaks the lengths but not the
-/// contents, which is the same contract `subtle::ConstantTimeEq` provides
-/// for `[u8]`.
-#[inline]
-fn ct_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
 /// Default per-client channel capacity. Matches the old `broadcast::channel(4096)`.
 ///
 /// At ~10k events/sec peak (market open), 4096 gives ~400ms of headroom
@@ -91,8 +71,6 @@ struct Inner {
     /// across `.await`) is sufficient; the critical sections are
     /// pointer swaps.
     ws_session: std::sync::Mutex<Option<Arc<tokio::sync::Notify>>>,
-    /// Random token required by the shutdown endpoint.
-    shutdown_token: String,
     /// Monotonic count of FPSS events dropped on the bounded
     /// callback->broadcast handoff (see `ws::start_fpss_bridge`). Mirrors the
     /// FPSS SDK's per-handle `dropped_events()` counter so operators can
@@ -103,7 +81,7 @@ struct Inner {
 
 impl AppState {
     /// Create new app state wrapping a connected `Client`.
-    pub fn new(client: Client, shutdown_token: String) -> Self {
+    pub fn new(client: Client) -> Self {
         Self {
             inner: Arc::new(Inner {
                 client,
@@ -112,7 +90,6 @@ impl AppState {
                 ws_clients: Arc::new(RwLock::new(Vec::new())),
                 shutdown: tokio::sync::Notify::new(),
                 ws_session: std::sync::Mutex::new(None),
-                shutdown_token,
                 fpss_broadcast_dropped: AtomicU64::new(0),
             }),
         }
@@ -127,13 +104,6 @@ impl AppState {
             .fpss_broadcast_dropped
             .fetch_add(1, Ordering::Relaxed)
             .wrapping_add(1)
-    }
-
-    /// Total FPSS events dropped on the bounded callback->broadcast handoff
-    /// since this `AppState` was created. Used by the WS health endpoint and
-    /// the per-1024-drop rate-limited warning log in `ws::broadcast`.
-    pub fn fpss_broadcast_dropped(&self) -> u64 {
-        self.inner.fpss_broadcast_dropped.load(Ordering::Relaxed)
     }
 
     /// Borrow the unified `Client` client.
@@ -273,15 +243,6 @@ impl AppState {
         }
     }
 
-    /// Validate a shutdown token against the one generated at startup.
-    ///
-    /// Uses constant-time comparison so an attacker cannot probe the token
-    /// byte-by-byte via the response latency of `POST /shutdown`. A length
-    /// mismatch returns `false` without revealing content.
-    pub fn validate_shutdown_token(&self, token: &str) -> bool {
-        ct_eq(self.inner.shutdown_token.as_bytes(), token.as_bytes())
-    }
-
     /// Signal graceful server shutdown. Stops FPSS streaming if active.
     pub fn shutdown(&self) {
         self.inner.client.stream().stop_streaming();
@@ -296,7 +257,7 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::{ct_eq, ws_client_capacity_from, WS_CLIENT_CAPACITY};
+    use super::{ws_client_capacity_from, WS_CLIENT_CAPACITY};
     use std::sync::Arc;
 
     /// Unset env falls back to the compiled-in default capacity.
@@ -399,24 +360,5 @@ mod tests {
             waited.is_err(),
             "a lone session must not receive a close signal"
         );
-    }
-
-    #[test]
-    fn ct_eq_equal_returns_true() {
-        assert!(ct_eq(b"token", b"token"));
-        assert!(ct_eq(&[], &[]));
-    }
-
-    #[test]
-    fn ct_eq_unequal_returns_false() {
-        assert!(!ct_eq(b"abc", b"xyz"));
-        // Differs only at the last byte — full scan must still happen.
-        assert!(!ct_eq(b"token1", b"token2"));
-    }
-
-    #[test]
-    fn ct_eq_length_mismatch_returns_false() {
-        assert!(!ct_eq(b"token", b"token_long"));
-        assert!(!ct_eq(&[], b"x"));
     }
 }

--- a/tools/server/src/state.rs
+++ b/tools/server/src/state.rs
@@ -45,6 +45,19 @@ fn ws_client_capacity_from(raw: Option<&str>) -> usize {
 /// the JSON payload per client.
 pub type WsClients = Arc<RwLock<Vec<mpsc::Sender<Arc<str>>>>>;
 
+/// WebSocket option-`strike` wire encoding.
+///
+/// `Terminal` emits and accepts the JVM terminal's 1/10-cent integer (a
+/// `$570` strike is `570000`) — the exact drop-in wire form. `Dollars`
+/// emits and accepts a dollar value (`570`), the SDK's convenience form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum StrikeFormat {
+    /// The JVM terminal's 1/10-cent integer (a `$570` strike is `570000`).
+    Terminal,
+    /// A dollar value (a `$570` strike is `570`).
+    Dollars,
+}
+
 /// Shared server state, cloned into every axum handler.
 #[derive(Clone)]
 pub struct AppState {
@@ -77,11 +90,13 @@ struct Inner {
     /// scrape one number to detect WS-side back-pressure independent of the
     /// SDK-side event ring overrun counter.
     fpss_broadcast_dropped: AtomicU64,
+    /// WebSocket option-`strike` wire encoding (see [`StrikeFormat`]).
+    strike_format: StrikeFormat,
 }
 
 impl AppState {
     /// Create new app state wrapping a connected `Client`.
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client, strike_format: StrikeFormat) -> Self {
         Self {
             inner: Arc::new(Inner {
                 client,
@@ -91,8 +106,14 @@ impl AppState {
                 shutdown: tokio::sync::Notify::new(),
                 ws_session: std::sync::Mutex::new(None),
                 fpss_broadcast_dropped: AtomicU64::new(0),
+                strike_format,
             }),
         }
+    }
+
+    /// The WebSocket option-`strike` wire encoding this server serves.
+    pub fn strike_format(&self) -> StrikeFormat {
+        self.inner.strike_format
     }
 
     /// Increment the FPSS broadcast-drop counter and return the post-increment

--- a/tools/server/src/ws/broadcast.rs
+++ b/tools/server/src/ws/broadcast.rs
@@ -42,9 +42,8 @@ const WARN_EVERY_N: u64 = 1024;
 /// so a stalled broadcast task can never accumulate unbounded heap. When the
 /// channel is full, the callback increments [`AppState::record_fpss_broadcast_drop`]
 /// and returns immediately — the event-dispatch consumer thread is never blocked.
-/// Drops surface to operators through the `fpss_broadcast_dropped()` counter
-/// and a rate-limited `tracing::warn!` (one warning per [`WARN_EVERY_N`]
-/// drops).
+/// Drops surface to operators through a rate-limited `tracing::warn!` (one
+/// warning per [`WARN_EVERY_N`] drops).
 ///
 /// # Contract identity
 ///

--- a/tools/server/src/ws/broadcast.rs
+++ b/tools/server/src/ws/broadcast.rs
@@ -76,7 +76,12 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
             // and broadcast. No map lock acquired in the broadcast task.
             // Borrow through the `Arc` (deref) so the serializer sees the
             // same `&Contract` it always did.
-            let json = fpss_event_to_ws_json(&event, peeked.as_deref());
+            let json = fpss_event_to_ws_json(
+                &event,
+                peeked.as_deref(),
+                state_for_task.fpss_status(),
+                state_for_task.strike_format(),
+            );
             if let Some(ws_json) = json {
                 let msg: Arc<str> = Arc::from(ws_json);
                 state_for_task.broadcast_ws(msg).await;

--- a/tools/server/src/ws/format.rs
+++ b/tools/server/src/ws/format.rs
@@ -7,6 +7,8 @@ use thetadatadx::fpss::{
     StreamControl, StreamData, StreamEvent, UNRESOLVED_CONTRACT_SYMBOL_PREFIX,
 };
 
+use crate::state::StrikeFormat;
+
 /// Total events dropped because their JSON serialization failed.
 ///
 /// Distinct from the WS broadcast-channel drop counter — this counts
@@ -45,9 +47,19 @@ fn try_serialize(msg: &sonic_rs::Value) -> Option<String> {
 /// (see [`super::contract_map::lookup_event_contract`]). Passing it in
 /// keeps the broadcast task contract-aware without re-deriving the
 /// reference from the event on every serialisation.
+///
+/// `status` is the live terminal->FPSS connectivity (`CONNECTED` /
+/// `DISCONNECTED`, from [`crate::state::AppState::fpss_status`]). The
+/// terminal stamps it into the header of every frame, not just STATUS
+/// heartbeats, so it is threaded onto each frame built here.
+///
+/// `strike_format` selects the option-`strike` encoding on the contract
+/// envelope (see [`StrikeFormat`]).
 pub(super) fn fpss_event_to_ws_json(
     event: &StreamEvent,
     peeked_contract: Option<&Contract>,
+    status: &str,
+    strike_format: StrikeFormat,
 ) -> Option<String> {
     match event {
         StreamEvent::Data(data) => {
@@ -180,7 +192,10 @@ pub(super) fn fpss_event_to_ws_json(
             // no way to disambiguate a backlog of pre-ContractAssigned
             // ticks from a serialisation regression.
             let mut msg_obj = sonic_rs::Object::new();
-            msg_obj.insert("header", sonic_rs::json!({ "type": event_type }));
+            msg_obj.insert(
+                "header",
+                sonic_rs::json!({ "type": event_type, "status": status }),
+            );
             match peeked_contract {
                 Some(c) if is_unresolved_contract(c) => {
                     // Pre-ContractAssigned tick. Emit a `pending`
@@ -191,7 +206,7 @@ pub(super) fn fpss_event_to_ws_json(
                     }
                 }
                 Some(c) => {
-                    msg_obj.insert("contract", contract_to_json(c));
+                    msg_obj.insert("contract", contract_to_json(c, strike_format));
                 }
                 None => {
                     msg_obj.insert("contract", sonic_rs::json!({}));
@@ -213,6 +228,7 @@ pub(super) fn fpss_event_to_ws_json(
                 let msg = sonic_rs::json!({
                     "header": {
                         "type": "REQ_RESPONSE",
+                        "status": status,
                         "response": result.as_wire_str(),
                         "req_id": req_id,
                     }
@@ -228,13 +244,13 @@ pub(super) fn fpss_event_to_ws_json(
             // which is a `header.status` value the terminal never emits.
             StreamControl::MarketOpen => {
                 let msg = sonic_rs::json!({
-                    "header": { "type": "STATE", "state": "START" }
+                    "header": { "type": "STATE", "status": status, "state": "START" }
                 });
                 try_serialize(&msg)
             }
             StreamControl::MarketClose => {
                 let msg = sonic_rs::json!({
-                    "header": { "type": "STATE", "state": "STOP" }
+                    "header": { "type": "STATE", "status": status, "state": "STOP" }
                 });
                 try_serialize(&msg)
             }
@@ -298,23 +314,33 @@ fn parse_unresolved_contract_id(symbol: &str) -> Option<i32> {
 /// - `security_type` / `root` are always present (the terminal names the
 ///   keys `security_type` and `root`, not `sec_type` / `symbol`).
 /// - `expiration` / `strike` / `right` are present only for options.
-/// - `strike` is dollars (a `$550.00` strike serializes as `550.0`), the
-///   same unit every other public surface speaks; the wire's fixed-point
-///   integer never leaves the codec layer.
-fn contract_to_json(c: &Contract) -> sonic_rs::Value {
+/// - `strike` follows `strike_format`: `Terminal` emits the terminal's
+///   fixed-point integer in 1/10 of a cent (a `$140.00` strike serializes as
+///   `140000`), matching the streaming wire the JVM terminal emits;
+///   `Dollars` emits the dollar value (`140.0`), the SDK's convenience form.
+fn contract_to_json(c: &Contract, strike_format: StrikeFormat) -> sonic_rs::Value {
     let mut obj = sonic_rs::Object::new();
     obj.insert("security_type", sonic_rs::Value::from(c.sec_type.as_str()));
     obj.insert("root", sonic_rs::Value::from(&*c.symbol));
     if let Some(exp) = c.expiration {
         obj.insert("expiration", sonic_rs::Value::from(exp));
     }
-    // `strike` is dollars on every public surface; the wire's
-    // fixed-point integer never leaves the codec layer.
-    if let Some(strike) = c.strike_dollars() {
-        obj.insert(
-            "strike",
-            sonic_rs::to_value(&strike).expect("f64 should serialize"),
-        );
+    match strike_format {
+        // `Terminal`: the 1/10-cent integer emitted verbatim (`140000`).
+        StrikeFormat::Terminal => {
+            if let Some(strike) = c.strike_thousandths {
+                obj.insert("strike", sonic_rs::Value::from(strike));
+            }
+        }
+        // `Dollars`: the dollar value (`140.0`), the SDK's convenience form.
+        StrikeFormat::Dollars => {
+            if let Some(strike) = c.strike_dollars() {
+                obj.insert(
+                    "strike",
+                    sonic_rs::to_value(&strike).expect("f64 serializes"),
+                );
+            }
+        }
     }
     if let Some(is_call) = c.is_call {
         obj.insert(
@@ -389,8 +415,9 @@ mod tests {
     fn trade_frame_matches_terminal_field_set() {
         let contract = Arc::new(Contract::stock("AAPL"));
         let event = make_trade(Arc::clone(&contract));
-        let json = fpss_event_to_ws_json(&event, Some(&contract))
-            .expect("Trade serialization must succeed");
+        let json =
+            fpss_event_to_ws_json(&event, Some(&contract), "CONNECTED", StrikeFormat::Terminal)
+                .expect("Trade serialization must succeed");
 
         for key in [
             "ms_of_day",
@@ -413,9 +440,11 @@ mod tests {
                 "Trade frame must NOT carry the SDK-only `{key}` column: {json}"
             );
         }
+        // Header carries the frame type and the live FPSS connectivity
+        // status the terminal stamps into every message header.
         assert!(
-            json.contains("\"header\":{\"type\":\"TRADE\"}"),
-            "Trade frame header type: {json}"
+            json.contains("\"type\":\"TRADE\"") && json.contains("\"status\":\"CONNECTED\""),
+            "Trade frame header type + status: {json}"
         );
     }
 
@@ -426,8 +455,9 @@ mod tests {
     fn market_value_frame_serializes_calculated_columns() {
         let contract = Arc::new(Contract::stock("SPX"));
         let event = make_market_value(Arc::clone(&contract));
-        let json = fpss_event_to_ws_json(&event, Some(&contract))
-            .expect("MARKET_VALUE serialization must succeed");
+        let json =
+            fpss_event_to_ws_json(&event, Some(&contract), "CONNECTED", StrikeFormat::Terminal)
+                .expect("MARKET_VALUE serialization must succeed");
 
         for key in [
             "ms_of_day",
@@ -446,8 +476,8 @@ mod tests {
             "MARKET_VALUE frame must NOT carry the our-only `received_at_ns`: {json}"
         );
         assert!(
-            json.contains("\"header\":{\"type\":\"MARKET_VALUE\"}"),
-            "MARKET_VALUE frame header type: {json}"
+            json.contains("\"type\":\"MARKET_VALUE\"") && json.contains("\"status\":\"CONNECTED\""),
+            "MARKET_VALUE frame header type + status: {json}"
         );
         // The terminal names the contract key `root`, not `symbol`.
         assert!(
@@ -467,8 +497,9 @@ mod tests {
         let event = make_quote(Arc::clone(&contract));
         let peeked = lookup_event_contract(&event).expect("event carries its contract");
         assert_eq!(&*peeked.symbol, "AAPL");
-        let json = fpss_event_to_ws_json(&event, Some(&peeked))
-            .expect("serialization must succeed with the event's contract");
+        let json =
+            fpss_event_to_ws_json(&event, Some(&peeked), "CONNECTED", StrikeFormat::Terminal)
+                .expect("serialization must succeed with the event's contract");
         assert!(
             json.contains("\"root\":\"AAPL\""),
             "serialized JSON must include the event's contract under `root`: {json}"
@@ -483,7 +514,7 @@ mod tests {
     fn empty_contract_sentinel_serializes_without_id_leak() {
         let sentinel = Arc::new(Contract::stock(""));
         let event = make_quote(Arc::clone(&sentinel));
-        let json = fpss_event_to_ws_json(&event, None)
+        let json = fpss_event_to_ws_json(&event, None, "CONNECTED", StrikeFormat::Terminal)
             .expect("serialization must succeed with no resolved contract");
         assert!(
             !json.contains("\"id\":"),
@@ -502,8 +533,13 @@ mod tests {
     fn unresolved_sentinel_surfaces_wire_id_to_ws_payload() {
         let unresolved = Arc::new(Contract::pending(42));
         let event = make_quote(Arc::clone(&unresolved));
-        let json = fpss_event_to_ws_json(&event, Some(&unresolved))
-            .expect("serialization must succeed for an unresolved sentinel");
+        let json = fpss_event_to_ws_json(
+            &event,
+            Some(&unresolved),
+            "CONNECTED",
+            StrikeFormat::Terminal,
+        )
+        .expect("serialization must succeed for an unresolved sentinel");
 
         assert!(
             json.contains("\"unresolved_contract_id\":42"),
@@ -549,7 +585,7 @@ mod tests {
                 req_id: 7,
                 result: outcome,
             });
-            let json = fpss_event_to_ws_json(&event, None)
+            let json = fpss_event_to_ws_json(&event, None, "CONNECTED", StrikeFormat::Terminal)
                 .expect("REQ_RESPONSE control frame must serialise");
             assert!(
                 json.contains(&format!("\"response\":\"{token}\"")),
@@ -581,7 +617,7 @@ mod tests {
         ] {
             let event =
                 StreamEvent::Control(thetadatadx::fpss::StreamControl::Disconnected { reason });
-            let json = fpss_event_to_ws_json(&event, None)
+            let json = fpss_event_to_ws_json(&event, None, "CONNECTED", StrikeFormat::Terminal)
                 .expect("DISCONNECTED control frame must serialise");
             // Key order inside the header object is serializer-defined;
             // assert on content, not byte-exact key ordering.
@@ -603,15 +639,17 @@ mod tests {
     }
 
     /// The contract envelope uses the terminal's key names (`security_type`
-    /// / `root`, not `sec_type` / `symbol`) and emits `strike` in dollars
-    /// (a `$550.00` strike serializes as `550.0`) — the same unit every
-    /// other public surface speaks.
+    /// / `root`, not `sec_type` / `symbol`) and emits `strike` as the
+    /// terminal's 1/10-cent integer (a `$550.00` strike serializes as
+    /// `550000`) — the streaming wire's unit, distinct from the REST
+    /// surface's dollars.
     #[test]
-    fn option_contract_envelope_uses_terminal_keys_and_dollar_strike() {
+    fn option_contract_envelope_uses_terminal_keys_and_integer_strike() {
         let contract = Arc::new(Contract::option_raw("SPY", 20_260_417, true, 550_000));
         let event = make_quote(Arc::clone(&contract));
-        let json = fpss_event_to_ws_json(&event, Some(&contract))
-            .expect("Quote serialization must succeed");
+        let json =
+            fpss_event_to_ws_json(&event, Some(&contract), "CONNECTED", StrikeFormat::Terminal)
+                .expect("Quote serialization must succeed");
 
         assert!(
             json.contains("\"security_type\":\"OPTION\""),
@@ -621,20 +659,41 @@ mod tests {
             json.contains("\"root\":\"SPY\""),
             "contract must carry `root`, not `symbol`: {json}"
         );
-        // Dollars float (`550.0`), NOT the raw thousandths integer.
+        // Raw 1/10-cent integer (`550000`), NOT the dollars float.
         assert!(
-            json.contains("\"strike\":550.0"),
-            "strike must serialize as a dollars float: {json}"
+            json.contains("\"strike\":550000"),
+            "strike must serialize as the terminal's 1/10-cent integer: {json}"
         );
         assert!(
-            !json.contains("\"strike\":550000"),
-            "strike must NOT serialize as the raw thousandths integer: {json}"
+            !json.contains("\"strike\":550.0"),
+            "strike must NOT serialize as a dollars float: {json}"
         );
         assert!(json.contains("\"expiration\":20260417"), "{json}");
         assert!(json.contains("\"right\":\"C\""), "{json}");
         // The old key names must be gone entirely.
         assert!(!json.contains("\"sec_type\":"), "{json}");
         assert!(!json.contains("\"symbol\":"), "{json}");
+    }
+
+    /// Under `StrikeFormat::Dollars` the same `550000` wire strike serializes
+    /// as the dollar value `550.0`, not the 1/10-cent integer — the SDK's
+    /// convenience form the `--strike-format dollars` flag selects.
+    #[test]
+    fn option_contract_envelope_emits_dollars_strike_when_selected() {
+        let contract = Arc::new(Contract::option_raw("SPY", 20_260_417, true, 550_000));
+        let event = make_quote(Arc::clone(&contract));
+        let json =
+            fpss_event_to_ws_json(&event, Some(&contract), "CONNECTED", StrikeFormat::Dollars)
+                .expect("Quote serialization must succeed");
+
+        assert!(
+            json.contains("\"strike\":550.0"),
+            "strike must serialize as the dollar value under Dollars: {json}"
+        );
+        assert!(
+            !json.contains("\"strike\":550000"),
+            "strike must NOT serialize as the 1/10-cent integer under Dollars: {json}"
+        );
     }
 
     /// The FPSS START / STOP lifecycle frames (decoded to `MarketOpen` /
@@ -649,8 +708,8 @@ mod tests {
             (thetadatadx::fpss::StreamControl::MarketClose, "STOP"),
         ] {
             let event = StreamEvent::Control(ctrl);
-            let json =
-                fpss_event_to_ws_json(&event, None).expect("STATE control frame must serialise");
+            let json = fpss_event_to_ws_json(&event, None, "CONNECTED", StrikeFormat::Terminal)
+                .expect("STATE control frame must serialise");
             // Key order inside the header object is serializer-defined;
             // assert on content, not byte-exact key ordering.
             assert!(
@@ -676,7 +735,8 @@ mod tests {
             message: "boom".to_string(),
         });
         assert!(
-            fpss_event_to_ws_json(&server_error, None).is_none(),
+            fpss_event_to_ws_json(&server_error, None, "CONNECTED", StrikeFormat::Terminal)
+                .is_none(),
             "ServerError must not emit a header.type=ERROR frame"
         );
 
@@ -686,7 +746,7 @@ mod tests {
             contract: Arc::new(Contract::stock("AAPL")),
         });
         assert!(
-            fpss_event_to_ws_json(&assigned, None).is_none(),
+            fpss_event_to_ws_json(&assigned, None, "CONNECTED", StrikeFormat::Terminal).is_none(),
             "ContractAssigned must not emit a standalone CONTRACT frame"
         );
 
@@ -701,7 +761,9 @@ mod tests {
         assert!(
             fpss_event_to_ws_json(
                 &oi,
-                Some(&Contract::option_raw("SPY", 20_260_417, true, 550_000))
+                Some(&Contract::option_raw("SPY", 20_260_417, true, 550_000)),
+                "CONNECTED",
+                StrikeFormat::Terminal
             )
             .is_none(),
             "OpenInterest must not emit an OPEN_INTEREST frame"
@@ -715,8 +777,9 @@ mod tests {
     fn resolved_contract_path_unchanged_by_med_001_fix() {
         let resolved = Arc::new(Contract::stock("SPY"));
         let event = make_quote(Arc::clone(&resolved));
-        let json = fpss_event_to_ws_json(&event, Some(&resolved))
-            .expect("serialization must succeed for a resolved contract");
+        let json =
+            fpss_event_to_ws_json(&event, Some(&resolved), "CONNECTED", StrikeFormat::Terminal)
+                .expect("serialization must succeed for a resolved contract");
 
         assert!(json.contains("\"root\":\"SPY\""));
         assert!(

--- a/tools/server/src/ws/format.rs
+++ b/tools/server/src/ws/format.rs
@@ -17,13 +17,6 @@ use thetadatadx::fpss::{
 /// to a serialization bug.
 static JSON_SERIALIZE_FAILURES: AtomicU64 = AtomicU64::new(0);
 
-/// Snapshot of [`JSON_SERIALIZE_FAILURES`]. Used by metrics exporters
-/// and integration tests to assert the counter increments as expected.
-#[must_use]
-pub fn json_serialize_failure_count() -> u64 {
-    JSON_SERIALIZE_FAILURES.load(Ordering::Relaxed)
-}
-
 /// Wrap a `sonic_rs::to_string` call so a serialization failure logs
 /// (rate-limited at every 1024 failures) and bumps the public counter.
 /// Returns `None` exactly when `to_string` returned `Err`.

--- a/tools/server/src/ws/mod.rs
+++ b/tools/server/src/ws/mod.rs
@@ -15,15 +15,12 @@
 //!
 //! # Hardening
 //!
-//! The WS router composes the same layers as the REST router
-//! (`router::build`): a 256-wide `ConcurrencyLimitLayer`, a 64 KiB
-//! `DefaultBodyLimit`, and — only when the operator opts in via the
-//! rate-limit env vars — a per-peer-IP `GovernorLayer`. The terminal this
-//! server replaces does no per-IP rate limiting, so the default attaches no
-//! governor. On top of that, `handle_client_message` rejects any `Message::Text`
-//! longer than [`WS_MAX_TEXT_BYTES`]. A legitimate subscribe / stop command
-//! is well under 200 bytes; anything larger is attack-shaped and discarded
-//! before `sonic_rs::from_str` touches it.
+//! The WS router composes the same generic admission layers as the REST
+//! router (`router::build`): a 256-wide `ConcurrencyLimitLayer` and a 64 KiB
+//! `DefaultBodyLimit`. On top of that, `handle_client_message` rejects any
+//! `Message::Text` longer than [`WS_MAX_TEXT_BYTES`]. A legitimate subscribe
+//! / stop command is well under 200 bytes; anything larger is attack-shaped
+//! and discarded before `sonic_rs::from_str` touches it.
 
 mod broadcast;
 mod contract_map;
@@ -32,16 +29,10 @@ mod session;
 mod subscribe;
 mod upgrade;
 
-use std::sync::Arc;
-use std::time::Duration;
-
 use axum::extract::DefaultBodyLimit;
 use axum::routing::get;
 use axum::Router;
 use tower::limit::ConcurrencyLimitLayer;
-use tower_governor::governor::GovernorConfigBuilder;
-use tower_governor::key_extractor::PeerIpKeyExtractor;
-use tower_governor::GovernorLayer;
 
 use crate::state::AppState;
 
@@ -55,7 +46,7 @@ use crate::router::{BODY_LIMIT_BYTES, GLOBAL_CONCURRENCY_LIMIT};
 
 /// Build the WebSocket router (single route: `/v1/events`).
 ///
-/// Applies the same hardening layers as `router::build`:
+/// Applies the same generic admission layers as `router::build`:
 ///
 /// 1. `ConcurrencyLimitLayer` caps in-flight WS upgrades to
 ///    [`GLOBAL_CONCURRENCY_LIMIT`]; the single-client invariant is still
@@ -63,44 +54,10 @@ use crate::router::{BODY_LIMIT_BYTES, GLOBAL_CONCURRENCY_LIMIT};
 ///    attackers from queueing thousands of blocked upgrades.
 /// 2. `DefaultBodyLimit` caps the upgrade request body at
 ///    [`BODY_LIMIT_BYTES`].
-/// 3. `GovernorLayer` keyed on the peer connect-info IP enforces the
-///    operator's tuned `(per_second, burst)` pair — only when `rate_limit`
-///    is `Some` (the operator opted in via the rate-limit env vars; see
-///    `router::resolve_rate_limit`). The same pair is applied to the HTTP
-///    general governor, keeping the two surfaces consistent. The default is
-///    no governor, matching the terminal this server replaces. Peer-IP-only
-///    — `X-Forwarded-For` is ignored (see `router.rs` for rationale).
-pub fn router(state: AppState, rate_limit: Option<crate::router::RateLimit>) -> Router {
-    let mut app = Router::new()
+pub fn router(state: AppState) -> Router {
+    Router::new()
         .route("/v1/events", get(upgrade::ws_upgrade))
         .layer(ConcurrencyLimitLayer::new(GLOBAL_CONCURRENCY_LIMIT))
-        .layer(DefaultBodyLimit::max(BODY_LIMIT_BYTES));
-
-    if let Some((per_second, burst_size)) = rate_limit {
-        let governor = Arc::new(
-            GovernorConfigBuilder::default()
-                .key_extractor(PeerIpKeyExtractor)
-                .per_second(per_second)
-                .burst_size(burst_size)
-                .finish()
-                .expect("ws governor config invariants hold at build time"),
-        );
-
-        // Matches the REST router: periodically purge stale per-IP buckets so
-        // the rate-limit map cannot grow unbounded under churn.
-        let cleanup = Arc::clone(&governor);
-        tokio::spawn(async move {
-            let interval = Duration::from_secs(60);
-            loop {
-                tokio::time::sleep(interval).await;
-                cleanup.limiter().retain_recent();
-            }
-        });
-
-        app = app.layer(
-            GovernorLayer::new(governor).error_handler(crate::router::governor_error_response),
-        );
-    }
-
-    app.with_state(state)
+        .layer(DefaultBodyLimit::max(BODY_LIMIT_BYTES))
+        .with_state(state)
 }

--- a/tools/server/src/ws/mod.rs
+++ b/tools/server/src/ws/mod.rs
@@ -37,7 +37,6 @@ use tower::limit::ConcurrencyLimitLayer;
 use crate::state::AppState;
 
 pub use broadcast::start_fpss_bridge;
-pub use format::json_serialize_failure_count;
 
 // The WS router shares the HTTP router's admission caps verbatim so the two
 // surfaces shed pressure identically; import the originals rather than mirror

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -7,7 +7,7 @@ use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::time::is_valid_yyyymmdd;
 use thetadatadx::SecType;
 
-use crate::state::AppState;
+use crate::state::{AppState, StrikeFormat};
 use crate::validation;
 
 use super::session::send_response;
@@ -73,15 +73,20 @@ impl ReqResponse {
 /// only the JSON value, so the exact wire shape — including the
 /// `response` token and an optional `error` diagnostic — is testable
 /// without a live socket. `error` is omitted entirely on a success ack.
+///
+/// `status` is the live terminal->FPSS connectivity (`CONNECTED` /
+/// `DISCONNECTED`), which the terminal stamps into every message header.
 pub(super) fn build_req_response(
     response: ReqResponse,
     req_id: i64,
     error: Option<&str>,
+    status: &str,
 ) -> sonic_rs::Value {
     match error {
         Some(msg) => sonic_rs::json!({
             "header": {
                 "type": "REQ_RESPONSE",
+                "status": status,
                 "response": response.as_str(),
                 "req_id": req_id,
                 "error": msg,
@@ -90,6 +95,7 @@ pub(super) fn build_req_response(
         None => sonic_rs::json!({
             "header": {
                 "type": "REQ_RESPONSE",
+                "status": status,
                 "response": response.as_str(),
                 "req_id": req_id,
             }
@@ -115,7 +121,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             "text frame exceeds maximum of {WS_MAX_TEXT_BYTES} bytes (got {})",
             text.len()
         );
-        let resp = build_req_response(ReqResponse::Error, 0, Some(err_msg.as_str()));
+        let resp = build_req_response(
+            ReqResponse::Error,
+            0,
+            Some(err_msg.as_str()),
+            state.fpss_status(),
+        );
         send_response(socket, &resp, "oversize_text_reply").await;
         return;
     }
@@ -124,7 +135,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
         Ok(v) => v,
         Err(_) => {
             tracing::warn!("invalid WebSocket JSON: {}", text);
-            let resp = build_req_response(ReqResponse::Error, 0, None);
+            let resp = build_req_response(ReqResponse::Error, 0, None, state.fpss_status());
             send_response(socket, &resp, "invalid_json_reply").await;
             return;
         }
@@ -190,7 +201,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
     // performed in `handler::build_endpoint_args`.
     if let Err(e) = validation::validate_symbol(symbol, "symbol") {
         tracing::warn!(error = %e, "WS subscribe: symbol failed length validation");
-        let resp = build_req_response(ReqResponse::Error, req_id, Some(e.message.as_str()));
+        let resp = build_req_response(
+            ReqResponse::Error,
+            req_id,
+            Some(e.message.as_str()),
+            state.fpss_status(),
+        );
         send_response(socket, &resp, "bad_request_reply").await;
         return;
     }
@@ -220,6 +236,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                     ReqResponse::Error,
                     req_id,
                     Some("expiration must be an integer"),
+                    state.fpss_status(),
                 );
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
@@ -233,7 +250,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                     "WS subscribe: option expiration out of i32 range"
                 );
                 let err_msg = format!("expiration {exp_i64} exceeds i32 range");
-                let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
+                let resp = build_req_response(
+                    ReqResponse::Error,
+                    req_id,
+                    Some(err_msg.as_str()),
+                    state.fpss_status(),
+                );
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -261,7 +283,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                 "'exp' out of range (expected YYYYMMDD {}..={}; got {exp})",
                 MIN_OPTION_EXP, MAX_OPTION_EXP
             );
-            let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
+            let resp = build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(err_msg.as_str()),
+                state.fpss_status(),
+            );
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
@@ -275,20 +302,35 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                  reject reason: month/day decomposition is not a real \
                  Gregorian day, e.g. Feb 30 or Apr 31)"
             );
-            let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
+            let resp = build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(err_msg.as_str()),
+                state.fpss_status(),
+            );
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
-        // `strike` is the price in dollars — the same unit every other
-        // public surface speaks. The wire's fixed-point conversion is
-        // the SDK's job (`parse_strike_dollars` scales to thousandths
-        // internally before `Contract::option_raw`).
+        // `strike` encoding follows the server's `--strike-format`: the
+        // terminal's 1/10-cent integer (`550000` for `$550.00`, used
+        // verbatim — the default, matching the outbound WS frame) or a
+        // dollar value (`550`, scaled to wire thousandths). Either way it
+        // reaches `Contract::option_raw` in wire units.
         let strike_val = contract_obj.get("strike").unwrap_or(&null_val);
-        let strike = match parse_strike_dollars(strike_val.as_f64()) {
+        let parsed_strike = match state.strike_format() {
+            StrikeFormat::Terminal => parse_strike_thousandths(strike_val.as_f64()),
+            StrikeFormat::Dollars => parse_strike_dollars(strike_val.as_f64()),
+        };
+        let strike = match parsed_strike {
             Ok(v) => v,
             Err(err_msg) => {
                 tracing::warn!(error = %err_msg, "WS subscribe: invalid option 'strike'");
-                let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
+                let resp = build_req_response(
+                    ReqResponse::Error,
+                    req_id,
+                    Some(err_msg.as_str()),
+                    state.fpss_status(),
+                );
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -298,7 +340,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             Ok(sides) => sides,
             Err(err_msg) => {
                 tracing::warn!(error = %err_msg, "WS subscribe: invalid option 'right'");
-                let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
+                let resp = build_req_response(
+                    ReqResponse::Error,
+                    req_id,
+                    Some(err_msg.as_str()),
+                    state.fpss_status(),
+                );
                 send_response(socket, &resp, "bad_request_reply").await;
                 return;
             }
@@ -318,7 +365,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
         Ok(subs) => subs,
         Err(err_msg) => {
             tracing::warn!(req_type = %req_type, "WS subscribe: unsupported req_type");
-            let resp = build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()));
+            let resp = build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(err_msg.as_str()),
+                state.fpss_status(),
+            );
             send_response(socket, &resp, "bad_request_reply").await;
             return;
         }
@@ -335,7 +387,9 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
         let resp = match result {
             // Both add and remove acknowledge with the single documented
             // success token; the protocol defines no removal-specific value.
-            Ok(()) => build_req_response(ReqResponse::Subscribed, req_id, None),
+            Ok(()) => {
+                build_req_response(ReqResponse::Subscribed, req_id, None, state.fpss_status())
+            }
             Err(e) => {
                 tracing::warn!(error = %e, "FPSS subscription failed");
                 let err_msg = e.to_string();
@@ -343,7 +397,12 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
                 // or permission rejection from a generic failure, so every
                 // upstream error maps to the generic token. The enum carries
                 // the more specific values for the day the error type does.
-                build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()))
+                build_req_response(
+                    ReqResponse::Error,
+                    req_id,
+                    Some(err_msg.as_str()),
+                    state.fpss_status(),
+                )
             }
         };
         send_response(socket, &resp, "subscription_reply").await;
@@ -356,6 +415,7 @@ pub(super) async fn handle_client_message(state: &AppState, text: &str, socket: 
             ReqResponse::Error,
             req_id,
             Some("streaming is not started; no subscription was installed"),
+            state.fpss_status(),
         );
         send_response(socket, &resp, "streaming_off_reply").await;
     }
@@ -382,6 +442,7 @@ fn build_stop_response(state: &AppState, req_id: i64) -> sonic_rs::Value {
             ReqResponse::Error,
             req_id,
             Some("streaming is not started; no stream was stopped"),
+            state.fpss_status(),
         );
     }
 
@@ -393,7 +454,12 @@ fn build_stop_response(state: &AppState, req_id: i64) -> sonic_rs::Value {
         Err(e) => {
             tracing::warn!(error = %e, "STOP: could not read active subscriptions");
             let msg = e.to_string();
-            return build_req_response(ReqResponse::Error, req_id, Some(msg.as_str()));
+            return build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(msg.as_str()),
+                state.fpss_status(),
+            );
         }
     };
     let full = match stream.active_full_subscriptions() {
@@ -401,7 +467,12 @@ fn build_stop_response(state: &AppState, req_id: i64) -> sonic_rs::Value {
         Err(e) => {
             tracing::warn!(error = %e, "STOP: could not read active full subscriptions");
             let msg = e.to_string();
-            return build_req_response(ReqResponse::Error, req_id, Some(msg.as_str()));
+            return build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(msg.as_str()),
+                state.fpss_status(),
+            );
         }
     };
 
@@ -423,11 +494,16 @@ fn build_stop_response(state: &AppState, req_id: i64) -> sonic_rs::Value {
         .collect::<Vec<_>>();
 
     match stream.unsubscribe_many(removals) {
-        Ok(()) => build_req_response(ReqResponse::Subscribed, req_id, None),
+        Ok(()) => build_req_response(ReqResponse::Subscribed, req_id, None, state.fpss_status()),
         Err(e) => {
             tracing::warn!(error = %e, "STOP: unsubscribe failed");
             let msg = e.to_string();
-            build_req_response(ReqResponse::Error, req_id, Some(msg.as_str()))
+            build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(msg.as_str()),
+                state.fpss_status(),
+            )
         }
     }
 }
@@ -461,6 +537,7 @@ fn apply_bulk_trade(
             ReqResponse::Error,
             req_id,
             Some("streaming is not started; no subscription was installed"),
+            state.fpss_status(),
         );
     }
 
@@ -470,11 +547,16 @@ fn apply_bulk_trade(
         stream.unsubscribe_many(subscriptions)
     };
     match result {
-        Ok(()) => build_req_response(ReqResponse::Subscribed, req_id, None),
+        Ok(()) => build_req_response(ReqResponse::Subscribed, req_id, None, state.fpss_status()),
         Err(e) => {
             tracing::warn!(error = %e, "bulk trade subscription failed");
             let err_msg = e.to_string();
-            build_req_response(ReqResponse::Error, req_id, Some(err_msg.as_str()))
+            build_req_response(
+                ReqResponse::Error,
+                req_id,
+                Some(err_msg.as_str()),
+                state.fpss_status(),
+            )
         }
     }
 }
@@ -496,16 +578,45 @@ const ACCEPTED_REQ_TYPES: &[&str] = &[
     "FULL_OPEN_INTEREST",
 ];
 
-/// Parse the option `strike` field (dollars, JSON number) into the
+/// Parse the option `strike` field — the terminal's streaming-wire
+/// integer in 1/10 of a cent (a `$550.00` strike is `550000`) — into the
 /// FPSS wire's fixed-point thousandths integer.
 ///
-/// Accepts any positive finite number at or above the smallest
-/// representable strike; rejects missing / non-numeric values,
-/// non-positive strikes, positive strikes that round to zero in the
-/// thousandths unit (the smallest valid strike is $0.001), and values
-/// whose thousandths scaling overflows `i32`. Dollars are the only
-/// accepted unit; clients holding the wire integer divide by 1000
-/// before subscribing.
+/// The value arrives already in wire units, so it is used verbatim with
+/// no scaling. Rejects missing / non-numeric values, non-finite or
+/// non-positive values, a fractional (non-integer) value, and any value
+/// above `i32::MAX`.
+fn parse_strike_thousandths(raw: Option<f64>) -> Result<i32, String> {
+    let strike = raw.ok_or_else(|| {
+        "'strike' must be an integer in 1/10 of a cent (e.g. 550000 for $550), got: <missing or non-numeric>"
+            .to_string()
+    })?;
+    if !strike.is_finite() || strike <= 0.0 {
+        return Err(format!(
+            "'strike' must be a positive integer in 1/10 of a cent (got {strike})"
+        ));
+    }
+    if strike.fract() != 0.0 {
+        return Err(format!(
+            "'strike' must be a whole integer in 1/10 of a cent, not fractional (got {strike})"
+        ));
+    }
+    if strike > f64::from(i32::MAX) {
+        return Err(format!("'strike' {strike} exceeds the representable range"));
+    }
+    // Reason: bounds checked above; positivity and integrality checked above.
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(strike as i32)
+}
+
+/// Parse the option `strike` field as a dollar value (a `$550.00` strike is
+/// `550`, `$550.50` is `550.5`) and scale it to the FPSS wire's 1/10-cent
+/// integer (`550000` / `550500`). Selected by `--strike-format dollars` —
+/// the SDK's convenience form.
+///
+/// Rejects missing / non-numeric values, non-finite or non-positive values,
+/// a value below the smallest representable unit ($0.001, which would round
+/// to a $0.00 strike), and any value that overflows `i32` after scaling.
 fn parse_strike_dollars(raw: Option<f64>) -> Result<i32, String> {
     let dollars = raw.ok_or_else(|| {
         "'strike' must be a number in dollars (e.g. 550 or 550.5), got: <missing or non-numeric>"
@@ -517,10 +628,9 @@ fn parse_strike_dollars(raw: Option<f64>) -> Result<i32, String> {
         ));
     }
     let scaled = (dollars * 1000.0).round();
-    // A positive strike below half the smallest representable unit
-    // rounds to zero thousandths. A zero strike is not a real
-    // instrument, so reject it rather than silently collapse the
-    // contract to a $0.00 strike.
+    // A positive strike below half the smallest representable unit rounds to
+    // zero thousandths. A zero strike is not a real instrument, so reject it
+    // rather than silently collapse the contract to a $0.00 strike.
     if scaled < 1.0 {
         return Err(format!(
             "'strike' {dollars} is below the smallest representable strike ($0.001)"
@@ -695,11 +805,50 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    //  strike dollars -> fixed-point thousandths
+    //  strike 1/10-cent integer -> wire thousandths (verbatim)
     // -----------------------------------------------------------------------
 
     #[test]
-    fn strike_accepts_smallest_representable_and_normal_values() {
+    fn strike_accepts_wire_integer_values_verbatim() {
+        // The wire value is already in 1/10-cent units: a `$550` strike is
+        // `550000`, a `$140` strike is `140000`, each used verbatim.
+        assert_eq!(parse_strike_thousandths(Some(550_000.0)).unwrap(), 550_000);
+        assert_eq!(parse_strike_thousandths(Some(140_000.0)).unwrap(), 140_000);
+        // The smallest valid strike is a single 1/10-cent unit.
+        assert_eq!(parse_strike_thousandths(Some(1.0)).unwrap(), 1);
+    }
+
+    #[test]
+    fn strike_rejects_fractional_value() {
+        // A fractional value is no longer scaled — it is now an error, not
+        // `550500`. The wire carries whole 1/10-cent integers only.
+        let err = parse_strike_thousandths(Some(550.5)).unwrap_err();
+        assert!(
+            err.contains("fractional") || err.contains("whole integer"),
+            "diagnostic must explain the integer requirement: {err}"
+        );
+        assert!(parse_strike_thousandths(Some(0.001)).is_err());
+    }
+
+    #[test]
+    fn strike_rejects_non_positive_and_non_numeric() {
+        assert!(parse_strike_thousandths(Some(0.0)).is_err());
+        assert!(parse_strike_thousandths(Some(-1.0)).is_err());
+        assert!(parse_strike_thousandths(Some(f64::NAN)).is_err());
+        assert!(parse_strike_thousandths(None).is_err());
+    }
+
+    #[test]
+    fn strike_rejects_above_i32_max() {
+        assert!(parse_strike_thousandths(Some(f64::from(i32::MAX) + 1.0)).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    //  strike dollars -> wire thousandths (scaled, --strike-format dollars)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn strike_dollars_scales_to_wire_thousandths() {
         // $0.001 is the smallest representable strike: it maps to the
         // smallest nonzero thousandths value.
         assert_eq!(parse_strike_dollars(Some(0.001)).unwrap(), 1);
@@ -710,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn strike_rejects_sub_smallest_unit_positive_value() {
+    fn strike_dollars_rejects_sub_smallest_unit_positive_value() {
         // 0.0004 dollars scales to 0.4 thousandths, which rounds to 0.
         // A 0-strike contract is not a real instrument, so the value
         // must be rejected rather than silently collapsed to zero.
@@ -726,7 +875,7 @@ mod tests {
     }
 
     #[test]
-    fn strike_rejects_non_positive_and_non_numeric() {
+    fn strike_dollars_rejects_non_positive_and_non_numeric() {
         assert!(parse_strike_dollars(Some(0.0)).is_err());
         assert!(parse_strike_dollars(Some(-1.0)).is_err());
         assert!(parse_strike_dollars(Some(f64::NAN)).is_err());
@@ -1015,7 +1164,7 @@ mod tests {
     /// envelope carries no `error` field.
     #[test]
     fn success_subscribe_returns_subscribed() {
-        let resp = build_req_response(ReqResponse::Subscribed, 7, None);
+        let resp = build_req_response(ReqResponse::Subscribed, 7, None, "CONNECTED");
         assert_eq!(response_token(&resp), "SUBSCRIBED");
         assert_eq!(
             resp.get("header")
@@ -1034,7 +1183,7 @@ mod tests {
     /// `error` field naming the cause.
     #[test]
     fn validation_failure_returns_error_with_message() {
-        let resp = build_req_response(ReqResponse::Error, 3, Some("symbol too long"));
+        let resp = build_req_response(ReqResponse::Error, 3, Some("symbol too long"), "CONNECTED");
         assert_eq!(response_token(&resp), "ERROR");
         assert_eq!(
             resp.get("header")
@@ -1053,6 +1202,7 @@ mod tests {
             ReqResponse::Error,
             1,
             Some("streaming is not started; no subscription was installed"),
+            "CONNECTED",
         );
         assert_eq!(response_token(&resp), "ERROR");
         assert_ne!(response_token(&resp), "SUBSCRIBED");
@@ -1077,6 +1227,7 @@ mod tests {
             ReqResponse::Error,
             9,
             Some("streaming is not started; no stream was stopped"),
+            "CONNECTED",
         );
         assert_eq!(response_token(&resp), "ERROR");
         assert_ne!(response_token(&resp), "SUBSCRIBED");
@@ -1092,7 +1243,7 @@ mod tests {
     /// with the single documented success token and carries no error.
     #[test]
     fn stop_that_applied_returns_subscribed() {
-        let resp = build_req_response(ReqResponse::Subscribed, 9, None);
+        let resp = build_req_response(ReqResponse::Subscribed, 9, None, "CONNECTED");
         assert_eq!(response_token(&resp), "SUBSCRIBED");
         assert!(
             resp.get("header").and_then(|h| h.get("error")).is_none(),


### PR DESCRIPTION
## Summary

Makes `thetadatadx-server` an exact drop-in for the ThetaData terminal, after an exhaustive audit of its HTTP + WebSocket surface against the reference docs (docs.thetadata.us) and a live validation run against a real FPSS session.

## 1. Drop the server's per-IP rate limiting

The terminal does no per-IP rate limiting; real limits are enforced upstream. Removes the opt-in governor and the shutdown-route limiter along with the `tower_governor` dependency. Generic body-size and concurrency caps stay.

## 2. Mirror the terminal's system routes 1:1

The terminal serves exactly three unauthenticated `GET /v3/terminal/*` routes; our server had invented a `POST /v3/system/shutdown` (token-gated) plus a parallel `/v3/system/*` status tree and non-terminal aliases, and never served the documented `GET /v3/terminal/shutdown` (a client calling it got a 404).

Now the server serves exactly:

| Method | Route | Body |
|---|---|---|
| `GET` | `/v3/terminal/shutdown` | `OK` (kills the process) |
| `GET` | `/v3/terminal/fpss/status` | `CONNECTED` / `DISCONNECTED` |
| `GET` | `/v3/terminal/mdds/status` | `CONNECTED` / `DISCONNECTED` |

All unauthenticated, bare `text/plain`. The `/v3/system/*` routes and the `X-Shutdown-Token` machinery are removed. The OpenAPI contract, docs, and the v12→v13 migration guide are swept to match. The two route paths carry the terminal's own published codenames verbatim; a scoped gate exception permits them exclusively as the literal route path (operationIds and prose stay codename-free).

## 3. WebSocket wire format 1:1 (configurable)

On the WebSocket, an option `strike` now defaults to the terminal's 1/10-cent integer (a $570 strike is `570000`) on both the subscribe input and the event output; `--strike-format dollars` switches it to a dollar value for the SDK's convenience form. Every message header now carries the streaming-channel connectivity `status`, matching the terminal, not only the `STATUS` heartbeat. REST strike and the native SDK bindings keep dollars — only the server's WebSocket wire changed. The docs-consistency strike-safety gate is scoped so REST reference pages stay dollars-only while the WebSocket/streaming pages may show the terminal form.

## Known follow-ups (not in this PR)

- REST `format=html` returns 400; the v3 spec's `format` enum includes `html` (the terminal renders an HTML table). Needs an HTML-table renderer or an explicit decision.
- The terminal's `mdds`/`fpss` status can report `UNVERIFIED`/`ERROR`; ours reports only `CONNECTED`/`DISCONNECTED` (the SDK's `ConnectionStatus` has no clean source for the other two).
- The checked-in `scripts/ci/data/upstream_openapi.yaml` snapshot is stale (missing `interest_rate/history/eod` + the flat-file paths).

## Verification

- `thetadatadx-server`: 177 tests pass, clippy clean, fmt clean; docs-consistency + client-facing-vocab gates pass.
- Live-validated against a real FPSS session (STOCK/OPTION/INDEX.PRO): terminal status routes return `CONNECTED`; `/v3/system/*` return 404; WebSocket subscribe acks carry `header.status`; the `terminal` vs `dollars` strike modes behave correctly; REST option strike stays dollars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
