### PR TITLE
fix(flatfiles): remove fabricated index-EOD flat-file dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Typed `index` end-of-day flat-file accessor across every binding.** The index EOD flat file was already a served dataset but lacked the typed one-liner its option and stock siblings had; `flat_files.index_eod(...)` (and the async twin) is now available in Python, TypeScript, Rust, and C++, so callers no longer fall back to the generic request form.
-
 ### Changed
 
 - **`thetadatadx-server` reports all four terminal connectivity states.** `GET /v3/terminal/fpss/status` and the WebSocket `STATUS` heartbeat now return `CONNECTED`, `UNVERIFIED` (the socket is up but login is not yet confirmed), `DISCONNECTED`, or `ERROR` — matching the terminal — instead of only connected/disconnected. The historical (MDDS) channel stays `CONNECTED` while the server runs, since it is per-request with no persistent connection to lose.

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Typed `index` end-of-day flat-file accessor across every binding.** The index EOD flat file was already a served dataset but lacked the typed one-liner its option and stock siblings had; `flat_files.index_eod(...)` (and the async twin) is now available in Python, TypeScript, Rust, and C++, so callers no longer fall back to the generic request form.
-
 ### Changed
 
 - **`thetadatadx-server` reports all four terminal connectivity states.** `GET /v3/terminal/fpss/status` and the WebSocket `STATUS` heartbeat now return `CONNECTED`, `UNVERIFIED` (the socket is up but login is not yet confirmed), `DISCONNECTED`, or `ERROR` — matching the terminal — instead of only connected/disconnected. The historical (MDDS) channel stays `CONNECTED` while the server runs, since it is per-request with no persistent connection to lose.

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -3194,7 +3194,7 @@ paths:
         is the file bytes, streamed as an attachment. Only these pairs are
         served (any other pairing returns 400):
         `option/trade_quote`, `option/open_interest`, `option/eod`,
-        `stock/trade_quote`, `stock/eod`, `index/eod`. The path form takes the
+        `stock/trade_quote`, `stock/eod`. The path form takes the
         parameters independently, so an unserved pairing (for example
         `stock/open_interest`) is accepted by the route but rejected at request
         time with 400.
@@ -3204,7 +3204,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [option, stock, index]
+            enum: [option, stock]
           description: Security type (case-insensitive).
         - name: req_type
           in: path
@@ -3214,7 +3214,7 @@ paths:
             enum: [trade_quote, open_interest, eod]
           description: |
             Request type (case-insensitive). `open_interest` is served for
-            `option` only; `index` serves `eod` only.
+            `option` only.
         - name: date
           in: query
           required: true

--- a/parity.toml
+++ b/parity.toml
@@ -1185,17 +1185,6 @@ rust = true
 params = ["String"]
 returns = "FlatFileRowList"
 
-[[method]]
-class = "FlatFilesNamespace"
-name = "indexEod"
-python = true
-typescript = true
-cpp = true
-rust = true
-[method.signature]
-params = ["String"]
-returns = "FlatFileRowList"
-
 # The generic string-keyed dispatcher. The managed bindings take three String
 # params (sec-type, req-type, date); the Rust core takes the typed
 # `(SecType, ReqType, &str)` enums, so its param list is a per-lang override

--- a/thetadatadx-cpp/README.md
+++ b/thetadatadx-cpp/README.md
@@ -220,7 +220,7 @@ auto oi = unified.flat_files().request("OPTION", "OPEN_INTEREST", "20260428");
 unified.flat_files().to_path("OPTION", "TRADE_QUOTE", "20260428", "/tmp/option-trade-quote", "csv");
 ```
 
-The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod`, stock `trade_quote` / `eod`, and index `eod`. Available `flat_files().*` methods: `option_trade_quote`, `option_open_interest`, `option_eod`, `stock_trade_quote`, `stock_eod`, `index_eod`, plus `request(...)` and `to_path(...)`; the generic paths reject an unserved `(security, request)` pair with a typed invalid-parameter error. `thetadatadx::HistoricalClient` remains the historical-only entry point; `thetadatadx::Client` adds streaming and flat files on the same connection.
+The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod`, stock `trade_quote` / `eod`. Available `flat_files().*` methods: `option_trade_quote`, `option_open_interest`, `option_eod`, `stock_trade_quote`, `stock_eod`, plus `request(...)` and `to_path(...)`; the generic paths reject an unserved `(security, request)` pair with a typed invalid-parameter error. `thetadatadx::HistoricalClient` remains the historical-only entry point; `thetadatadx::Client` adds streaming and flat files on the same connection.
 
 ## Endpoint coverage
 

--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -1376,7 +1376,7 @@ public:
 
     // Convenience accessors cover exactly the datasets the flat-file
     // distribution serves — option trade_quote / open_interest / eod,
-    // stock trade_quote / eod, and index eod. Other request types are
+    // stock trade_quote / eod. Other request types are
     // reachable via the historical surface, not as flat files.
     FlatFileRowList option_trade_quote(const std::string& date) const {
         return request("OPTION", "TRADE_QUOTE", date);
@@ -1392,9 +1392,6 @@ public:
     }
     FlatFileRowList stock_eod(const std::string& date) const {
         return request("STOCK", "EOD", date);
-    }
-    FlatFileRowList index_eod(const std::string& date) const {
-        return request("INDEX", "EOD", date);
     }
 
     /// Pull a flat-file blob and write the requested vendor format

--- a/thetadatadx-py/README.md
+++ b/thetadatadx-py/README.md
@@ -233,7 +233,7 @@ path = client.flatfile_to_path("OPTION", "TRADE_QUOTE", "20260428",
                             "/tmp/option-trade-quote", format="csv")
 ```
 
-The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod`, stock `trade_quote` / `eod`, and index `eod`. Available `flat_files.*` methods: `option_trade_quote`, `option_open_interest`, `option_eod`, `stock_trade_quote`, `stock_eod`, `index_eod`, plus `request(sec_type, req_type, date)`. The generic `request(...)` and `flatfile_to_path(...)` paths reject an unserved `(security, request)` pair with a typed invalid-parameter error.
+The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod`, stock `trade_quote` / `eod`. Available `flat_files.*` methods: `option_trade_quote`, `option_open_interest`, `option_eod`, `stock_trade_quote`, `stock_eod`, plus `request(sec_type, req_type, date)`. The generic `request(...)` and `flatfile_to_path(...)` paths reject an unserved `(security, request)` pair with a typed invalid-parameter error.
 
 ## Endpoint coverage
 

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -6146,10 +6146,6 @@ class FlatFilesNamespace:
         """Return the decoded stock-EOD flat file for ``date`` (``YYYYMMDD``)."""
         ...
 
-    def index_eod(self, date: str) -> FlatFileRowList:
-        """Return the decoded index-EOD flat file for ``date`` (``YYYYMMDD``)."""
-        ...
-
     def request(self, sec_type: str, req_type: str, date: str) -> FlatFileRowList:
         """Return a decoded flat file selected by string identifiers.
 
@@ -6185,10 +6181,6 @@ class FlatFilesNamespace:
 
     def stock_eod_async(self, date: str) -> Awaitable[FlatFileRowList]:
         """Awaitable stock-EOD flat file for ``date`` (``YYYYMMDD``)."""
-        ...
-
-    def index_eod_async(self, date: str) -> Awaitable[FlatFileRowList]:
-        """Awaitable index-EOD flat file for ``date`` (``YYYYMMDD``)."""
         ...
 
     def request_async(

--- a/thetadatadx-py/src/flatfile_methods.rs
+++ b/thetadatadx-py/src/flatfile_methods.rs
@@ -197,7 +197,7 @@ impl FlatFilesNamespace {
 #[pymethods]
 impl FlatFilesNamespace {
     fn __repr__(&self) -> &'static str {
-        "FlatFilesNamespace(option_*, stock_*, index_eod; .to_arrow/.to_pandas/.to_polars/.to_list)"
+        "FlatFilesNamespace(option_*, stock_*; .to_arrow/.to_pandas/.to_polars/.to_list)"
     }
 
     /// Decoded option-trade-quote flat file for `date` (YYYYMMDD).
@@ -223,11 +223,6 @@ impl FlatFilesNamespace {
     /// Decoded stock-EOD flat file for `date` (YYYYMMDD).
     fn stock_eod(&self, py: Python<'_>, date: &str) -> PyResult<FlatFileRowList> {
         self.pull_decoded(py, SecType::Stock, ReqType::Eod, date)
-    }
-
-    /// Decoded index-EOD flat file for `date` (YYYYMMDD).
-    fn index_eod(&self, py: Python<'_>, date: &str) -> PyResult<FlatFileRowList> {
-        self.pull_decoded(py, SecType::Index, ReqType::Eod, date)
     }
 
     /// Generic dispatcher — `sec_type` and `req_type` accept the same
@@ -295,11 +290,6 @@ impl FlatFilesNamespace {
     /// Awaitable stock-EOD flat file for `date` (YYYYMMDD).
     fn stock_eod_async<'py>(&self, py: Python<'py>, date: &str) -> PyResult<Bound<'py, PyAny>> {
         self.pull_decoded_async(py, SecType::Stock, ReqType::Eod, date)
-    }
-
-    /// Awaitable index-EOD flat file for `date` (YYYYMMDD).
-    fn index_eod_async<'py>(&self, py: Python<'py>, date: &str) -> PyResult<Bound<'py, PyAny>> {
-        self.pull_decoded_async(py, SecType::Index, ReqType::Eod, date)
     }
 
     /// Awaitable generic dispatcher. `sec_type` and `req_type` accept the

--- a/thetadatadx-rs/src/client.rs
+++ b/thetadatadx-rs/src/client.rs
@@ -2182,7 +2182,7 @@ impl Client {
 /// This is the Rust counterpart of the `FlatFiles` / `FlatFilesNamespace`
 /// handle on the Python, TypeScript, and C++ bindings: the method set
 /// (`option_trade_quote`, `option_open_interest`, `option_eod`,
-/// `stock_trade_quote`, `stock_eod`, `index_eod`, the generic `request`,
+/// `stock_trade_quote`, `stock_eod`, the generic `request`,
 /// and `to_path`) mirrors them exactly, so flat files are reached the same
 /// way from every binding.
 #[derive(Clone, Copy)]
@@ -2271,21 +2271,6 @@ impl FlatFiles<'_> {
         self.0
             .flatfile_request_decoded(
                 crate::flatfiles::SecType::Stock,
-                crate::flatfiles::ReqType::Eod,
-                date,
-            )
-            .await
-    }
-
-    /// Decoded index end-of-day flat file for `date` (`YYYYMMDD`).
-    ///
-    /// # Errors
-    ///
-    /// Same conditions as [`Self::option_trade_quote`].
-    pub async fn index_eod(&self, date: &str) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(
-                crate::flatfiles::SecType::Index,
                 crate::flatfiles::ReqType::Eod,
                 date,
             )
@@ -3004,7 +2989,6 @@ mod tests {
         assert_rows(view.option_eod("20240115"));
         assert_rows(view.stock_trade_quote("20240115"));
         assert_rows(copy.stock_eod("20240115"));
-        assert_rows(view.index_eod("20240115"));
 
         // Generic decoded dispatcher: typed enums in.
         assert_rows(view.request(

--- a/thetadatadx-rs/src/flatfiles/index.rs
+++ b/thetadatadx-rs/src/flatfiles/index.rs
@@ -193,8 +193,8 @@ fn parse_one_entry(cur: &mut Cursor<&[u8]>, sec: SecType) -> Result<IndexEntry, 
             // INDEX and STOCK share the contract-key layout: a length-prefixed
             // root followed by the entry-level trading date, with no
             // expiration / strike / right (an index has no option dimensions).
-            // The vendor's `index/flat_file/eod` section confirms this byte
-            // layout — each entry is `root_len ; root ; i32 date`.
+            // Each entry is `root_len ; root ; i32 date`; the INDEX arm shares
+            // the stock EOD byte layout for the decode path.
             let root_len = read_u8(&mut e)? as usize;
             let mut root_bytes = vec![0u8; root_len];
             e.read_exact(&mut root_bytes)?;

--- a/thetadatadx-rs/src/flatfiles/request.rs
+++ b/thetadatadx-rs/src/flatfiles/request.rs
@@ -551,14 +551,13 @@ mod tests {
     }
 
     #[test]
-    fn dataset_gate_accepts_the_six_served_combos() {
+    fn dataset_gate_accepts_the_five_served_combos() {
         for (sec, req) in [
             (SecType::Option, ReqType::TradeQuote),
             (SecType::Option, ReqType::OpenInterest),
             (SecType::Option, ReqType::Eod),
             (SecType::Stock, ReqType::TradeQuote),
             (SecType::Stock, ReqType::Eod),
-            (SecType::Index, ReqType::Eod),
         ] {
             assert!(
                 validate_dataset(sec, req).is_ok(),
@@ -580,6 +579,7 @@ mod tests {
             (SecType::Stock, ReqType::OpenInterest, "stock open_interest"),
             (SecType::Index, ReqType::TradeQuote, "index trade_quote"),
             (SecType::Index, ReqType::Quote, "index quote"),
+            (SecType::Index, ReqType::Eod, "index eod"),
         ] {
             let err = validate_dataset(sec, req).expect_err("unserved pair must be rejected");
             // Typed invalid-parameter leaf, not a network failure.

--- a/thetadatadx-rs/src/flatfiles/types.rs
+++ b/thetadatadx-rs/src/flatfiles/types.rs
@@ -101,8 +101,8 @@ impl fmt::Display for ReqType {
 /// distribution actually serves.
 ///
 /// The flat-file service publishes a fixed matrix of daily snapshot
-/// datasets — option `trade_quote` / `open_interest` / `eod`, stock
-/// `trade_quote` / `eod`, and index `eod`. Every other request type
+/// datasets — option `trade_quote` / `open_interest` / `eod` and stock
+/// `trade_quote` / `eod`. Every other request type
 /// (per-tick quotes, trades, OHLC bars) is served by the historical
 /// endpoints, not as a flat file. Sending an unserved pair yields a server
 /// `INVALID_PARAMS:Invalid request type` rejection; this predicate lets
@@ -116,7 +116,6 @@ pub fn flat_file_serves(sec: SecType, req: ReqType) -> bool {
             SecType::Option,
             ReqType::TradeQuote | ReqType::OpenInterest | ReqType::Eod
         ) | (SecType::Stock, ReqType::TradeQuote | ReqType::Eod)
-            | (SecType::Index, ReqType::Eod)
     )
 }
 
@@ -136,7 +135,6 @@ pub const SERVED_DATASETS: &[(SecType, ReqType)] = &[
     (SecType::Option, ReqType::Eod),
     (SecType::Stock, ReqType::TradeQuote),
     (SecType::Stock, ReqType::Eod),
-    (SecType::Index, ReqType::Eod),
 ];
 
 /// Reason a [`Client::flatfile_request`](crate::Client::flatfile_request)
@@ -392,8 +390,8 @@ mod tests {
                 );
             }
         }
-        // The served set is exactly the documented six datasets.
-        assert_eq!(SERVED_DATASETS.len(), 6);
+        // The served set is exactly the documented five datasets.
+        assert_eq!(SERVED_DATASETS.len(), 5);
     }
 
     /// Every security type maps to its exact upper-case wire token; the

--- a/thetadatadx-ts/README.md
+++ b/thetadatadx-ts/README.md
@@ -226,7 +226,7 @@ const oi = await client.flatFiles.request('OPTION', 'OPEN_INTEREST', '20260428')
 await client.flatFileToPath('OPTION', 'TRADE_QUOTE', '20260428', '/tmp/option-trade-quote', 'csv');
 ```
 
-The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod`, stock `trade_quote` / `eod`, and index `eod`. Available `flatFiles.*` methods: `optionTradeQuote`, `optionOpenInterest`, `optionEod`, `stockTradeQuote`, `stockEod`, `indexEod`, plus `request(secType, reqType, date)`. The generic `request(...)` and `flatFileToPath(...)` paths reject an unserved `(security, request)` pair with a typed invalid-parameter error.
+The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod`, stock `trade_quote` / `eod`. Available `flatFiles.*` methods: `optionTradeQuote`, `optionOpenInterest`, `optionEod`, `stockTradeQuote`, `stockEod`, plus `request(secType, reqType, date)`. The generic `request(...)` and `flatFileToPath(...)` paths reject an unserved `(security, request)` pair with a typed invalid-parameter error.
 
 ## Endpoint coverage
 

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -783,8 +783,6 @@ export declare class FlatFilesNamespace {
   stockTradeQuote(date: string): Promise<FlatFileRowList>
   /** Stock end-of-day flat file for the given `YYYYMMDD` date. */
   stockEod(date: string): Promise<FlatFileRowList>
-  /** Index end-of-day flat file for the given `YYYYMMDD` date. */
-  indexEod(date: string): Promise<FlatFileRowList>
   /**
    * Generic dispatcher — `secType` and `reqType` accept `"OPTION"` /
    * `"QUOTE"` style strings.

--- a/thetadatadx-ts/src/flatfile_methods.rs
+++ b/thetadatadx-ts/src/flatfile_methods.rs
@@ -236,13 +236,6 @@ impl FlatFilesNamespace {
         Ok(FlatFileRowList { rows })
     }
 
-    /// Index end-of-day flat file for the given `YYYYMMDD` date.
-    #[napi(js_name = "indexEod")]
-    pub async fn index_eod(&self, date: String) -> napi::Result<FlatFileRowList> {
-        let rows = pull_decoded(&self.client, SecType::Index, ReqType::Eod, &date).await?;
-        Ok(FlatFileRowList { rows })
-    }
-
     /// Generic dispatcher — `secType` and `reqType` accept `"OPTION"` /
     /// `"QUOTE"` style strings.
     #[napi]

--- a/tools/mcp/src/flatfile_tools.rs
+++ b/tools/mcp/src/flatfile_tools.rs
@@ -84,9 +84,8 @@ fn served_req_type_tokens_for(sec: SecType) -> Vec<String> {
 /// `req_type` tokens served for it, derived from `SERVED_DATASETS`. This makes
 /// the generic-tool schema pair-aware: a JSON-schema validator accepts a
 /// `(sec_type, req_type)` document only when it matches a served pair, so an
-/// individually-valid-but-unserved combination (e.g. stock `open_interest`,
-/// a non-EOD `index` request) fails the schema rather than parsing and being
-/// rejected only at runtime.
+/// individually-valid-but-unserved combination (e.g. stock `open_interest`)
+/// fails the schema rather than parsing and being rejected only at runtime.
 fn served_pair_branches() -> Vec<Value> {
     let mut branches: Vec<Value> = Vec::new();
     let mut seen_secs: Vec<String> = Vec::new();
@@ -412,17 +411,22 @@ mod tests {
     }
 
     /// The advertised `sec_type` / `req_type` enums must cover exactly the
-    /// tokens the served matrix yields (each in both cases), including `INDEX`
-    /// (the served matrix includes index EOD), and must not offer a request
-    /// type the flat-file service never serves — no per-tick `QUOTE` / `TRADE`
-    /// / `OHLC`.
+    /// tokens the served matrix yields (each in both cases) and must not offer
+    /// a request type the flat-file service never serves — no per-tick `QUOTE`
+    /// / `TRADE` / `OHLC`, and no `INDEX` security (not a flat-file dataset).
     #[test]
     fn generic_tool_enums_match_the_served_matrix() {
         let sec_tokens = generic_request_enum("sec_type");
-        for served in ["OPTION", "STOCK", "INDEX", "option", "stock", "index"] {
+        for served in ["OPTION", "STOCK", "option", "stock"] {
             assert!(
                 sec_tokens.iter().any(|t| t == served),
                 "sec_type enum must advertise `{served}`; got {sec_tokens:?}"
+            );
+        }
+        for unserved in ["INDEX", "index"] {
+            assert!(
+                !sec_tokens.iter().any(|t| t == unserved),
+                "sec_type enum must not advertise unserved `{unserved}`; got {sec_tokens:?}"
             );
         }
 
@@ -522,10 +526,10 @@ mod tests {
 
     /// The schema's pair-aware `oneOf` must encode exactly the served matrix:
     /// the option branch offers `eod`, `open_interest`, and `trade_quote`; the
-    /// stock branch offers `eod` and `trade_quote` but never `open_interest`;
-    /// the index branch offers `eod` only. This is what makes a validator reject
-    /// stock `open_interest` (and any non-EOD `index` request) before the
-    /// handler runs.
+    /// stock branch offers `eod` and `trade_quote` but never `open_interest`.
+    /// This is what makes a validator reject stock `open_interest` before the
+    /// handler runs. There is no `index` branch — index is not a flat-file
+    /// dataset.
     #[test]
     fn generic_tool_oneof_encodes_served_pairs() {
         let branches = generic_request_pair_branches();
@@ -561,35 +565,19 @@ mod tests {
             );
         }
 
-        // The index branch serves EOD only — never trade_quote or
-        // open_interest: the flat-file service serves index EOD alone.
-        let index_branch = branches
-            .iter()
-            .find(|(sec, _)| sec.iter().any(|t| t == "INDEX"))
-            .expect("a oneOf branch must cover the index security type");
+        // Index is not a flat-file dataset: no branch may cover it.
         assert!(
-            index_branch.1.iter().any(|t| t == "EOD"),
-            "index branch must serve `EOD`; got {:?}",
-            index_branch.1
+            !branches
+                .iter()
+                .any(|(sec, _)| sec.iter().any(|t| t == "INDEX" || t == "index")),
+            "no oneOf branch may cover the index security type; got {branches:?}"
         );
-        for unserved in [
-            "TRADE_QUOTE",
-            "OPEN_INTEREST",
-            "trade_quote",
-            "open_interest",
-        ] {
-            assert!(
-                !index_branch.1.iter().any(|t| t == unserved),
-                "index branch must not serve `{unserved}`; got {:?}",
-                index_branch.1
-            );
-        }
 
-        // One branch per served security type (option, stock, index).
+        // One branch per served security type (option, stock).
         assert_eq!(
             branches.len(),
-            3,
-            "the served matrix yields exactly three security-type branches"
+            2,
+            "the served matrix yields exactly two security-type branches"
         );
     }
 

--- a/tools/server/src/flatfile_routes.rs
+++ b/tools/server/src/flatfile_routes.rs
@@ -13,7 +13,7 @@
 //!   `SecType` / `ReqType`. Query params:
 //!   `date=YYYY-MM-DD|YYYYMMDD&format=csv|json|ndjson|jsonl|html`. The pair
 //!   must be a served flat-file dataset — option `trade_quote` /
-//!   `open_interest` / `eod`, stock `trade_quote` / `eod`, index `eod`; any
+//!   `open_interest` / `eod`, stock `trade_quote` / `eod`; any
 //!   other `(sec_type, req_type)` pair returns `400 bad_request`.
 //!
 //! Every format is written row-by-row by its `RowSink`, so even a JSON
@@ -619,9 +619,8 @@ mod tests {
     /// The served-matrix gate accepts every pair the distribution serves and
     /// rejects everything else — including a pair whose security and request
     /// types are each individually served but not as a pair (stock
-    /// open_interest). Index serves only EOD, so `(Index, Eod)` is accepted
-    /// while every non-EOD index pair is rejected. The rejection names the
-    /// dataset.
+    /// open_interest). No index pair is served, so every index dataset is
+    /// rejected. The rejection names the dataset.
     #[test]
     fn unserved_dataset_is_rejected_at_the_boundary() {
         for (sec, req) in [
@@ -630,7 +629,6 @@ mod tests {
             (SecType::Option, ReqType::Eod),
             (SecType::Stock, ReqType::TradeQuote),
             (SecType::Stock, ReqType::Eod),
-            (SecType::Index, ReqType::Eod),
         ] {
             assert!(
                 reject_unserved_dataset(sec, req).is_ok(),
@@ -644,6 +642,7 @@ mod tests {
             (SecType::Option, ReqType::Quote),
             (SecType::Option, ReqType::Trade),
             (SecType::Option, ReqType::Ohlc),
+            (SecType::Index, ReqType::Eod),
             (SecType::Index, ReqType::TradeQuote),
             (SecType::Index, ReqType::OpenInterest),
         ] {


### PR DESCRIPTION
Index EOD is not a served flat-file dataset — the authoritative vendor doc (v2 flat-file getting-started) lists exactly five: option trade_quote/open_interest/eod and stock trade_quote/eod. The served matrix wrongly included `(Index, Eod)` and #1163 built a typed `index_eod` accessor on top of that bug.

Removes `(Index, Eod)` from `flat_file_serves` + `SERVED_DATASETS`, drops the `index_eod` flat-file accessor across every binding (Python/TS/Rust/C++), the `parity.toml` row, the stubs, and the READMEs; moves the pair into the rejection tests. The **historical** index-EOD endpoint (`/v3/index/history/eod`) is a separate real surface and is left untouched.

Verified: served set is exactly the five real datasets; parity, docs-consistency, vocab, sdk-surface + docs-gen `--check` all pass; bindings build; core 994 + server 179 + mcp 33 + ts 24 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)