### PR TITLE
docs: describe concurrency as an account tier limit

### DIFF
--- a/docs-site/docs/articles/concurrent-requests.md
+++ b/docs-site/docs/articles/concurrent-requests.md
@@ -5,7 +5,7 @@ description: How many historical requests run in parallel per subscription tier.
 
 # Concurrent Requests
 
-Your requests are not rate-limited, but the number of historical requests **in flight at once** is capped by your subscription tier on each asset class:
+Your requests are not rate-limited, but the number of **concurrent** historical requests is capped by your subscription tier. Concurrency is account-wide and set by your **highest** subscription tier across asset classes:
 
 | Tier | Concurrent requests |
 |---|---:|
@@ -14,13 +14,9 @@ Your requests are not rate-limited, but the number of historical requests **in f
 | Standard | 4 |
 | Pro | 8 |
 
-## It's automatic
+## Fire your whole batch
 
-There is no knob to set. At connect time the SDK reads your tier from authentication and sizes its historical connection pool to match. A Pro account gets eight in-flight slots, Free gets one, and so on. You don't pass a value, you don't tune anything, and there's nothing to get wrong.
-
-Every historical call quietly takes a slot from that pool. Fire as many calls in parallel as you like, whether that's async tasks in Rust and Python, threads, or a process-wide backfill loop. Anything beyond your tier's slot count **queues in order and drains as slots free**. You never get a rejection for over-parallelism; the burst is absorbed as latency, not errors.
-
-So the idiomatic pattern is simply to launch your whole batch and let the pool pace it:
+You can issue more requests than your tier allows. The extra requests are **queued and run in order**, so a burst completes as fast as your tier permits without you managing anything. There is nothing to configure. The idiomatic pattern is to launch the whole batch and let it run at your tier's rate:
 
 ```python
 import asyncio
@@ -38,6 +34,6 @@ With a Pro subscription, eight of those requests run concurrently and the rest w
 
 ## When parallelism pays
 
-Concurrency multiplies throughput on multi-request workloads: per-day backfills, per-contract chain pulls, anything you can split with `split_date_range`. It does nothing for one giant request, so split the request first ([Request Sizing](/articles/request-sizing)), then let your tier's slots work through the pieces.
+Concurrency multiplies throughput on multi-request workloads: per-day backfills, per-contract chain pulls, anything you can split with `split_date_range`. It does nothing for one giant request, so split the request first ([Request Sizing](/articles/request-sizing)), then let your tier's capacity work through the pieces.
 
-One more queue exists upstream: if the servers themselves report exhaustion, the SDK retries with backoff before surfacing an error. Long-running bulk jobs should still expect occasional retries during peak hours; see [Data Issues?](/articles/data-issues) if a job stalls beyond that.
+If the service reports exhaustion during peak hours, the SDK retries with backoff before surfacing an error. Long-running bulk jobs should expect occasional retries at peak; see [Data Issues?](/articles/data-issues) if a job stalls beyond that.

--- a/docs-site/docs/articles/configuration.md
+++ b/docs-site/docs/articles/configuration.md
@@ -102,7 +102,7 @@ In Rust the same fields live on `DirectConfig` struct sub-configs (`config.retry
 
 Every field above is available on all four language surfaces under the naming convention shown earlier; unknown values fail at configuration time, not at first request.
 
-Historical request concurrency is not in this table because it isn't configurable. The SDK sizes its historical connection pool automatically from your subscription tier at connect time. See [Concurrent Requests](/articles/concurrent-requests).
+Historical request concurrency is not in this table because it isn't configurable: it is set by your subscription tier. See [Concurrent Requests](/articles/concurrent-requests).
 
 ## Config file (Rust)
 

--- a/docs-site/docs/server/http.md
+++ b/docs-site/docs/server/http.md
@@ -69,4 +69,4 @@ Mirrored 1:1 from the JVM terminal — unauthenticated `GET`, bare `text/plain` 
 
 ## Concurrency behavior
 
-Bursts queue, they don't fail. In-flight requests are capped at the HTTP edge (256) and by your [subscription tier's concurrency](/articles/concurrent-requests) inside the SDK; requests beyond either cap wait in order. Only genuine upstream exhaustion — after the SDK's own retries — surfaces as `503` with `Retry-After`. A client that disconnects or times out releases its slots immediately.
+Bursts queue, they don't fail. The HTTP edge admits up to 256 simultaneous requests; beyond that they queue and are served in order, and a client that disconnects or times out frees its place immediately. Genuine upstream exhaustion surfaces as `503` with `Retry-After`.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -156,7 +156,7 @@ Send JSON commands to manage subscriptions:
 
 ## Hardening
 
-- **256 concurrent in-flight requests** — requests past the cap queue on the layer's semaphore (they are not rejected), then queue again on the SDK's tier-sized request semaphore that matches the upstream concurrency cap. Bursts absorb as latency, not errors; see the Concurrency Model section in `docs-site/docs/server/http.md`. Upstream capacity rejections that survive the SDK's retry budget surface as `503` + `Retry-After`, not 500. **64 KiB body limit**, **4 KiB WebSocket `Message::Text` cap**.
+- **256 simultaneous HTTP requests admitted at the edge** — requests past the cap queue and are served in order rather than rejected, so a connection flood can't exhaust the runtime. Genuine upstream exhaustion surfaces as `503` + `Retry-After`, not 500. **64 KiB body limit**, **4 KiB WebSocket `Message::Text` cap**.
 - **`BoundedQuery<32>` extractor** counts `&`-delimited query-string pairs BEFORE `serde_urlencoded` runs, so a `?a=1&b=2&...` flood is rejected at parse time rather than after HashMap rehashing allocates MB+.
 - **CSV output defuses formula injection** — cells whose first byte is `=` / `+` / `-` / `@` / `\t` are prefixed with a single-quote `'` and CSV-quoted.
 - **Streaming TLS** verifies every peer against a captured SubjectPublicKeyInfo pin (`PinnedVerifier`, constant-time SHA-256 compare); MITM presenting any other cert is rejected even if it chains to a trusted CA. See `docs-site/docs/streaming/index.md`.


### PR DESCRIPTION
Aligns the concurrency docs (`articles/concurrent-requests`, `articles/configuration`, `server/http`, and the server README) with how the data service documents concurrent-request behavior: a tier-based limit that is account-wide and set by your highest subscription tier, with excess requests queued in order. Describes what a caller observes rather than how it is arranged internally. No API or behavior change.