### PR TITLE
docs: fix await_drain return doc and account-wide concurrency comment

### DIFF
--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -2631,8 +2631,10 @@ void thetadatadx_client_stop_streaming(const ThetaDataDxClient* handle);
  *  @param handle The unified handle.
  *  @param timeout_ms Maximum time to wait, in milliseconds.
  *  @return 1 once the previous session has finished firing the registered
- *          callback; 0 on timeout or when no stream has ever been started or
- *          stopped on this handle.
+ *          callback, or when no stream has ever been started or stopped on
+ *          this handle (an idle handle is already quiesced); 0 only on
+ *          timeout. Note the standalone thetadatadx_streaming_await_drain
+ *          returns 0 for the idle case instead.
  *  @note Must be called from a thread other than the streaming consumer. */
 int thetadatadx_client_await_drain(const ThetaDataDxClient* handle, uint64_t timeout_ms);
 

--- a/thetadatadx-ffi/src/streaming.rs
+++ b/thetadatadx-ffi/src/streaming.rs
@@ -1374,8 +1374,11 @@ pub unsafe extern "C" fn thetadatadx_client_panic_count(handle: *const ThetaData
 ///
 /// Returns `1` once the previous `thetadatadx_client_stop_streaming` /
 /// `_reconnect` session's event-dispatch consumer thread has finished
-/// firing the registered callback. Returns `0` on timeout or when no
-/// stream has been stopped on this handle.
+/// firing the registered callback, and also when no stream has ever been
+/// started or stopped on this handle (an idle handle has nothing to
+/// drain, so it is already quiesced). Returns `0` only on timeout. Note
+/// this differs from the standalone `thetadatadx_streaming_await_drain`,
+/// which returns `0` for the empty case.
 ///
 /// # When to call
 ///

--- a/thetadatadx-rs/src/auth/nexus.rs
+++ b/thetadatadx-rs/src/auth/nexus.rs
@@ -235,8 +235,11 @@ impl std::fmt::Debug for AuthResponse {
 /// User info returned by the Nexus auth endpoint.
 ///
 /// The Nexus API returns per-asset subscription tiers encoded as integers:
-/// FREE=0, VALUE=1, STANDARD=2, PROFESSIONAL=3. These drive concurrency
-/// limits: `2^tier` concurrent historical requests per asset class.
+/// FREE=0, VALUE=1, STANDARD=2, PROFESSIONAL=3. Concurrency is account-wide,
+/// not per asset class: [`AuthUser::max_concurrent_requests`] takes the
+/// highest tier across asset classes and permits `2^tier` concurrent
+/// historical requests, matching the vendor's account-wide-by-highest-tier
+/// rule.
 ///
 /// `Debug` is implemented manually so `email` never lands in panic
 /// output / tracing diagnostics / FFI `repr()`. The subscription


### PR DESCRIPTION
Two documentation-accuracy fixes surfaced during a review pass.

1. The unified `thetadatadx_client_await_drain` header (`thetadatadx.h`) and its Rust doc said it returns `0` when no stream has ever started, but an idle unified handle is already quiesced and returns `1`; only a timeout returns `0`. The standalone FPSS `thetadatadx_streaming_await_drain` returns `0` for the idle case, and the doc now states that difference.

2. An `AuthUser` comment described the concurrency limit as `2^tier` per asset class. The limit is account-wide: `max_concurrent_requests` takes the highest tier across asset classes, matching the vendor's account-wide-by-highest-tier rule.

Docs/comments only, no behavior change. Closes #1171.