### PR TITLE
chore(deps): stop dependabot bumping the self-referential platform packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,12 @@ updates:
     groups:
       patch-minor:
         update-types: ["patch", "minor"]
+    # The `thetadatadx-*` platform packages in optionalDependencies are this
+    # project's own napi binaries; their versions track the release and are
+    # set by scripts/release/bump_version.py, not dependabot. Bumping them to
+    # an as-yet-unpublished release version breaks the lockfile install.
+    ignore:
+      - dependency-name: "thetadatadx-*"
 
   - package-ecosystem: "npm"
     directory: "/docs-site"


### PR DESCRIPTION
The `thetadatadx-*` platform packages in `thetadatadx-ts/package.json` optionalDependencies are this project's own napi binaries, version-pinned to the release by `scripts/release/bump_version.py`. Dependabot was proposing bumps to them (#1166), which reference release versions not yet published to npm and break the lockfile install. This adds a `thetadatadx-*` ignore to the npm update config so dependabot leaves them alone while still tracking real third-party deps like `@types/node`.