### PR TITLE
fix(docs,ci): stable-install docs for 13.0.0 GA and repoint semver baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,7 +580,7 @@ jobs:
         continue-on-error: false
         with:
           package: thetadatadx
-          baseline-rev: v11.0.0  # VOCAB-OK: published-release tag is the semver-checks baseline anchor
+          baseline-rev: v13.0.0  # VOCAB-OK: published-release tag is the semver-checks baseline anchor
 
   surfaces:
     name: Extended Surfaces

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -26,12 +26,12 @@ The market-data client is async; call it from your application's async runtime.
 <template #python>
 
 ```bash
-pip install --pre thetadatadx
+pip install thetadatadx
 
 # Optional DataFrame adapters:
-pip install --pre "thetadatadx[pandas]"    # pandas
-pip install --pre "thetadatadx[polars]"    # polars
-pip install --pre "thetadatadx[arrow]"     # pyarrow only
+pip install "thetadatadx[pandas]"    # pandas
+pip install "thetadatadx[polars]"    # polars
+pip install "thetadatadx[arrow]"     # pyarrow only
 ```
 
 Requires Python 3.12+. Pre-built `abi3` wheels for Linux x86_64, macOS, and Windows — no Rust toolchain needed. On other platforms, build from source with [maturin](https://www.maturin.rs/) (`maturin develop --release` in `thetadatadx-py`).
@@ -41,7 +41,7 @@ Requires Python 3.12+. Pre-built `abi3` wheels for Linux x86_64, macOS, and Wind
 <template #typescript>
 
 ```bash
-npm install thetadatadx@next
+npm install thetadatadx
 ```
 
 Requires Node.js 20+. Pre-built native binaries install automatically per platform.

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -92,14 +92,14 @@ println!("{} {}", rows[0].bid, rows[0].ask);
 
 ## Install
 
-::: warning Install the release candidate
+::: tip Install
 
-The active release line is the **13.0.0 release candidate**. It carries the latest data coverage and fixes, and we recommend installing it. Grab the newest RC:
+The supported release line is **13.0.0**. Install the stable package directly. Versions before 13.0.0 are unsupported and have been withdrawn from the registries.
 
 ```bash
-pip install --pre thetadatadx          # Python 3.12+ (pinned: pip install thetadatadx==13.0.0rc17)
-npm install thetadatadx@next           # Node.js 20+ (pinned: npm install thetadatadx@13.0.0)
-cargo add thetadatadx@13.0.0     # Rust async client
+pip install thetadatadx            # Python 3.12+
+npm install thetadatadx            # Node.js 20+
+cargo add thetadatadx              # Rust async client
 ```
 
 :::


### PR DESCRIPTION
The docs-site install pages still advertised the release candidate (`pip install --pre`, `npm install @next`); switched to the stable package to match the README now that 13.0.0 is GA. Also repoints the release semver-check baseline from the removed `v11.0.0` tag to `v13.0.0`.