### PR TITLE
feat(market-data): flat files on the standalone MarketDataClient (0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-07
+
+### Added
+
+- **Flat files on the standalone `MarketDataClient`.** The market-data-only client now exposes the full flat-file surface — the `flat_files()` namespace view plus the `flatfile_request` / `flatfile_request_decoded` entries and the five per-dataset convenience methods — matching the unified `Client` method-for-method. Flat files are account-authenticated market data with no streaming leg, so they belong on the market-data handle; a market-data-only workflow no longer needs the unified client to pull whole-universe per-day distributions. Reached the same way on every binding: Rust and C++ `MarketDataClient::flat_files()`, and the Python and TypeScript market-data clients, all backed by the same flat-file engine as the unified client.
+
+### Fixed
+
+- **C++ flat-file view lifetime.** The C++ `FlatFiles` view now co-owns the client handle (`shared_ptr`) instead of borrowing it, so it stays valid if the originating client is closed or destroyed while the view — or an in-flight call on it — is still alive. The accessor is now plain `const` (safe on a temporary), matching the `market_data()` view; the handle is released only once the last owner drops.
+
 ## [0.1.0] - 2026-07-07
 
 The first public release of ThetaDataDx: a terminal-exact, drop-in market-data SDK across Rust, Python, TypeScript, and C++, plus a bundled HTTP + WebSocket server and an MCP server, all over one Rust engine. It connects straight to ThetaData with nothing to install and run locally, and delivers US stock, option, index, and interest-rate data three ways from a single authenticated client: point-in-time history, real-time streaming, and whole-universe flat files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx-rs = "0.1.0"
+thetadatadx-rs = "0.1.1"
 ```
 
 ```rust

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,13 +17,11 @@ for critical issues.
 
 ## Supported Versions
 
-Security fixes land on the current major line only. Older majors are not patched; upgrade to the latest `13.x` release.
+Security fixes land on the latest release. This is the project's first public release line, so there are no earlier supported versions.
 
-| Version | Supported          | Notes |
-| ------- | ------------------ | ----- |
-| 13.x    | :white_check_mark: | Current release |
-| 10.x-12.x | :x:              | Upgrade to 13.x |
-| < 10.0  | :x:                | Upgrade to 13.x |
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
 
 ## Security Design
 
@@ -57,13 +55,13 @@ All network operations enforce timeouts to prevent indefinite hangs:
 
 ### TLS
 
-All network connections use a **unified TLS stack** (`rustls` with ring backend):
+All network connections use a single, unified TLS stack:
 
 - **Market-data channel**: TLS with certificate validation
 - **Streaming channel**: TLS with certificate validation and pinning
 - **Nexus auth (HTTP)**: TLS with certificate validation
 
-Root certificates come from `webpki-roots` (Mozilla's CA bundle). Certificate
+Root certificates come from Mozilla's root CA bundle. Certificate
 validation is enforced on market-data and Nexus (HTTP) connections. Streaming
 uses a pinned verifier: it accepts only the configured streaming hostnames and the expected
 leaf `SubjectPublicKeyInfo` SHA-256 pin, while still verifying the TLS handshake
@@ -77,7 +75,7 @@ official terminal), so passwords longer than 127 bytes authenticate correctly
 
 ### Concurrent Request Limiting
 
-The SDK caps the number of in-flight market-data requests with an internal semaphore. The cap
+The SDK caps the number of in-flight market-data requests. The cap
 is derived automatically from the account's subscription tier at connect time and is not
 user-configurable. This respects the server-side per-tier concurrency limit and prevents
 runaway request storms from overwhelming the upstream server or triggering server-side rate
@@ -85,25 +83,25 @@ limiting.
 
 ### Unknown Compression Rejection
 
-`decompress_response` returns an error for unrecognized compression algorithms
+The response decompressor returns an error for unrecognized compression algorithms
 instead of silently treating the data as uncompressed. This prevents corrupt data from being
 silently passed to callers.
 
 ### Streaming Event Dispatch
 
-Streaming uses a dedicated async runtime path with bounded buffering for event
+Streaming uses a dedicated dispatch path with bounded buffering for event
 dispatch. The bounded buffer prevents unbounded memory growth from unconsumed
 events.
 
 ### Frame Size Limits
 
-Binary frame size assertions use `assert!` (not `debug_assert!`), ensuring they
-are enforced in release builds. This prevents oversized frames from causing
-unbounded memory allocation.
+Binary frame size checks are enforced in release builds, not only in debug
+builds. This prevents oversized frames from causing unbounded memory
+allocation.
 
 ### Dependencies
 
 We review dependencies for:
 - Known vulnerabilities (RustSec advisory database)
 - License compliance
-- Duplicate crate versions
+- Duplicate dependency versions

--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
       {
         text: 'API Reference',
         collapsed: false,
-        items: [{ text: 'Overview', link: '/reference/' }, ...(referenceSidebar as any)],
+        items: [{ text: 'Overview', link: '/reference/' }, { text: 'Flat Files', link: '/articles/flat-files' }, ...(referenceSidebar as any)],
       },
       {
         text: 'Streaming',

--- a/docs-site/docs/articles/flat-files.md
+++ b/docs-site/docs/articles/flat-files.md
@@ -112,6 +112,55 @@ The to-disk (`to_path` / `flatfile_to_path`) and HTTP paths write one of:
 
 The decoded-rows path (`option_trade_quote(...)`, `request(...)`) skips the file entirely and returns typed `FlatFileRow`s ready for Arrow, Polars, pandas, or your own pipeline.
 
+## Columnar & DataFrames
+
+The decoded-rows path hands back a typed row collection that converts straight to Arrow — and, on Python, to a Polars or pandas DataFrame — with no CSV round-trip. The Arrow schema is inferred from the file's own column header, so it always matches the dataset.
+
+<SdkTabs>
+
+<template #rust>
+
+```rust
+let rows = client.flat_files().option_trade_quote("20250303").await?;
+let batch = thetadatadx::flatfiles::arrow::rows_to_arrow(&rows)?; // arrow_array::RecordBatch
+```
+
+</template>
+
+<template #python>
+
+```python
+rows = client.flat_files.option_trade_quote("20250303")
+pl_df = rows.to_polars()     # Polars DataFrame
+pd_df = rows.to_pandas()     # pandas DataFrame
+table = rows.to_arrow()      # pyarrow Table (zero-copy)
+records = rows.to_list()     # list[dict]
+```
+
+</template>
+
+<template #typescript>
+
+```typescript
+import { tableFromIPC } from "apache-arrow";
+
+const rows = await client.flatFiles.optionTradeQuote('20250303');
+const table = tableFromIPC(rows.toArrowIpc());   // apache-arrow Table
+```
+
+</template>
+
+<template #cpp>
+
+```cpp
+auto rows = client.flat_files().option_trade_quote("20250303");
+std::vector<uint8_t> ipc = rows.to_arrow_ipc();  // feed arrow::ipc::RecordBatchStreamReader
+```
+
+</template>
+
+</SdkTabs>
+
 ## Column schema
 
 Each dataset's columns are described by the server in the file's header and carried on the decoded `FlatFileRow` (and the CSV header) — the SDK does not hardcode a fixed column set, so a server-side schema addition flows through without an SDK change. For the authoritative per-dataset column list, see ThetaData's [flat-file reference](https://http-docs.thetadata.us/operations/get-v2-flat-file-getting-started.html).

--- a/docs-site/docs/articles/flat-files.md
+++ b/docs-site/docs/articles/flat-files.md
@@ -11,6 +11,8 @@ Flat files deliver **the whole universe for one date in one call** — every opt
 
 The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod` and stock `trade_quote` / `eod`. The `flat_files` namespace exposes one method per served pair: `option_trade_quote`, `option_open_interest`, `option_eod`, `stock_trade_quote`, `stock_eod` — plus a generic `request(sec_type, req_type, date)` that rejects an unserved `(security, request)` pair with a typed invalid-parameter error before any network round-trip. Per-tick quotes, trades, and OHLC bars are served by the [reference endpoints](/reference/), not as flat files.
 
+Flat files are account-authenticated market data, so `client` below can be either the unified `Client` or the standalone `MarketDataClient` — both expose the identical `flat_files` surface. A market-data-only workflow never needs the unified client just to pull archives.
+
 <SdkTabs>
 
 <template #rust>

--- a/docs-site/docs/articles/flat-files.md
+++ b/docs-site/docs/articles/flat-files.md
@@ -5,11 +5,27 @@ description: Whole-universe daily archives — every contract for a date in one 
 
 # Flat Files
 
+<TierBadge tier="professional" />
+
 Flat files deliver **the whole universe for one date in one call** — every option contract or every stock for a given (security type, request type, date). Use them for daily ETL and backtests that need everything; use the per-contract [reference endpoints](/reference/) when you need one contract fast; use [streaming](/streaming/) for live data.
 
-## Pull a file
+## Datasets
 
-The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod` and stock `trade_quote` / `eod`. The `flat_files` namespace exposes one method per served pair: `option_trade_quote`, `option_open_interest`, `option_eod`, `stock_trade_quote`, `stock_eod` — plus a generic `request(sec_type, req_type, date)` that rejects an unserved `(security, request)` pair with a typed invalid-parameter error before any network round-trip. Per-tick quotes, trades, and OHLC bars are served by the [reference endpoints](/reference/), not as flat files.
+The distribution serves a fixed set of five datasets. Each is one method on the `flat_files` namespace plus a generic `request(sec_type, req_type, date)` dispatcher; an unserved `(security, request)` pair is rejected with a typed invalid-parameter error before any network round-trip. Per-tick quotes, trades, and OHLC bars are served by the [reference endpoints](/reference/), not as flat files. Response times and file sizes are ThetaData's published typicals for a full day.
+
+| Dataset | Method | What one file holds | Typical |
+|---|---|---|---|
+| Option trade-quote | `option_trade_quote` | Every OPRA trade paired with the NBBO quote in effect just before it, all contracts for the date. | ~3 min · ~1.2 GB |
+| Option open-interest | `option_open_interest` | The prior session's closing open interest from OPRA (published ~06:30 ET), one row per contract. | ~1 min · ~50 MB |
+| Option EOD | `option_eod` | Theta's 17:15 ET end-of-day summary (OPRA publishes no national EOD): `ms_of_day` is the report time, `ms_of_day2` the last trade, and the quote is the last NBBO at report time. | ~1 min · ~150 MB |
+| Stock trade-quote | `stock_trade_quote` | Every trade paired with the NBBO quote preceding it, all symbols for the date. | ~30 min · ~14 GB |
+| Stock EOD | `stock_eod` | The national 17:15 ET end-of-day summary (SIPs publish only partial EOD): `ms_of_day` report time, `ms_of_day2` last trade, and the last CTA/UTP NBBO. | ~1 sec · ~1.5 MB |
+
+## Availability
+
+The most recent **7 calendar days** are available; the prior day is generally ready between 00:30 and 01:00 ET. A request outside that window returns a typed no-data error, not empty rows — it is a window limit, not a failure. For deeper history, contact ThetaData.
+
+## Pull a file
 
 Flat files are account-authenticated market data, so `client` below can be either the unified `Client` or the standalone `MarketDataClient` — both expose the identical `flat_files` surface. A market-data-only workflow never needs the unified client just to pull archives.
 
@@ -75,6 +91,30 @@ The server streams the response body in chunks, so downloads of any size run in 
 </template>
 
 </SdkTabs>
+
+## Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `date` | yes | The archive date, `YYYYMMDD`. One date per call — flat files have no range form. |
+| `format` | no | On-disk encoding for the to-disk / HTTP paths; one of the formats below. Defaults to `csv`. The decoded-rows path returns typed rows and ignores it. |
+
+## Formats
+
+The to-disk (`to_path` / `flatfile_to_path`) and HTTP paths write one of:
+
+| Format | Value | Output |
+|---|---|---|
+| CSV | `csv` (default) | Vendor byte-format CSV — lowercase headers, byte-matches the terminal's own download. |
+| JSON Lines | `jsonl` / `ndjson` | One JSON object per row. |
+| JSON | `json` | A single JSON array of the same per-row objects. |
+| HTML | `html` | An HTML `<table>`. |
+
+The decoded-rows path (`option_trade_quote(...)`, `request(...)`) skips the file entirely and returns typed `FlatFileRow`s ready for Arrow, Polars, pandas, or your own pipeline.
+
+## Column schema
+
+Each dataset's columns are described by the server in the file's header and carried on the decoded `FlatFileRow` (and the CSV header) — the SDK does not hardcode a fixed column set, so a server-side schema addition flows through without an SDK change. For the authoritative per-dataset column list, see ThetaData's [flat-file reference](https://http-docs.thetadata.us/operations/get-v2-flat-file-getting-started.html).
 
 ## Size guidance
 

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx-rs = "0.1.0"
+thetadatadx-rs = "0.1.1"
 ```
 
 The market-data client is async; call it from your application's async runtime.

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-07
+
+### Added
+
+- **Flat files on the standalone `MarketDataClient`.** The market-data-only client now exposes the full flat-file surface — the `flat_files()` namespace view plus the `flatfile_request` / `flatfile_request_decoded` entries and the five per-dataset convenience methods — matching the unified `Client` method-for-method. Flat files are account-authenticated market data with no streaming leg, so they belong on the market-data handle; a market-data-only workflow no longer needs the unified client to pull whole-universe per-day distributions. Reached the same way on every binding: Rust and C++ `MarketDataClient::flat_files()`, and the Python and TypeScript market-data clients, all backed by the same flat-file engine as the unified client.
+
+### Fixed
+
+- **C++ flat-file view lifetime.** The C++ `FlatFiles` view now co-owns the client handle (`shared_ptr`) instead of borrowing it, so it stays valid if the originating client is closed or destroyed while the view — or an in-flight call on it — is still alive. The accessor is now plain `const` (safe on a temporary), matching the `market_data()` view; the handle is released only once the last owner drops.
+
 ## [0.1.0] - 2026-07-07
 
 The first public release of ThetaDataDx: a terminal-exact, drop-in market-data SDK across Rust, Python, TypeScript, and C++, plus a bundled HTTP + WebSocket server and an MCP server, all over one Rust engine. It connects straight to ThetaData with nothing to install and run locally, and delivers US stock, option, index, and interest-rate data three ways from a single authenticated client: point-in-time history, real-time streaming, and whole-universe flat files.

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 0.1.0
+  version: 0.1.1
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/docs-site/docs/reference/index.md
+++ b/docs-site/docs/reference/index.md
@@ -14,6 +14,9 @@ One page per endpoint. Each page carries the typed signature and a runnable samp
 | [Index](/reference/index/list/symbols) | List, snapshots, price history, at-time lookups. |
 | [Calendar](/reference/calendar/open-today) | Trading-calendar status by day and year. |
 | [Interest Rate](/reference/rate/history/eod) | Rate series history. |
+| [Flat Files](/articles/flat-files) | Whole-universe daily archives — every option contract or stock for a date in one call (option trade-quote / open-interest / EOD, stock trade-quote / EOD). |
+
+Per-contract endpoints have one page each; flat files are whole-file archives, so they share a single [Flat Files](/articles/flat-files) page rather than a page per dataset.
 
 Conventions shared by every endpoint — identifiers, units, timestamps — live in [Symbology & Contract Identity](/articles/symbology). Tier badges on each page map to [Subscriptions](/articles/subscriptions).
 

--- a/parity.toml
+++ b/parity.toml
@@ -978,6 +978,23 @@ rust = true         # `Client::flat_files()` view accessor
 [method.signature]
 returns = "FlatFilesNamespace"
 
+# The standalone market-data client exposes the same accessor: flat files are
+# account-authenticated market data with no streaming leg, so a market-data-only
+# handle reaches them without the unified client. Pinned on every binding so a
+# future drop/rename of the accessor trips the gate. Python resolves it through
+# the `MarketDataClient.__getattr__` forward to the unified client; TypeScript is
+# the napi `flatFiles` getter on `MarketDataClient`; C++ and Rust are the
+# `MarketDataClient::flat_files()` view accessor.
+[[method]]
+class = "MarketDataClient"
+name = "flatFiles"
+python = true
+typescript = true
+cpp = true
+rust = true         # `MarketDataClient::flat_files()` view accessor
+[method.signature]
+returns = "FlatFilesNamespace"
+
 # Deterministic base-client teardown (issue #1069). `close()` stops streaming
 # if live and releases the client; the language context-manager / RAII wrappers
 # (`__exit__`/`[Symbol.dispose]`/destructor) route through it. The
@@ -4246,6 +4263,37 @@ name = "flatfile_rows_to_arrow_ipc"
 [ffi_symbol.signature]
 params = ["*const ThetaDataDxFlatFileRowList"]
 returns = "ThetaDataDxFlatFileBytes"
+
+# Flat files from the standalone market-data client. Flat files are pure
+# account-authenticated market data, so the borrowed `MarketDataClient` handle
+# exposes the identical fetch surface as the unified client's
+# `thetadatadx_flatfile_*`. These two hand-written externs back the C++
+# `MarketDataClient::flat_files()` view (Python and TypeScript reach the same
+# surface through their unified-client-backed handles). No endpoint/config
+# family tracks them, so a `[[ffi_symbol]]` row pins each one's existence.
+[[ffi_symbol]]
+name = "market_data_flatfile_request_decoded"
+[ffi_symbol.signature]
+params = [
+    "*const ThetaDataDxMarketDataClient",
+    "*const c_char",
+    "*const c_char",
+    "*const c_char",
+]
+returns = "*mut ThetaDataDxFlatFileRowList"
+
+[[ffi_symbol]]
+name = "market_data_flatfile_request_to_path"
+[ffi_symbol.signature]
+params = [
+    "*const ThetaDataDxMarketDataClient",
+    "*const c_char",
+    "*const c_char",
+    "*const c_char",
+    "*const c_char",
+    "*const c_char",
+]
+returns = "i32"
 
 # Per-tick Arrow IPC terminals (`thetadatadx_<kind>_ticks_to_arrow_ipc`,
 # `thetadatadx_calendar_days_to_arrow_ipc`). Emitted by the

--- a/parity.toml
+++ b/parity.toml
@@ -980,11 +980,13 @@ returns = "FlatFilesNamespace"
 
 # The standalone market-data client exposes the same accessor: flat files are
 # account-authenticated market data with no streaming leg, so a market-data-only
-# handle reaches them without the unified client. Pinned on every binding so a
-# future drop/rename of the accessor trips the gate. Python resolves it through
-# the `MarketDataClient.__getattr__` forward to the unified client; TypeScript is
-# the napi `flatFiles` getter on `MarketDataClient`; C++ and Rust are the
-# `MarketDataClient::flat_files()` view accessor.
+# handle reaches them without the unified client. Genuinely enforced on every
+# binding so a future drop/rename of the accessor trips the gate. Python is the
+# explicit `#[getter] flat_files` on the `MarketDataClient` pyclass (a static
+# accessor, not the `__getattr__` forward, so the collector sees it); TypeScript
+# is the napi `flatFiles` getter on `MarketDataClient`; C++ and Rust are the
+# `MarketDataClient::flat_files()` view accessor (Rust harvested from
+# `impl MarketDataClient` in `mdds/client.rs`).
 [[method]]
 class = "MarketDataClient"
 name = "flatFiles"

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -2456,50 +2456,74 @@ PYI_SETTER_PROPERTY_ROWS: frozenset[tuple[str, str]] = frozenset(
 # Parity-toml `class` field → the Rust struct the Rust method collector
 # keys on. The flat-file namespace is the borrowed `FlatFiles` view
 # returned by `Client::flat_files()`; the unified entry-point client is
-# `Client`. Both live in `thetadatadx-rs/src/client.rs`. A row class
+# `Client`. Those two live in `thetadatadx-rs/src/client.rs`; the standalone
+# `MarketDataClient` below lives in `mdds/client.rs`. A row class
 # absent from this table is not gated on the Rust column (Python /
 # TypeScript / C++ only), so the Rust column is opt-in per row — exactly
 # the surfaces where Rust must mirror the other bindings.
 RUST_METHOD_CLASS: dict[str, str] = {
     "FlatFilesNamespace": "FlatFiles",
     "Client": "Client",
+    # The standalone market-data client is a distinct Rust struct (not a view
+    # borrowing `Client`); its cross-binding surface (`close`, `flat_files`)
+    # lives in `impl MarketDataClient` in `mdds/client.rs`, which the collector
+    # harvests alongside `client.rs` so the Rust column of those rows is
+    # genuinely enforced, not decorative.
+    "MarketDataClient": "MarketDataClient",
 }
+
+# The Rust source file each harvested view class is declared in — used only to
+# make a tripped-row diagnostic point at the right file (most live in
+# `client.rs`; `MarketDataClient` lives in the sibling `mdds/client.rs`).
+_RUST_CLASS_FILE: dict[str, str] = {
+    "MarketDataClient": "thetadatadx-rs/src/mdds/client.rs",
+}
+_DEFAULT_RUST_FILE = "thetadatadx-rs/src/client.rs"
 
 
 def _collect_rust_view_methods(client_rs: pathlib.Path) -> dict[str, set[str]]:
     """Return `{rust_class: {method, ...}}` for the public methods on the
-    Rust view structs that mirror the cross-binding surface.
+    Rust view / client structs that mirror the cross-binding surface.
 
     Parses every `impl FlatFiles<...> { ... }` and `impl Client { ... }`
-    block in `client.rs` and collects each `pub fn <name>` /
+    block in `client.rs`, plus every `impl MarketDataClient { ... }` block in
+    the sibling `mdds/client.rs`, and collects each `pub fn <name>` /
     `pub async fn <name>` (snake_case). `#[cfg(...)]` / `#[doc(hidden)]`
     gated methods are skipped — they are not part of the published surface
     a binding must mirror. The harvested set is keyed by the bare Rust
-    struct name (`FlatFiles`, `Client`), which the forward check resolves
-    a parity row's class to via `RUST_METHOD_CLASS`.
+    struct name (`FlatFiles`, `Client`, `MarketDataClient`), which the forward
+    check resolves a parity row's class to via `RUST_METHOD_CLASS`.
     """
     out: dict[str, set[str]] = {}
-    if not client_rs.is_file():
-        return out
-    text = _read_source(client_rs)
     # `pub fn <name>(` or `pub async fn <name>(`, capturing any leading
     # attribute lines so cfg/doc-hidden gating can be honoured.
     pub_fn_re = re.compile(
         r"((?:#\[[^\]]*\]\s*)*)\bpub\s+(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]"
     )
-    for struct in ("FlatFiles", "Client"):
-        # `impl FlatFiles<'_> {` / `impl Client {` — tolerate an optional
-        # generic / lifetime parameter list before the brace. Walk every
-        # matching impl block (there are several `impl Client` blocks).
-        impl_re = re.compile(rf"impl\s+{struct}\b[^{{]*\{{")
-        for header in impl_re.finditer(text):
-            body = _balanced_body(text, header.end())
-            for m in pub_fn_re.finditer(body):
-                attrs = m.group(1)
-                name = m.group(2)
-                if "cfg(" in attrs or "doc(hidden)" in attrs:
-                    continue
-                out.setdefault(struct, set()).add(name)
+
+    def _harvest(path: pathlib.Path, structs: tuple[str, ...]) -> None:
+        if not path.is_file():
+            return
+        text = _read_source(path)
+        for struct in structs:
+            # `impl FlatFiles<'_> {` / `impl Client {` / `impl MarketDataClient {`
+            # — tolerate an optional generic / lifetime parameter list before the
+            # brace, and walk every matching impl block (there are several).
+            impl_re = re.compile(rf"impl\s+{struct}\b[^{{]*\{{")
+            for header in impl_re.finditer(text):
+                body = _balanced_body(text, header.end())
+                for m in pub_fn_re.finditer(body):
+                    attrs = m.group(1)
+                    name = m.group(2)
+                    if "cfg(" in attrs or "doc(hidden)" in attrs:
+                        continue
+                    out.setdefault(struct, set()).add(name)
+
+    _harvest(client_rs, ("FlatFiles", "Client"))
+    # `mdds/client.rs` only carries the session/transport impl + the flat-file
+    # surface; the generated endpoint methods live in other files and are tracked
+    # by the market-data-base rows, not this view-method forward check.
+    _harvest(client_rs.parent / "mdds" / "client.rs", ("MarketDataClient",))
     return out
 
 
@@ -2751,7 +2775,7 @@ def _check_method_rows(
                     f"actual={actual_rust} ({verb} -- expected "
                     f"`pub fn {rust_member}` or `pub async fn {rust_member}` "
                     f"inside `impl {rust_lookup_class}` in "
-                    f"thetadatadx-rs/src/client.rs)"
+                    f"{_RUST_CLASS_FILE.get(rust_lookup_class, _DEFAULT_RUST_FILE)})"
                 )
 
     # Reverse-direction orphan scan for Client-level helper methods. A helper
@@ -7652,16 +7676,22 @@ def _sig_cpp_param_type(param: str) -> str:
 
 def _sig_extract_rust(client_rs: pathlib.Path, struct: str, method: str) -> tuple[list[str], str] | None:
     """Rust core signature: the `pub fn method` / `pub async fn method` inside
-    an `impl struct` block in `client.rs`. Receivers / the `py` token stripped;
-    the return is the `-> T` (defaulting to `()`)."""
-    if not client_rs.is_file():
-        return None
-    text = _read_source(client_rs)
+    an `impl struct` block. Receivers / the `py` token stripped; the return is
+    the `-> T` (defaulting to `()`).
+
+    Searches `client.rs` first, then the sibling `mdds/client.rs` — the
+    standalone `MarketDataClient`'s cross-binding surface (`close`,
+    `flat_files`) lives in the latter, so its signatures are pinned too rather
+    than degrading to unchecked."""
     impl_re = re.compile(r"impl\s+" + re.escape(struct) + r"\b[^{]*\{")
-    for h in impl_re.finditer(text):
-        sig = _sig_rust_fn(_balanced_body(text, h.end()), method, require_pub=True)
-        if sig is not None:
-            return sig
+    for path in (client_rs, client_rs.parent / "mdds" / "client.rs"):
+        if not path.is_file():
+            continue
+        text = _read_source(path)
+        for h in impl_re.finditer(text):
+            sig = _sig_rust_fn(_balanced_body(text, h.end()), method, require_pub=True)
+            if sig is not None:
+                return sig
     return None
 
 

--- a/thetadatadx-cpp/CMakeLists.txt
+++ b/thetadatadx-cpp/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 # `VERSION` tracks the C++ binding alongside the Rust Cargo manifests
 # (`Cargo.toml`, `thetadatadx-rs/Cargo.toml`, `tools/*/Cargo.toml`) and the
 # TypeScript `package.json` files; all bindings carry the same version.
-project(thetadatadx-cpp VERSION 0.1.0 LANGUAGES CXX)
+project(thetadatadx-cpp VERSION 0.1.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -2787,6 +2787,42 @@ int thetadatadx_flatfile_request_to_path(
     const char* path,
     const char* format);
 
+/** Pull a decoded flat-file blob from a standalone market-data client.
+ *  Flat files are account-authenticated market data, so the market-data
+ *  handle exposes the identical surface as the unified client.
+ *  @param handle The market-data handle.
+ *  @param sec_type "OPTION", "STOCK", or "INDEX".
+ *  @param req_type "EOD", "QUOTE", "OPEN_INTEREST", "OHLC", "TRADE", or
+ *                  "TRADE_QUOTE".
+ *  @param date The snapshot date as "YYYYMMDD".
+ *  @return A row-list handle the caller MUST free with
+ *          thetadatadx_flatfile_rowlist_free, or NULL on error (check
+ *          thetadatadx_last_error()). */
+ThetaDataDxFlatFileRowList* thetadatadx_market_data_flatfile_request_decoded(
+    const ThetaDataDxMarketDataClient* handle,
+    const char* sec_type,
+    const char* req_type,
+    const char* date);
+
+/** Pull a flat-file blob from a standalone market-data client and write the
+ *  requested vendor format directly to a file. The format extension is
+ *  appended to path automatically if missing.
+ *  @param handle The market-data handle.
+ *  @param sec_type "OPTION", "STOCK", or "INDEX".
+ *  @param req_type "EOD", "QUOTE", "OPEN_INTEREST", "OHLC", "TRADE", or
+ *                  "TRADE_QUOTE".
+ *  @param date The snapshot date as "YYYYMMDD".
+ *  @param path Output file path; the format extension is appended if missing.
+ *  @param format Output format: "csv", "json", "jsonl"/"ndjson", or "html".
+ *  @return 0 on success, -1 on error (check thetadatadx_last_error()). */
+int thetadatadx_market_data_flatfile_request_to_path(
+    const ThetaDataDxMarketDataClient* handle,
+    const char* sec_type,
+    const char* req_type,
+    const char* date,
+    const char* path,
+    const char* format);
+
 #ifdef __cplusplus
 }
 #endif

--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -906,6 +906,8 @@ private:
 /// (`ThetaDataDxMarketDataClient*`), freed automatically on destruction. The recommended
 /// entry point for pure-market-data access; the generated market-data query
 /// methods are mixed in from `market_data.hpp.inc`.
+class FlatFiles;
+
 class MarketDataClient {
 public:
     /** Connect a market-data client to ThetaData servers.
@@ -937,6 +939,17 @@ public:
      *  `Client` lifecycle. Idempotent: a second call is a no-op and the
      *  destructor after `close` frees nothing. */
     void close() { handle_.reset(); }
+
+    /** Flat-file namespace view for this market-data client.
+     *
+     *  Flat files are account-authenticated market data, so the standalone
+     *  market-data client reaches the identical surface as the unified
+     *  `Client::flat_files()`. The returned `FlatFiles` value co-owns this
+     *  client's handle (`shared_ptr`), so it stays valid even if this client is
+     *  closed or destroyed while the view (or an in-flight call on it) is still
+     *  alive — hence plain `const`, safe on a temporary. Defined out-of-line
+     *  below once `FlatFiles` is complete. */
+    FlatFiles flat_files() const;
 
     #include "market_data.hpp.inc"
 
@@ -1354,8 +1367,12 @@ private:
     std::unique_ptr<ThetaDataDxFlatFileRowList, FlatFileRowListDeleter> handle_;
 };
 
-/// Namespace handle exposing the FLATFILES surface for a connected
-/// unified client. Cheap to construct — borrows the parent handle.
+/// Namespace handle exposing the FLATFILES surface for a connected client
+/// (unified or standalone market-data). Cheap to construct — it shares
+/// ownership of the parent's handle via `shared_ptr`, so the view stays valid
+/// even if the originating client is closed or destroyed while the view (or an
+/// in-flight call on it) is still alive. The handle is freed only once the last
+/// owner — the client or any live `FlatFiles` — drops.
 class FlatFiles {
 public:
     /// Generic dispatcher. `sec_type` is "OPTION" / "STOCK" / "INDEX";
@@ -1366,8 +1383,14 @@ public:
     FlatFileRowList request(const std::string& sec_type,
                             const std::string& req_type,
                             const std::string& date) const {
-        ThetaDataDxFlatFileRowList* h = thetadatadx_flatfile_request_decoded(
-            handle_, sec_type.c_str(), req_type.c_str(), date.c_str());
+        // One view type serves both clients: the market-data handle takes the
+        // `thetadatadx_market_data_*` entry, the unified handle the plain one.
+        ThetaDataDxFlatFileRowList* h =
+            md_handle_ != nullptr
+                ? thetadatadx_market_data_flatfile_request_decoded(
+                      md_handle_.get(), sec_type.c_str(), req_type.c_str(), date.c_str())
+                : thetadatadx_flatfile_request_decoded(
+                      handle_.get(), sec_type.c_str(), req_type.c_str(), date.c_str());
         if (h == nullptr) {
             detail::throw_last_ffi_error();
         }
@@ -1402,9 +1425,14 @@ public:
                  const std::string& date,
                  const std::string& path,
                  const std::string& format = "csv") const {
-        int rc = thetadatadx_flatfile_request_to_path(
-            handle_, sec_type.c_str(), req_type.c_str(),
-            date.c_str(), path.c_str(), format.c_str());
+        int rc =
+            md_handle_ != nullptr
+                ? thetadatadx_market_data_flatfile_request_to_path(
+                      md_handle_.get(), sec_type.c_str(), req_type.c_str(),
+                      date.c_str(), path.c_str(), format.c_str())
+                : thetadatadx_flatfile_request_to_path(
+                      handle_.get(), sec_type.c_str(), req_type.c_str(),
+                      date.c_str(), path.c_str(), format.c_str());
         if (rc != 0) {
             detail::throw_last_ffi_error();
         }
@@ -1412,9 +1440,25 @@ public:
 
 private:
     friend class Client;
-    explicit FlatFiles(const ThetaDataDxClient* h) : handle_(h) {}
-    const ThetaDataDxClient* handle_;
+    friend class MarketDataClient;
+    // Exactly one handle is non-null: the unified client sets `handle_`, the
+    // standalone market-data client sets `md_handle_`. Both reach the same
+    // account-authenticated flat-file distribution. The view co-owns the
+    // handle (`shared_ptr`), so closing or destroying the originating client
+    // cannot free a handle a live view still dispatches through.
+    explicit FlatFiles(std::shared_ptr<const ThetaDataDxClient> h)
+        : handle_(std::move(h)) {}
+    explicit FlatFiles(std::shared_ptr<const ThetaDataDxMarketDataClient> h)
+        : md_handle_(std::move(h)) {}
+    std::shared_ptr<const ThetaDataDxClient> handle_;
+    std::shared_ptr<const ThetaDataDxMarketDataClient> md_handle_;
 };
+
+/// Out-of-line: `FlatFiles` is now a complete type, so the market-data
+/// client's accessor can return it by value co-owning the client's handle.
+inline FlatFiles MarketDataClient::flat_files() const {
+    return FlatFiles(handle_);
+}
 
 /// `unique_ptr` deleter that releases a `ThetaDataDxClient*` via `thetadatadx_client_free`.
 struct UnifiedDeleter {
@@ -2243,15 +2287,15 @@ public:
         return *this;
     }
 
-    /// Namespace handle for the FLATFILES surface. Cheap — borrows the
-    /// underlying C ABI handle, so the returned `FlatFiles` value borrows
-    /// `*this` and must not outlive it.
+    /// Namespace handle for the FLATFILES surface. Cheap — the returned
+    /// `FlatFiles` value co-owns the underlying C ABI handle (`shared_ptr`),
+    /// so it stays valid even if this client is closed or destroyed while the
+    /// view (or an in-flight call on it) is still alive.
     ///
-    /// Lvalue-only: the accessor is ref-qualified to `const&`, so calling
-    /// it on a temporary is a compile error. Bind the client to a variable
-    /// first (`auto& c = ...; auto ff = c.flat_files();`); the view then
-    /// cannot outlive its client.
-    FlatFiles flat_files() const& { return FlatFiles(handle_.get()); }
+    /// Plain `const` (not ref-qualified): safe on a temporary, since the view
+    /// keeps the handle alive on its own — the same ownership contract as
+    /// `market_data()`.
+    FlatFiles flat_files() const { return FlatFiles(handle_); }
 
     /// Market-data sub-namespace: `client.market_data().stock_history_eod(...)`.
     ///

--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -1448,13 +1448,13 @@ private:
     // cannot free a handle a live view still dispatches through.
     //
     // Unlike the streaming views, `FlatFiles` co-owns ONLY the handle, not the
-    // client's `CallbackState`. That is sound: the "last-handle-holder must
-    // also pin the callback" rule exists so a holder that keeps the event
-    // consumer firing past `close()` cannot outlive the callback storage. Flat
-    // files spawn no async work — every call is a synchronous `block_on`, and a
-    // `FlatFiles` outliving a streaming client only defers the raw handle free
-    // to a point already past `close()`'s consumer drain, touching no freed
-    // callback state. The market-data handle carries no callback at all.
+    // client's callback state. That is sound: the "last-handle-holder must also
+    // pin the callback" rule exists so a holder that keeps the event consumer
+    // firing past `close()` cannot outlive the callback storage. A flat-file
+    // call completes synchronously before it returns and starts no background
+    // delivery, so a `FlatFiles` outliving a streaming client only defers the
+    // handle release to a point already past `close()`'s consumer drain,
+    // touching no freed callback state. The market-data handle has no callback.
     explicit FlatFiles(std::shared_ptr<const ThetaDataDxClient> h)
         : handle_(std::move(h)) {}
     explicit FlatFiles(std::shared_ptr<const ThetaDataDxMarketDataClient> h)

--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -1446,6 +1446,15 @@ private:
     // account-authenticated flat-file distribution. The view co-owns the
     // handle (`shared_ptr`), so closing or destroying the originating client
     // cannot free a handle a live view still dispatches through.
+    //
+    // Unlike the streaming views, `FlatFiles` co-owns ONLY the handle, not the
+    // client's `CallbackState`. That is sound: the "last-handle-holder must
+    // also pin the callback" rule exists so a holder that keeps the event
+    // consumer firing past `close()` cannot outlive the callback storage. Flat
+    // files spawn no async work — every call is a synchronous `block_on`, and a
+    // `FlatFiles` outliving a streaming client only defers the raw handle free
+    // to a point already past `close()`'s consumer drain, touching no freed
+    // callback state. The market-data handle carries no callback at all.
     explicit FlatFiles(std::shared_ptr<const ThetaDataDxClient> h)
         : handle_(std::move(h)) {}
     explicit FlatFiles(std::shared_ptr<const ThetaDataDxMarketDataClient> h)

--- a/thetadatadx-cpp/tests/thetadatadx_client.cpp
+++ b/thetadatadx-cpp/tests/thetadatadx_client.cpp
@@ -182,14 +182,14 @@ TEST_CASE("Stream binds the full FPSS surface",
         decltype(std::declval<const thetadatadx::Client&>().market_data()),
         thetadatadx::MarketData>);
 
-    // View accessor binding contract. `stream()` (`&`) and `flat_files()`
-    // (`const&`) hand out non-owning views that borrow the client's handle,
-    // so they stay ref-qualified to reject a temporary `Client`. `market_data()`
-    // is NOT ref-qualified (plain `const`): the `MarketData` view it returns
-    // co-owns the handle by `shared_ptr`, so it (and any `<endpoint>_async`
-    // future launched from it) keeps the handle alive on its own and may
-    // safely outlive a temporary `Client`. These assertions pin those binding
-    // rules.
+    // View accessor binding contract. `stream()` (`&`) hands out a non-owning
+    // view that borrows the client's handle, so it stays ref-qualified to
+    // reject a temporary `Client`. `market_data()` and `flat_files()` are NOT
+    // ref-qualified (plain `const`): the views they return co-own the handle by
+    // `shared_ptr`, so they (and any `<endpoint>_async` future launched from a
+    // `MarketData` view) keep the handle alive on their own and may safely
+    // outlive a temporary — or an explicitly closed — `Client`. These
+    // assertions pin those binding rules.
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::stream), thetadatadx::Client&>);
     // `stream()` is `&`-qualified (non-const lvalue ref), so it rejects an
@@ -200,23 +200,23 @@ TEST_CASE("Stream binds the full FPSS surface",
         decltype(&thetadatadx::Client::market_data), const thetadatadx::Client&>);
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::flat_files), const thetadatadx::Client&>);
-    // `market_data()` is plain `const` (not ref-qualified), so it binds to an
-    // rvalue `Client` in every standard — the co-owning view it returns is
-    // sound on a temporary.
+    // `market_data()` and `flat_files()` are plain `const` (not ref-qualified),
+    // so they bind to an rvalue `Client` in every standard — the co-owning
+    // views they return are sound on a temporary.
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::market_data), thetadatadx::Client&&>);
-    // `flat_files()` is `const&`-qualified. C++17 treats `is_invocable` of a
-    // `const&` member on an rvalue as false (the rvalue is rejected), but
-    // C++20 (LWG-resolved) treats it as true — an rvalue binds to a const
-    // lvalue ref. The runtime borrow contract (the flat-files view must not
-    // outlive the client) is unchanged; only the trait's answer differs by
-    // standard, so this rvalue assertion is gated to C++17. The C++ SDK builds
-    // C++17 by default; the `THETADATADX_CPP_ARROW` reader links arrow-cpp,
-    // which mandates C++20.
-#if __cplusplus < 202002L
-    STATIC_REQUIRE_FALSE(std::is_invocable_v<
+    STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::flat_files), thetadatadx::Client&&>);
-#endif
+
+    // The standalone market-data client mirrors the unified accessor: flat
+    // files are account-authenticated market data, so `MarketDataClient` hands
+    // out the same plain-`const`, co-owning `flat_files()` view. Pins that the
+    // market-data-only surface reaches flat files identically and is sound on a
+    // temporary.
+    STATIC_REQUIRE(std::is_invocable_v<
+        decltype(&thetadatadx::MarketDataClient::flat_files), const thetadatadx::MarketDataClient&>);
+    STATIC_REQUIRE(std::is_invocable_v<
+        decltype(&thetadatadx::MarketDataClient::flat_files), thetadatadx::MarketDataClient&&>);
 
     // set_callback
     STATIC_REQUIRE(std::is_invocable_v<decltype(&SV::set_callback), SV&, Cb>);

--- a/thetadatadx-ffi/Cargo.toml
+++ b/thetadatadx-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-ffi/src/flatfiles.rs
+++ b/thetadatadx-ffi/src/flatfiles.rs
@@ -24,6 +24,7 @@ use thetadatadx::flatfiles::{self, FlatFileFormat, FlatFileRow, ReqType, SecType
 use crate::error::{cstr_to_str, set_error, set_error_from};
 use crate::runtime;
 use crate::streaming::ThetaDataDxClient;
+use crate::types::ThetaDataDxMarketDataClient;
 
 // ── Heap-owned row-list handle ─────────────────────────────────────────
 
@@ -119,9 +120,53 @@ unsafe fn parse_fmt(raw: *const c_char) -> Result<FlatFileFormat, String> {
 
 // ── FFI entry points ───────────────────────────────────────────────────
 
-/// Pull a decoded flat-file blob for `(sec_type, req_type, date)` and
-/// return an opaque row-list handle. Returns null on error; check
-/// `thetadatadx_last_error()` for details.
+/// Parse the shared `(sec_type, req_type, date)` request arguments. On any
+/// parse fault it sets the thread-local FFI error and returns `None`; the
+/// caller then returns its own null / `-1` sentinel. `date` is returned
+/// owned so the borrow of the raw pointer does not outlive this call.
+///
+/// # Safety
+/// Each pointer must be a NUL-terminated C string the caller pins for the
+/// call duration (or null for `date`, rejected here).
+unsafe fn parse_ff_args(
+    sec_type: *const c_char,
+    req_type: *const c_char,
+    date: *const c_char,
+) -> Option<(SecType, ReqType, String)> {
+    // SAFETY: `sec_type` is a caller-pinned NUL-terminated C string; `parse_sec` validates non-null + UTF-8 before reading.
+    let sec = match unsafe { parse_sec(sec_type) } {
+        Ok(v) => v,
+        Err(e) => {
+            set_error(&e);
+            return None;
+        }
+    };
+    // SAFETY: `req_type` is a caller-pinned NUL-terminated C string; `parse_req` validates non-null + UTF-8 before reading.
+    let req = match unsafe { parse_req(req_type) } {
+        Ok(v) => v,
+        Err(e) => {
+            set_error(&e);
+            return None;
+        }
+    };
+    // SAFETY: `date` is a caller-pinned NUL-terminated C string; `cstr_to_str` validates non-null + UTF-8 before reading.
+    let date = match unsafe { cstr_to_str(date) } {
+        Ok(Some(s)) => s.to_owned(),
+        Ok(None) => {
+            set_error("date is null");
+            return None;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
+            return None;
+        }
+    };
+    Some((sec, req, date))
+}
+
+/// Pull a decoded flat-file blob for `(sec_type, req_type, date)` from the
+/// unified client and return an opaque row-list handle. Returns null on
+/// error; check `thetadatadx_last_error()` for details.
 ///
 /// The returned handle MUST be freed with `thetadatadx_flatfile_rowlist_free`.
 #[no_mangle]
@@ -136,45 +181,59 @@ pub unsafe extern "C" fn thetadatadx_flatfile_request_decoded(
             set_error("unified handle is null");
             return ptr::null_mut();
         }
-        // SAFETY: `sec_type` is a NUL-terminated C string the caller pins for the call duration; `parse_sec` forwards to `cstr_to_str`, which validates non-null + UTF-8 before reading.
-        let sec = match unsafe { parse_sec(sec_type) } {
-            Ok(v) => v,
-            Err(e) => {
-                set_error(&e);
-                return ptr::null_mut();
-            }
-        };
-        // SAFETY: `req_type` is a NUL-terminated C string the caller pins for the call duration; `parse_req` validates non-null + UTF-8 before reading.
-        let req = match unsafe { parse_req(req_type) } {
-            Ok(v) => v,
-            Err(e) => {
-                set_error(&e);
-                return ptr::null_mut();
-            }
-        };
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let date_str = match unsafe { cstr_to_str(date) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("date is null");
-                return ptr::null_mut();
-            }
-            Err(e) => {
-                set_error(&format!("date is not valid UTF-8: {e}"));
-                return ptr::null_mut();
-            }
+        // SAFETY: request-arg pointers are caller-pinned NUL-terminated C strings.
+        let Some((sec, req, date)) = (unsafe { parse_ff_args(sec_type, req_type, date) }) else {
+            return ptr::null_mut();
         };
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let unified = unsafe { &*handle };
-        let res = runtime().block_on(unified.inner.flatfile_request_decoded(sec, req, date_str));
-        match res {
-            Ok(rows) => Box::into_raw(Box::new(ThetaDataDxFlatFileRowList { rows })),
-            Err(e) => {
-                set_error_from(&e);
-                ptr::null_mut()
-            }
-        }
+        flatfile_rowlist_or_null(
+            runtime().block_on(unified.inner.flatfile_request_decoded(sec, req, &date)),
+        )
     })
+}
+
+/// Pull a decoded flat-file blob from a standalone [`ThetaDataDxMarketDataClient`].
+/// Flat files are account-authenticated market data, so the market-data
+/// handle exposes the identical surface as the unified client. Returns null
+/// on error; the returned handle MUST be freed with
+/// `thetadatadx_flatfile_rowlist_free`.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_market_data_flatfile_request_decoded(
+    handle: *const ThetaDataDxMarketDataClient,
+    sec_type: *const c_char,
+    req_type: *const c_char,
+    date: *const c_char,
+) -> *mut ThetaDataDxFlatFileRowList {
+    ffi_boundary!(ptr::null_mut(), {
+        if handle.is_null() {
+            set_error("market-data handle is null");
+            return ptr::null_mut();
+        }
+        // SAFETY: request-arg pointers are caller-pinned NUL-terminated C strings.
+        let Some((sec, req, date)) = (unsafe { parse_ff_args(sec_type, req_type, date) }) else {
+            return ptr::null_mut();
+        };
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let mdc = unsafe { &*handle };
+        flatfile_rowlist_or_null(
+            runtime().block_on(mdc.inner.flatfile_request_decoded(sec, req, &date)),
+        )
+    })
+}
+
+/// Box a decoded row vector into an opaque row-list handle, or set the FFI
+/// error and return null.
+fn flatfile_rowlist_or_null(
+    res: Result<Vec<FlatFileRow>, thetadatadx::Error>,
+) -> *mut ThetaDataDxFlatFileRowList {
+    match res {
+        Ok(rows) => Box::into_raw(Box::new(ThetaDataDxFlatFileRowList { rows })),
+        Err(e) => {
+            set_error_from(&e);
+            ptr::null_mut()
+        }
+    }
 }
 
 /// Number of rows in a row-list handle. Returns 0 if the handle is null.
@@ -287,10 +346,45 @@ pub unsafe extern "C" fn thetadatadx_flatfile_rowlist_free(
     })
 }
 
-/// Pull a flat-file blob and write the requested vendor format
-/// (`csv` / `json` / `jsonl` / `ndjson` / `html`) directly to `path`.
-/// Skips the typed-row decode step. Returns 0 on success, -1 on error;
-/// check `thetadatadx_last_error()`.
+/// Parse the `to_path`-only trailing args (`format`, `path`) shared by the
+/// unified and market-data write paths. On any parse fault it sets the FFI
+/// error and returns `None`. `path` is returned owned so the borrow of the
+/// raw pointer does not outlive this call.
+///
+/// # Safety
+/// `format` is a NUL-terminated C string or null (the `csv` default);
+/// `path` is a caller-pinned NUL-terminated C string.
+unsafe fn parse_ff_write_args(
+    format: *const c_char,
+    path: *const c_char,
+) -> Option<(FlatFileFormat, String)> {
+    // SAFETY: `format` is validated (UTF-8, or null → csv) by `parse_fmt`.
+    let fmt = match unsafe { parse_fmt(format) } {
+        Ok(v) => v,
+        Err(e) => {
+            set_error(&e);
+            return None;
+        }
+    };
+    // SAFETY: `path` is a caller-pinned NUL-terminated C string; `cstr_to_str` validates non-null + UTF-8 before reading.
+    let path = match unsafe { cstr_to_str(path) } {
+        Ok(Some(s)) => s.to_owned(),
+        Ok(None) => {
+            set_error("path is null");
+            return None;
+        }
+        Err(e) => {
+            set_error(&format!("path is not valid UTF-8: {e}"));
+            return None;
+        }
+    };
+    Some((fmt, path))
+}
+
+/// Pull a flat-file blob from the unified client and write the requested
+/// vendor format (`csv` / `json` / `jsonl` / `ndjson` / `html`) directly to
+/// `path`. Skips the typed-row decode step. Returns 0 on success, -1 on
+/// error; check `thetadatadx_last_error()`.
 #[no_mangle]
 pub unsafe extern "C" fn thetadatadx_flatfile_request_to_path(
     handle: *const ThetaDataDxClient,
@@ -305,68 +399,72 @@ pub unsafe extern "C" fn thetadatadx_flatfile_request_to_path(
             set_error("unified handle is null");
             return -1;
         }
-        // SAFETY: `sec_type` is a NUL-terminated C string the caller pins for the call duration; `parse_sec` validates non-null + UTF-8 before reading.
-        let sec = match unsafe { parse_sec(sec_type) } {
-            Ok(v) => v,
-            Err(e) => {
-                set_error(&e);
-                return -1;
-            }
+        // SAFETY: request-arg pointers are caller-pinned NUL-terminated C strings.
+        let Some((sec, req, date)) = (unsafe { parse_ff_args(sec_type, req_type, date) }) else {
+            return -1;
         };
-        // SAFETY: `req_type` is a NUL-terminated C string the caller pins for the call duration; `parse_req` validates non-null + UTF-8 before reading.
-        let req = match unsafe { parse_req(req_type) } {
-            Ok(v) => v,
-            Err(e) => {
-                set_error(&e);
-                return -1;
-            }
-        };
-        // SAFETY: `format` is a NUL-terminated C string (or null for the `csv` default) the caller pins for the call duration; `parse_fmt` validates UTF-8 before reading.
-        let fmt = match unsafe { parse_fmt(format) } {
-            Ok(v) => v,
-            Err(e) => {
-                set_error(&e);
-                return -1;
-            }
-        };
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let date_str = match unsafe { cstr_to_str(date) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("date is null");
-                return -1;
-            }
-            Err(e) => {
-                set_error(&format!("date is not valid UTF-8: {e}"));
-                return -1;
-            }
-        };
-        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
-        let path_str = match unsafe { cstr_to_str(path) } {
-            Ok(Some(s)) => s,
-            Ok(None) => {
-                set_error("path is null");
-                return -1;
-            }
-            Err(e) => {
-                set_error(&format!("path is not valid UTF-8: {e}"));
-                return -1;
-            }
+        // SAFETY: `format` / `path` are caller-pinned (format may be null → csv).
+        let Some((fmt, path)) = (unsafe { parse_ff_write_args(format, path) }) else {
+            return -1;
         };
         // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
         let unified = unsafe { &*handle };
-        match runtime().block_on(unified.inner.flatfile_request(
+        flatfile_write_rc(runtime().block_on(unified.inner.flatfile_request(
             sec,
             req,
-            date_str,
-            std::path::Path::new(path_str),
+            &date,
+            std::path::Path::new(&path),
             fmt,
-        )) {
-            Ok(_) => 0,
-            Err(e) => {
-                set_error_from(&e);
-                -1
-            }
-        }
+        )))
     })
+}
+
+/// Pull a flat-file blob from a standalone [`ThetaDataDxMarketDataClient`] and
+/// write it to `path`. Identical surface to the unified write path — flat
+/// files are account-authenticated market data. Returns 0 on success, -1 on
+/// error; check `thetadatadx_last_error()`.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_market_data_flatfile_request_to_path(
+    handle: *const ThetaDataDxMarketDataClient,
+    sec_type: *const c_char,
+    req_type: *const c_char,
+    date: *const c_char,
+    path: *const c_char,
+    format: *const c_char,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if handle.is_null() {
+            set_error("market-data handle is null");
+            return -1;
+        }
+        // SAFETY: request-arg pointers are caller-pinned NUL-terminated C strings.
+        let Some((sec, req, date)) = (unsafe { parse_ff_args(sec_type, req_type, date) }) else {
+            return -1;
+        };
+        // SAFETY: `format` / `path` are caller-pinned (format may be null → csv).
+        let Some((fmt, path)) = (unsafe { parse_ff_write_args(format, path) }) else {
+            return -1;
+        };
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let mdc = unsafe { &*handle };
+        flatfile_write_rc(runtime().block_on(mdc.inner.flatfile_request(
+            sec,
+            req,
+            &date,
+            std::path::Path::new(&path),
+            fmt,
+        )))
+    })
+}
+
+/// Map a flat-file write result to the C return code (0 / -1), setting the
+/// FFI error on failure.
+fn flatfile_write_rc(res: Result<std::path::PathBuf, thetadatadx::Error>) -> i32 {
+    match res {
+        Ok(_) => 0,
+        Err(e) => {
+            set_error_from(&e);
+            -1
+        }
+    }
 }

--- a/thetadatadx-py/Cargo.lock
+++ b/thetadatadx-py/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "disruptor",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/thetadatadx-py/Cargo.toml
+++ b/thetadatadx-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-py/src/flatfile_methods.rs
+++ b/thetadatadx-py/src/flatfile_methods.rs
@@ -326,7 +326,7 @@ impl crate::Client {
     /// `flat_files = client.flat_files` in user code is identical to
     /// calling `client.flat_files.option_eod(...)` inline.
     #[getter]
-    fn flat_files(&self) -> PyResult<FlatFilesNamespace> {
+    pub(crate) fn flat_files(&self) -> PyResult<FlatFilesNamespace> {
         Ok(FlatFilesNamespace {
             client: self.client_arc()?,
         })

--- a/thetadatadx-py/src/mdds_client.rs
+++ b/thetadatadx-py/src/mdds_client.rs
@@ -40,6 +40,7 @@
 use pyo3::exceptions::PyAttributeError;
 use pyo3::prelude::*;
 
+use crate::flatfile_methods::FlatFilesNamespace;
 use crate::{Client, Config, Credentials};
 
 /// Methods on the `client.stream` [`crate::StreamView`] surface (plus
@@ -244,6 +245,17 @@ impl MarketDataClient {
         // is always connected by construction (the constructor errored
         // out otherwise).
         "MarketDataClient(connected)".to_string()
+    }
+
+    /// Flat-file namespace handle. Flat files are account-authenticated
+    /// market data with no streaming leg, so the market-data-only client
+    /// reaches the identical surface as the unified client. An explicit
+    /// accessor (rather than the `__getattr__` forward) so the cross-binding
+    /// parity contract can pin it statically. Forwards to the wrapped unified
+    /// client's `flat_files` namespace.
+    #[getter]
+    fn flat_files(&self, py: Python<'_>) -> PyResult<FlatFilesNamespace> {
+        self.inner.borrow(py).flat_files()
     }
 
     /// Deterministically close the market-data client.

--- a/thetadatadx-rs/Cargo.toml
+++ b/thetadatadx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/thetadatadx-rs/README.md
+++ b/thetadatadx-rs/README.md
@@ -27,13 +27,13 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx-rs = "0.1.0"
+thetadatadx-rs = "0.1.1"
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx-rs = { version = "0.1.0", features = ["polars"] }
+thetadatadx-rs = { version = "0.1.1", features = ["polars"] }
 ```
 
 ## Quick start

--- a/thetadatadx-rs/src/client.rs
+++ b/thetadatadx-rs/src/client.rs
@@ -2203,7 +2203,11 @@ impl FlatFiles<'_> {
         date: &str,
     ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
         crate::flatfiles::flatfile_request_decoded_with_config(
-            self.creds, sec_type, req_type, date, self.config,
+            self.creds,
+            sec_type,
+            req_type,
+            date,
+            self.config,
         )
         .await
     }

--- a/thetadatadx-rs/src/client.rs
+++ b/thetadatadx-rs/src/client.rs
@@ -2165,30 +2165,49 @@ impl Client {
     /// ```
     #[must_use]
     pub fn flat_files(&self) -> FlatFiles<'_> {
-        FlatFiles(self)
+        FlatFiles {
+            creds: &self.creds,
+            config: &self.flatfiles_config,
+        }
     }
 }
 
-/// Borrowed view exposing the unified [`Client`]'s flat-files surface.
+/// Borrowed view exposing a client's flat-files surface.
 ///
-/// Returned by [`Client::flat_files`]. Holds a shared borrow of the
-/// client and forwards every call onto the same credentials and
-/// flat-files retry config the unified client owns — no duplicated state,
-/// no behavior change. Each method delegates to the matching inherent
-/// [`Client`] flat-file method, which in turn drives the
-/// `crate::flatfiles::*_with_config` engine. The view is `Copy`; take it
-/// per call site rather than storing it.
+/// Returned by [`Client::flat_files`] and
+/// [`crate::MarketDataClient::flat_files`]. Holds a shared borrow of the
+/// credentials and flat-files retry config the owning client carries — no
+/// duplicated state, no behavior change. Each method drives the
+/// `crate::flatfiles::*_with_config` engine directly, so both clients reach
+/// the identical flat-file distribution over the legacy MDDS port. The view
+/// is `Copy`; take it per call site rather than storing it.
 ///
 /// This is the Rust counterpart of the `FlatFiles` / `FlatFilesNamespace`
 /// handle on the Python, TypeScript, and C++ bindings: the method set
 /// (`option_trade_quote`, `option_open_interest`, `option_eod`,
 /// `stock_trade_quote`, `stock_eod`, the generic `request`,
 /// and `to_path`) mirrors them exactly, so flat files are reached the same
-/// way from every binding.
+/// way from every binding and from either client.
 #[derive(Clone, Copy)]
-pub struct FlatFiles<'a>(&'a Client);
+pub struct FlatFiles<'a> {
+    pub(crate) creds: &'a Credentials,
+    pub(crate) config: &'a crate::config::FlatFilesConfig,
+}
 
 impl FlatFiles<'_> {
+    /// Shared decode leg: pull and decode any served pair for `date`.
+    async fn decoded(
+        &self,
+        sec_type: crate::flatfiles::SecType,
+        req_type: crate::flatfiles::ReqType,
+        date: &str,
+    ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
+        crate::flatfiles::flatfile_request_decoded_with_config(
+            self.creds, sec_type, req_type, date, self.config,
+        )
+        .await
+    }
+
     /// Decoded option trade-quote flat file for `date` (`YYYYMMDD`).
     ///
     /// # Errors
@@ -2199,13 +2218,12 @@ impl FlatFiles<'_> {
         &self,
         date: &str,
     ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(
-                crate::flatfiles::SecType::Option,
-                crate::flatfiles::ReqType::TradeQuote,
-                date,
-            )
-            .await
+        self.decoded(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::TradeQuote,
+            date,
+        )
+        .await
     }
 
     /// Decoded option open-interest flat file for `date` (`YYYYMMDD`).
@@ -2217,13 +2235,12 @@ impl FlatFiles<'_> {
         &self,
         date: &str,
     ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(
-                crate::flatfiles::SecType::Option,
-                crate::flatfiles::ReqType::OpenInterest,
-                date,
-            )
-            .await
+        self.decoded(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::OpenInterest,
+            date,
+        )
+        .await
     }
 
     /// Decoded option end-of-day flat file for `date` (`YYYYMMDD`).
@@ -2235,13 +2252,12 @@ impl FlatFiles<'_> {
         &self,
         date: &str,
     ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(
-                crate::flatfiles::SecType::Option,
-                crate::flatfiles::ReqType::Eod,
-                date,
-            )
-            .await
+        self.decoded(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::Eod,
+            date,
+        )
+        .await
     }
 
     /// Decoded stock trade-quote flat file for `date` (`YYYYMMDD`).
@@ -2253,13 +2269,12 @@ impl FlatFiles<'_> {
         &self,
         date: &str,
     ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(
-                crate::flatfiles::SecType::Stock,
-                crate::flatfiles::ReqType::TradeQuote,
-                date,
-            )
-            .await
+        self.decoded(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::TradeQuote,
+            date,
+        )
+        .await
     }
 
     /// Decoded stock end-of-day flat file for `date` (`YYYYMMDD`).
@@ -2268,13 +2283,12 @@ impl FlatFiles<'_> {
     ///
     /// Same conditions as [`Self::option_trade_quote`].
     pub async fn stock_eod(&self, date: &str) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(
-                crate::flatfiles::SecType::Stock,
-                crate::flatfiles::ReqType::Eod,
-                date,
-            )
-            .await
+        self.decoded(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::Eod,
+            date,
+        )
+        .await
     }
 
     /// Generic dispatcher — pull and decode any served `(sec_type,
@@ -2295,9 +2309,7 @@ impl FlatFiles<'_> {
         req_type: crate::flatfiles::ReqType,
         date: &str,
     ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
-        self.0
-            .flatfile_request_decoded(sec_type, req_type, date)
-            .await
+        self.decoded(sec_type, req_type, date).await
     }
 
     /// Pull a flat-file blob for `(sec_type, req_type, date)` and write
@@ -2323,9 +2335,16 @@ impl FlatFiles<'_> {
         output_path: impl AsRef<std::path::Path>,
         format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
-        self.0
-            .flatfile_request(sec_type, req_type, date, output_path, format)
-            .await
+        crate::flatfiles::flatfile_request_with_config(
+            self.creds,
+            sec_type,
+            req_type,
+            date,
+            output_path,
+            format,
+            self.config,
+        )
+        .await
     }
 }
 

--- a/thetadatadx-rs/src/mdds/client.rs
+++ b/thetadatadx-rs/src/mdds/client.rs
@@ -17,12 +17,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::auth::{self, Credentials, SessionToken};
-use crate::FlatFiles;
 use crate::config::DirectConfig;
 use crate::error::Error;
 use crate::grpc::{Channel, ChannelPool, ChannelTuning};
 use crate::mdds::tier::SubscriptionTier;
 use crate::proto;
+use crate::FlatFiles;
 
 /// Version string sent in `QueryInfo.terminal_version`.
 const TERMINAL_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/thetadatadx-rs/src/mdds/client.rs
+++ b/thetadatadx-rs/src/mdds/client.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::auth::{self, Credentials, SessionToken};
+use crate::FlatFiles;
 use crate::config::DirectConfig;
 use crate::error::Error;
 use crate::grpc::{Channel, ChannelPool, ChannelTuning};
@@ -373,8 +374,8 @@ impl MarketDataClient {
     ///
     /// Cheap borrowed handle; take it per call site rather than storing it.
     #[must_use]
-    pub fn flat_files(&self) -> crate::FlatFiles<'_> {
-        crate::FlatFiles {
+    pub fn flat_files(&self) -> FlatFiles<'_> {
+        FlatFiles {
             creds: &self.creds,
             config: &self.config.flatfiles,
         }

--- a/thetadatadx-rs/src/mdds/client.rs
+++ b/thetadatadx-rs/src/mdds/client.rs
@@ -82,6 +82,12 @@ pub struct MarketDataClient {
     options_tier: Option<SubscriptionTier>,
     indices_tier: Option<SubscriptionTier>,
     interest_rate_tier: Option<SubscriptionTier>,
+    /// Credentials retained for the flat-file surface. Flat files open a
+    /// fresh, self-authenticating connection to the legacy MDDS port per
+    /// call (independent of the gRPC channel pool above), so `flat_files()`
+    /// needs the account credentials directly. Mirrors the unified
+    /// [`crate::Client`], which carries the same field for the same reason.
+    creds: Credentials,
 }
 
 // ── Infrastructure (not generated — these are session/transport methods, not ThetaData endpoints) ──
@@ -201,6 +207,7 @@ impl MarketDataClient {
             options_tier,
             indices_tier,
             interest_rate_tier,
+            creds: creds.clone(),
         })
     }
 
@@ -330,7 +337,7 @@ impl MarketDataClient {
             "00000000-0000-0000-0000-000000000000".to_string(),
             config.auth.nexus_url.clone(),
             config.market_data_environment,
-            creds,
+            creds.clone(),
         );
         let mut query_parameters = HashMap::new();
         query_parameters.insert("client".to_string(), "terminal".to_string());
@@ -346,7 +353,164 @@ impl MarketDataClient {
             options_tier: None,
             indices_tier: None,
             interest_rate_tier: None,
+            creds,
         }
+    }
+}
+
+// ── Flat files (bulk per-day distribution over the legacy MDDS port) ──
+//
+// Flat files are pure account-authenticated market data, so they belong on
+// the market-data surface. Each call opens a fresh, self-authenticating
+// connection to the legacy MDDS port (independent of this client's gRPC
+// channel pool) and needs only the credentials and flat-files retry config
+// this client already holds. The surface mirrors the unified
+// [`crate::Client`] method-for-method — every entry routes through the same
+// [`crate::FlatFiles`] view — so a standalone `MarketDataClient` reaches
+// flat files exactly like the unified handle and like every language binding.
+impl MarketDataClient {
+    /// Flat-file namespace view: `client.flat_files().stock_eod("20240115").await?`.
+    ///
+    /// Cheap borrowed handle; take it per call site rather than storing it.
+    #[must_use]
+    pub fn flat_files(&self) -> crate::FlatFiles<'_> {
+        crate::FlatFiles {
+            creds: &self.creds,
+            config: &self.config.flatfiles,
+        }
+    }
+
+    /// Pull a flat-file blob for `(sec_type, req_type, date)`, decode it, and
+    /// write the requested `format` to disk. Mirror of
+    /// [`crate::Client::flatfile_request`].
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_request(
+        &self,
+        sec_type: crate::flatfiles::SecType,
+        req_type: crate::flatfiles::ReqType,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flat_files()
+            .to_path(sec_type, req_type, date, output_path, format)
+            .await
+    }
+
+    /// Pull a flat-file blob and return decoded rows in memory. Mirror of
+    /// [`crate::Client::flatfile_request_decoded`].
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_request_decoded(
+        &self,
+        sec_type: crate::flatfiles::SecType,
+        req_type: crate::flatfiles::ReqType,
+        date: &str,
+    ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
+        self.flat_files().request(sec_type, req_type, date).await
+    }
+
+    /// Convenience: option open-interest flat file for `date`, written to disk.
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_option_open_interest(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::OpenInterest,
+            date,
+            output_path,
+            format,
+        )
+        .await
+    }
+
+    /// Convenience: option trade-quote flat file for `date`, written to disk.
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_option_trade_quote(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::TradeQuote,
+            date,
+            output_path,
+            format,
+        )
+        .await
+    }
+
+    /// Convenience: option end-of-day flat file for `date`, written to disk.
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_option_eod(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::Eod,
+            date,
+            output_path,
+            format,
+        )
+        .await
+    }
+
+    /// Convenience: stock trade-quote flat file for `date`, written to disk.
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_stock_trade_quote(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::TradeQuote,
+            date,
+            output_path,
+            format,
+        )
+        .await
+    }
+
+    /// Convenience: stock end-of-day flat file for `date`, written to disk.
+    ///
+    /// # Errors
+    /// Same conditions as [`crate::Client::flatfile_request`].
+    pub async fn flatfile_stock_eod(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::Eod,
+            date,
+            output_path,
+            format,
+        )
+        .await
     }
 }
 
@@ -568,6 +732,22 @@ mod pool_size_tests {
             session_created: None,
         };
         assert_eq!(effective_pool_size(&auth), 4);
+    }
+}
+
+#[cfg(test)]
+mod flat_files_surface_tests {
+    use super::MarketDataClient;
+
+    /// Compile-time: the standalone market-data client carries the flat-file
+    /// surface, mirroring the unified [`crate::Client`]. Referencing the fn
+    /// items proves the accessor and decode entry exist with the expected
+    /// receiver and return type; nothing is invoked, so no connection opens.
+    #[test]
+    fn market_data_client_exposes_flat_files() {
+        let _accessor: for<'a> fn(&'a MarketDataClient) -> crate::FlatFiles<'a> =
+            MarketDataClient::flat_files;
+        let _decoded = MarketDataClient::flatfile_request_decoded;
     }
 }
 

--- a/thetadatadx-ts/Cargo.lock
+++ b/thetadatadx-ts/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/thetadatadx-ts/Cargo.toml
+++ b/thetadatadx-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/thetadatadx-ts/npm/darwin-arm64/package.json
+++ b/thetadatadx-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-ts-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "os": [
     "darwin"
   ],

--- a/thetadatadx-ts/npm/linux-x64-gnu/package.json
+++ b/thetadatadx-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-ts-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "os": [
     "linux"
   ],

--- a/thetadatadx-ts/npm/win32-x64-msvc/package.json
+++ b/thetadatadx-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-ts-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "os": [
     "win32"
   ],

--- a/thetadatadx-ts/package.json
+++ b/thetadatadx-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-ts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -33,9 +33,9 @@
     "typescript": "6.0.3"
   },
   "optionalDependencies": {
-    "thetadatadx-ts-darwin-arm64": "0.1.0",
-    "thetadatadx-ts-linux-x64-gnu": "0.1.0",
-    "thetadatadx-ts-win32-x64-msvc": "0.1.0"
+    "thetadatadx-ts-darwin-arm64": "0.1.1",
+    "thetadatadx-ts-linux-x64-gnu": "0.1.1",
+    "thetadatadx-ts-win32-x64-msvc": "0.1.1"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "sonic-rs",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/npm/darwin-arm64/package.json
+++ b/tools/mcp/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-server-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "thetadatadx-mcp-server prebuilt server binary for darwin-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/darwin-x64/package.json
+++ b/tools/mcp/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-server-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "thetadatadx-mcp-server prebuilt server binary for darwin-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-arm64/package.json
+++ b/tools/mcp/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-server-linux-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "thetadatadx-mcp-server prebuilt server binary for linux-arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/linux-x64/package.json
+++ b/tools/mcp/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-server-linux-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "thetadatadx-mcp-server prebuilt server binary for linux-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/mcp/npm/thetadatadx-mcp-server/package.json
+++ b/tools/mcp/npm/thetadatadx-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for ThetaData market data — run it with `npx -y thetadatadx-mcp-server`, no Rust toolchain required",
   "license": "Apache-2.0",
   "repository": {
@@ -14,11 +14,11 @@
     "bin/cli.js"
   ],
   "optionalDependencies": {
-    "thetadatadx-mcp-server-linux-x64": "0.1.0",
-    "thetadatadx-mcp-server-linux-arm64": "0.1.0",
-    "thetadatadx-mcp-server-darwin-x64": "0.1.0",
-    "thetadatadx-mcp-server-darwin-arm64": "0.1.0",
-    "thetadatadx-mcp-server-win32-x64": "0.1.0"
+    "thetadatadx-mcp-server-linux-x64": "0.1.1",
+    "thetadatadx-mcp-server-linux-arm64": "0.1.1",
+    "thetadatadx-mcp-server-darwin-x64": "0.1.1",
+    "thetadatadx-mcp-server-darwin-arm64": "0.1.1",
+    "thetadatadx-mcp-server-win32-x64": "0.1.1"
   },
   "engines": {
     "node": ">= 18"

--- a/tools/mcp/npm/win32-x64/package.json
+++ b/tools/mcp/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-mcp-server-win32-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "thetadatadx-mcp-server prebuilt server binary for win32-x64",
   "license": "Apache-2.0",
   "repository": {

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
The standalone MarketDataClient now exposes the full flat-file surface, matching the unified Client method-for-method on every binding. Flat files are account-authenticated market data with no streaming leg, so they belong on the market-data handle; a market-data-only workflow no longer needs the unified client to pull whole-universe per-day distributions.

Rust: the FlatFiles view borrows (&Credentials, &FlatFilesConfig) instead of &Client, so both the unified Client and mdds::MarketDataClient build it from their own state through one engine. C++ adds two FFI entry points on the market-data handle and a MarketDataClient::flat_files() accessor; Python and TypeScript reach the surface through their unified-backed handles, now enrolled in the machine-checked parity contract.

Also hardens the C++ FlatFiles view to co-own its client handle via shared_ptr instead of borrowing a raw pointer, so a view stays valid if the originating client is closed or destroyed while a call on it is in flight. The accessor is now plain const, matching the market_data() view.

Ships as 0.1.1.