### PR TITLE
docs(fpss): describe flush_mode as outbound-only, not a data-latency tradeoff

### DIFF
--- a/docs-site/docs/articles/configuration.md
+++ b/docs-site/docs/articles/configuration.md
@@ -95,7 +95,7 @@ In Rust the same fields live on `DirectConfig` struct sub-configs (`config.retry
 | Request deadlines | `timeout_ms` per request (builder / kwarg) | Hard per-call deadline; expiry raises a timeout error and frees the slot. |
 | Retries | `retry_initial_delay_ms`, `retry_max_delay_ms`, `retry_max_attempts`, `retry_jitter`, `retry_max_elapsed_secs` | Backoff schedule for transient market-data-request faults. |
 | Streaming reconnect | `reconnect_policy`, `reconnect_max_attempts`, `reconnect_wait_ms`, `reconnect_wait_max_ms`, `reconnect_jitter`, `reconnect_stable_window_secs`, … | Automatic streaming reconnection. See [Reconnection & Monitoring](/streaming/reliability). |
-| Streaming latency | `flush_mode` (`"batched"` default / `"immediate"`), `streaming_ring_size`, `streaming_timeout_ms`, keepalive fields | Write-path flush behavior and event-buffer capacity. |
+| Streaming write path & buffering | `flush_mode` (`"batched"` default / `"immediate"`), `streaming_ring_size`, `streaming_timeout_ms`, keepalive fields | `flush_mode` flushes **outbound** control frames (subscribe / ping) and does not affect received-data latency; `streaming_ring_size` is the inbound event-buffer capacity. |
 | Flat files | `flatfiles_max_attempts`, `flatfiles_initial_backoff_secs`, `flatfiles_max_backoff_secs`, `flatfiles_jitter` | Retry budget for bulk downloads. |
 | Observability | `metrics_port` | Optional local Prometheus exporter port (off by default). |
 | Runtime | `worker_threads` | Async worker-thread count for embedded bindings (0 = auto). |

--- a/docs-site/docs/streaming/reliability.md
+++ b/docs-site/docs/streaming/reliability.md
@@ -52,7 +52,7 @@ Caller-driven recovery is always available: `reconnect()` re-opens the session a
 
 | Mode | Behavior |
 |---|---|
-| `"batched"` (default) | Outbound frames coalesce and flush on the heartbeat cadence (~100 ms), so a subscription burst goes out as fewer, larger packets — gentler on the server, fewer syscalls. Received data is unaffected. |
+| `"batched"` (default) | Outbound frames coalesce and flush on the heartbeat cadence (~250 ms), so a subscription burst goes out as fewer, larger packets — gentler on the server, fewer syscalls. Received data is unaffected. |
 | `"immediate"` | Every outbound frame flushes as written, so a subscribe / unsubscribe reaches the server at once — at the cost of one syscall per frame. |
 
 ```python

--- a/docs-site/docs/streaming/reliability.md
+++ b/docs-site/docs/streaming/reliability.md
@@ -48,12 +48,12 @@ Caller-driven recovery is always available: `reconnect()` re-opens the session a
 
 ## Flush mode
 
-`flush_mode` trades write-path latency against syscall volume:
+`flush_mode` controls how the client flushes its **outbound** writes — subscribe, unsubscribe, and heartbeat pings. It does not touch the inbound path: received trades, quotes, and OHLCVC are dispatched continuously either way, so it never adds latency to the data you receive.
 
 | Mode | Behavior |
 |---|---|
-| `"batched"` (default) | Outbound frames flush on the heartbeat cadence — the throughput-friendly default. |
-| `"immediate"` | Every frame flushes as written — lowest latency. |
+| `"batched"` (default) | Outbound frames coalesce and flush on the heartbeat cadence (~100 ms), so a subscription burst goes out as fewer, larger packets — gentler on the server, fewer syscalls. Received data is unaffected. |
+| `"immediate"` | Every outbound frame flushes as written, so a subscribe / unsubscribe reaches the server at once — at the cost of one syscall per frame. |
 
 ```python
 cfg = Config.production()

--- a/docs-site/docs/streaming/reliability.md
+++ b/docs-site/docs/streaming/reliability.md
@@ -52,7 +52,7 @@ Caller-driven recovery is always available: `reconnect()` re-opens the session a
 
 | Mode | Behavior |
 |---|---|
-| `"batched"` (default) | Outbound frames coalesce and flush on the heartbeat cadence (~250 ms), so a subscription burst goes out as fewer, larger packets — gentler on the server, fewer syscalls. Received data is unaffected. |
+| `"batched"` (default) | Outbound frames coalesce and flush on the PING heartbeat (the `ping_interval_ms` cadence, ~250 ms by default), so a subscription burst goes out as fewer, larger packets — gentler on the server, fewer syscalls. Received data is unaffected. |
 | `"immediate"` | Every outbound frame flushes as written, so a subscribe / unsubscribe reaches the server at once — at the cost of one syscall per frame. |
 
 ```python

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -1927,7 +1927,7 @@ int32_t thetadatadx_config_get_metrics_port(const ThetaDataDxConfig* config, boo
 
 /**
  * Set streaming flush mode on a config handle.
- *   mode=0: Batched (default) -- flush only on PING every 100ms.
+ *   mode=0: Batched (default) -- flush only on PING (the ping_interval_ms heartbeat, 250 ms by default).
  *   mode=1: Immediate -- flush after every frame write.
  * @param config Config handle to mutate.
  * @param mode Flush mode selector (0 = Batched, 1 = Immediate).

--- a/thetadatadx-ffi/src/config_accessors.rs
+++ b/thetadatadx-ffi/src/config_accessors.rs
@@ -1461,7 +1461,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_market_data_host(
 
 /// Set streaming flush mode on a config handle.
 ///
-/// - `mode = 0`: Batched (default) -- flush only on PING every 250ms
+/// - `mode = 0`: Batched (default) -- flush only on PING (the `ping_interval_ms` heartbeat, 250 ms by default)
 /// - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
 ///
 /// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when

--- a/thetadatadx-ffi/src/config_accessors.rs
+++ b/thetadatadx-ffi/src/config_accessors.rs
@@ -1461,7 +1461,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_market_data_host(
 
 /// Set streaming flush mode on a config handle.
 ///
-/// - `mode = 0`: Batched (default) -- flush only on PING every 100ms
+/// - `mode = 0`: Batched (default) -- flush only on PING every 250ms
 /// - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
 ///
 /// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -284,7 +284,7 @@ class Config:
     streaming_host_shuffle_seed: Optional[int]
     """Seed for the per-client streaming host shuffle; ``None`` draws a fresh seed each connect."""
     flush_mode: Literal["batched", "immediate"]
-    """Streaming write-flush policy. ``"batched"`` (default) flushes on the heartbeat (~100 ms); ``"immediate"`` flushes after every wire write. The setter accepts the same two strings case-insensitively and raises ``ValueError`` otherwise."""
+    """Streaming write-flush policy. ``"batched"`` (default) flushes on the PING heartbeat (the ``ping_interval_ms`` cadence, ~250 ms by default); ``"immediate"`` flushes after every wire write. The setter accepts the same two strings case-insensitively and raises ``ValueError`` otherwise."""
     @property
     def market_data_environment(self) -> Literal["PROD", "STAGE"]:
         """Target market-data environment carried by this configuration: ``"PROD"`` for the production cluster or ``"STAGE"`` for staging. The market-data and streaming channels are selected independently; :meth:`Config.production` / :meth:`Config.stage` (and the ``THETADATA_MARKET_DATA_TYPE`` key on :meth:`Config.from_dotenv`) set the market-data channel, and this is the readback of that selection. Read-only: the selector is chosen by the environment-tier factories, not assigned directly. Mirrors the ``market_data_type`` string the inline :class:`Client` constructor accepts."""

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -639,7 +639,7 @@ impl Config {
     /// inbound trades and quotes are dispatched continuously either way.
     ///
     /// ``"batched"`` (default) coalesces outbound frames and flushes on the
-    /// PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+    /// PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
     /// larger packets — gentler on the server, fewer syscalls. ``"immediate"``
     /// flushes after every write, so a subscribe reaches the server at once,
     /// at a higher per-frame syscall cost.

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -634,12 +634,15 @@ impl Config {
         guard.market_data_host().to_string()
     }
 
-    /// Set the streaming write-flush policy.
+    /// Set the flush policy for **outbound** streaming writes (subscribe /
+    /// unsubscribe / ping). This does not affect received-data latency:
+    /// inbound trades and quotes are dispatched continuously either way.
     ///
-    /// Accepts ``"batched"`` (default, flushes on the PING heartbeat,
-    /// roughly every 100 ms — best throughput) or ``"immediate"``
-    /// (flushes after every wire write — lowest latency, higher
-    /// per-frame syscall cost).
+    /// ``"batched"`` (default) coalesces outbound frames and flushes on the
+    /// PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+    /// larger packets — gentler on the server, fewer syscalls. ``"immediate"``
+    /// flushes after every write, so a subscribe reaches the server at once,
+    /// at a higher per-frame syscall cost.
     #[setter]
     fn set_flush_mode(&self, mode: &str) -> PyResult<()> {
         let mode = mode.to_ascii_lowercase();

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -639,7 +639,7 @@ impl Config {
     /// inbound trades and quotes are dispatched continuously either way.
     ///
     /// ``"batched"`` (default) coalesces outbound frames and flushes on the
-    /// PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
+    /// PING heartbeat (the `ping_interval_ms` cadence, ~250 ms by default), so a subscription burst goes out as fewer,
     /// larger packets — gentler on the server, fewer syscalls. ``"immediate"``
     /// flushes after every write, so a subscribe reaches the server at once,
     /// at a higher per-frame syscall cost.

--- a/thetadatadx-rs/config.default.toml
+++ b/thetadatadx-rs/config.default.toml
@@ -38,8 +38,9 @@ connect_timeout = 2000
 # Read timeout — how long to wait for data before the link is considered
 # dead (ms). Matches the terminal's streaming socket read timeout and rides
 # through the brief silence right after a full-market subscribe while the
-# server sets the subscription up. The ~100 ms cadence is the client's ping
-# to the server, not an inbound heartbeat; inbound frames arrive ~250 ms.
+# server sets the subscription up. The client's outbound ping runs on
+# ping_interval (250 ms default), not an inbound heartbeat; inbound frames
+# arrive continuously on an active session.
 read_timeout = 10000
 
 # Client outbound ping interval (ms). This ping proves write-side health at a

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -2014,20 +2014,26 @@ handle), routing through the typed leaf the FFI error code
 selects.
 """
 py_doc = """
-Set the streaming write-flush policy.
+Set the flush policy for **outbound** streaming writes (subscribe /
+unsubscribe / ping). This does not affect received-data latency:
+inbound trades and quotes are dispatched continuously either way.
 
-Accepts ``"batched"`` (default, flushes on the PING heartbeat,
-roughly every 100 ms — best throughput) or ``"immediate"``
-(flushes after every wire write — lowest latency, higher
-per-frame syscall cost).
+``"batched"`` (default) coalesces outbound frames and flushes on the
+PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+larger packets — gentler on the server, fewer syscalls. ``"immediate"``
+flushes after every write, so a subscribe reaches the server at once,
+at a higher per-frame syscall cost.
 """
 ts_doc = """
-Set the streaming write-flush policy.
+Set the flush policy for **outbound** streaming writes (subscribe /
+unsubscribe / ping). This does not affect received-data latency:
+inbound trades and quotes are dispatched continuously either way.
 
-Accepts `"batched"` (default — flushes on the PING heartbeat,
-roughly every 100 ms — best throughput) or `"immediate"`
-(flushes after every wire write — lowest latency, higher
-per-frame syscall cost).
+`"batched"` (default) coalesces outbound frames and flushes on the
+PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+larger packets — gentler on the server, fewer syscalls. `"immediate"`
+flushes after every write, so a subscribe reaches the server at once,
+at a higher per-frame syscall cost.
 """
 py_param = "mode"
 ts_param = "mode"

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -1996,7 +1996,7 @@ ts_err = 'setFlushMode: mode must be "batched" or "immediate"; got {mode:?}'
 doc = """
 Set streaming flush mode on a config handle.
 
-- `mode = 0`: Batched (default) -- flush only on PING every 250ms
+- `mode = 0`: Batched (default) -- flush only on PING (the `ping_interval_ms` heartbeat, 250 ms by default)
 - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
 
 Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
@@ -2019,7 +2019,7 @@ unsubscribe / ping). This does not affect received-data latency:
 inbound trades and quotes are dispatched continuously either way.
 
 ``"batched"`` (default) coalesces outbound frames and flushes on the
-PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
+PING heartbeat (the `ping_interval_ms` cadence, ~250 ms by default), so a subscription burst goes out as fewer,
 larger packets — gentler on the server, fewer syscalls. ``"immediate"``
 flushes after every write, so a subscribe reaches the server at once,
 at a higher per-frame syscall cost.
@@ -2030,7 +2030,7 @@ unsubscribe / ping). This does not affect received-data latency:
 inbound trades and quotes are dispatched continuously either way.
 
 `"batched"` (default) coalesces outbound frames and flushes on the
-PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
+PING heartbeat (the `ping_interval_ms` cadence, ~250 ms by default), so a subscription burst goes out as fewer,
 larger packets — gentler on the server, fewer syscalls. `"immediate"`
 flushes after every write, so a subscribe reaches the server at once,
 at a higher per-frame syscall cost.

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -1996,7 +1996,7 @@ ts_err = 'setFlushMode: mode must be "batched" or "immediate"; got {mode:?}'
 doc = """
 Set streaming flush mode on a config handle.
 
-- `mode = 0`: Batched (default) -- flush only on PING every 100ms
+- `mode = 0`: Batched (default) -- flush only on PING every 250ms
 - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
 
 Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
@@ -2019,7 +2019,7 @@ unsubscribe / ping). This does not affect received-data latency:
 inbound trades and quotes are dispatched continuously either way.
 
 ``"batched"`` (default) coalesces outbound frames and flushes on the
-PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
 larger packets — gentler on the server, fewer syscalls. ``"immediate"``
 flushes after every write, so a subscribe reaches the server at once,
 at a higher per-frame syscall cost.
@@ -2030,7 +2030,7 @@ unsubscribe / ping). This does not affect received-data latency:
 inbound trades and quotes are dispatched continuously either way.
 
 `"batched"` (default) coalesces outbound frames and flushes on the
-PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
 larger packets — gentler on the server, fewer syscalls. `"immediate"`
 flushes after every write, so a subscribe reaches the server at once,
 at a higher per-frame syscall cost.

--- a/thetadatadx-rs/src/config/fpss.rs
+++ b/thetadatadx-rs/src/config/fpss.rs
@@ -12,7 +12,7 @@
 #[non_exhaustive]
 pub enum StreamingFlushMode {
     /// Coalesce outbound frames and flush them on the heartbeat cadence (one
-    /// ping interval, 100 ms by default). A burst of subscriptions goes out as
+    /// ping interval, 250 ms by default). A burst of subscriptions goes out as
     /// fewer, larger TCP segments instead of one flush per frame — gentler on
     /// the server and lower syscall overhead. The only cost is up to one ping
     /// interval before a subscribe / unsubscribe reaches the server; received
@@ -153,10 +153,10 @@ pub struct StreamingConfig {
     /// frames, no pings) for a few seconds while it sets the
     /// subscription up; a 10 s deadline rides through that gap where a
     /// shorter one trips inside it and forces an unnecessary reconnect.
-    /// The ~100 ms cadence is the client's ping to the server, not an
-    /// inbound heartbeat; inbound frames and pings arrive roughly every
-    /// ~250 ms on an active session. Validated to the range
-    /// `[100, 60_000]` ms.
+    /// The ping is the client's outbound heartbeat to the server (one
+    /// `ping_interval_ms`, ~250 ms by default), not an inbound signal;
+    /// inbound frames arrive continuously on an active session. Validated
+    /// to the range `[100, 60_000]` ms.
     pub timeout_ms: u64,
 
     /// Streaming event ring buffer size (slots).

--- a/thetadatadx-rs/src/config/fpss.rs
+++ b/thetadatadx-rs/src/config/fpss.rs
@@ -1,14 +1,27 @@
 //! Streaming (TCP) sub-configuration.
 
-/// Controls when the streaming write buffer is flushed.
+/// Controls when the client's **outbound** streaming write buffer is
+/// flushed to the server.
+///
+/// This governs only the frames the client *sends* — subscribe, unsubscribe,
+/// and heartbeat pings. It has no effect on the inbound market-data path:
+/// received trades, quotes, and OHLCVC are read off the socket and dispatched
+/// continuously regardless of this setting, so it never adds latency to the
+/// data you receive.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum StreamingFlushMode {
-    /// Flush only on PING frames. Lower syscall overhead, up to one
-    /// ping interval of additional latency.
+    /// Coalesce outbound frames and flush them on the heartbeat cadence (one
+    /// ping interval, 100 ms by default). A burst of subscriptions goes out as
+    /// fewer, larger TCP segments instead of one flush per frame — gentler on
+    /// the server and lower syscall overhead. The only cost is up to one ping
+    /// interval before a subscribe / unsubscribe reaches the server; received
+    /// market data is unaffected.
     #[default]
     Batched,
-    /// Flush after every frame write. Lowest latency, higher syscall overhead.
+    /// Flush every outbound frame as it is written, so a subscribe /
+    /// unsubscribe reaches the server immediately — at the cost of one syscall
+    /// per frame.
     Immediate,
 }
 

--- a/thetadatadx-rs/src/fpss/io_loop/mod.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/mod.rs
@@ -1051,6 +1051,14 @@ where
                 }
 
                 // --- Phase 2: Drain command channel (non-blocking) ---
+                //
+                // These are OUTBOUND control frames (subscribe / unsubscribe /
+                // ping) — never market data. In `Batched` mode a non-ping frame
+                // is buffered (`no_flush`) and rides out on the next ping's
+                // flush, coalescing a subscription burst into fewer, larger TCP
+                // segments (gentler on the server, fewer syscalls). `Immediate`
+                // flushes each frame so a subscribe reaches the server at once.
+                // The inbound read path (Phase 1) is unaffected either way.
                 loop {
                     match cmd_rx.try_recv() {
                         Ok(IoCommand::WriteFrame { code, payload }) => {

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -571,7 +571,7 @@ export declare class Config {
    * inbound trades and quotes are dispatched continuously either way.
    *
    * `"batched"` (default) coalesces outbound frames and flushes on the
-   * PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
+   * PING heartbeat (the `ping_interval_ms` cadence, ~250 ms by default), so a subscription burst goes out as fewer,
    * larger packets — gentler on the server, fewer syscalls. `"immediate"`
    * flushes after every write, so a subscribe reaches the server at once,
    * at a higher per-frame syscall cost.

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -566,12 +566,15 @@ export declare class Config {
   /** Current market-data gRPC host. */
   get marketDataHost(): string
   /**
-   * Set the streaming write-flush policy.
+   * Set the flush policy for **outbound** streaming writes (subscribe /
+   * unsubscribe / ping). This does not affect received-data latency:
+   * inbound trades and quotes are dispatched continuously either way.
    *
-   * Accepts `"batched"` (default — flushes on the PING heartbeat,
-   * roughly every 100 ms — best throughput) or `"immediate"`
-   * (flushes after every wire write — lowest latency, higher
-   * per-frame syscall cost).
+   * `"batched"` (default) coalesces outbound frames and flushes on the
+   * PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+   * larger packets — gentler on the server, fewer syscalls. `"immediate"`
+   * flushes after every write, so a subscribe reaches the server at once,
+   * at a higher per-frame syscall cost.
    */
   setFlushMode(mode: string): void
   /**

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -571,7 +571,7 @@ export declare class Config {
    * inbound trades and quotes are dispatched continuously either way.
    *
    * `"batched"` (default) coalesces outbound frames and flushes on the
-   * PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+   * PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
    * larger packets — gentler on the server, fewer syscalls. `"immediate"`
    * flushes after every write, so a subscribe reaches the server at once,
    * at a higher per-frame syscall cost.

--- a/thetadatadx-ts/index.js
+++ b/thetadatadx-ts/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-android-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-ts-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-ts-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-ts-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-ts-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-ts-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-ts-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-ts-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-ts-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-ts-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-ts-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-ts-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-ts-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-ts-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -919,12 +919,15 @@ impl Config {
         Ok(guard.market_data_host().to_string())
     }
 
-    /// Set the streaming write-flush policy.
+    /// Set the flush policy for **outbound** streaming writes (subscribe /
+    /// unsubscribe / ping). This does not affect received-data latency:
+    /// inbound trades and quotes are dispatched continuously either way.
     ///
-    /// Accepts `"batched"` (default — flushes on the PING heartbeat,
-    /// roughly every 100 ms — best throughput) or `"immediate"`
-    /// (flushes after every wire write — lowest latency, higher
-    /// per-frame syscall cost).
+    /// `"batched"` (default) coalesces outbound frames and flushes on the
+    /// PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+    /// larger packets — gentler on the server, fewer syscalls. `"immediate"`
+    /// flushes after every write, so a subscribe reaches the server at once,
+    /// at a higher per-frame syscall cost.
     #[napi(js_name = "setFlushMode")]
     pub fn set_flush_mode(&self, mode: String) -> napi::Result<()> {
         let mode = mode.to_ascii_lowercase();

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -924,7 +924,7 @@ impl Config {
     /// inbound trades and quotes are dispatched continuously either way.
     ///
     /// `"batched"` (default) coalesces outbound frames and flushes on the
-    /// PING heartbeat (~100 ms), so a subscription burst goes out as fewer,
+    /// PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
     /// larger packets — gentler on the server, fewer syscalls. `"immediate"`
     /// flushes after every write, so a subscribe reaches the server at once,
     /// at a higher per-frame syscall cost.

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -924,7 +924,7 @@ impl Config {
     /// inbound trades and quotes are dispatched continuously either way.
     ///
     /// `"batched"` (default) coalesces outbound frames and flushes on the
-    /// PING heartbeat (~250 ms), so a subscription burst goes out as fewer,
+    /// PING heartbeat (the `ping_interval_ms` cadence, ~250 ms by default), so a subscription burst goes out as fewer,
     /// larger packets — gentler on the server, fewer syscalls. `"immediate"`
     /// flushes after every write, so a subscribe reaches the server at once,
     /// at a higher per-frame syscall cost.


### PR DESCRIPTION
flush_mode was framed as a "write-path latency vs syscall volume" tradeoff, which reads as if the default Batched mode delays received market data. It does not.

The setting gates only the client's **outbound** control frames — subscribe, unsubscribe, and heartbeat pings — at the two `IoCommand::WriteFrame` sites in the io_loop. The inbound read path dispatches trades, quotes, and OHLCVC continuously regardless of the mode, so flush_mode never adds latency to received data.

Batched (default) coalesces outbound frames and flushes them on the ping cadence (~100ms), so a subscription burst goes out as fewer, larger TCP segments — gentler on the server, fewer syscalls. Immediate flushes each frame so a subscribe reaches the server at once. Received-data latency is identical either way; the default stays Batched because coalescing outbound writes is the server-friendly choice.

Corrects the `StreamingFlushMode` enum doc, the io_loop flush-site comment, the Python/TypeScript setter docstrings (via `config_surface.toml` + regenerated accessors), and the streaming / configuration docs pages. Docs and comments only — no behavior change.