### PR TITLE
fix(python): route snapshot endpoints through the normal request path (drop the 5s cap)

### DIFF
--- a/thetadatadx-py/src/_generated/market_data_methods.rs
+++ b/thetadatadx-py/src/_generated/market_data_methods.rs
@@ -15276,7 +15276,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         ohlc_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -15368,7 +15368,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         trade_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -15459,7 +15459,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         quote_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -15550,7 +15550,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         market_value_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -16865,7 +16865,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         ohlc_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -16980,7 +16980,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         trade_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -17095,7 +17095,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         quote_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -17216,7 +17216,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         open_interest_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -17336,7 +17336,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         market_value_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -17483,7 +17483,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         iv_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -17664,7 +17664,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         greeks_all_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -17844,7 +17844,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         greeks_first_order_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -18024,7 +18024,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         greeks_second_order_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -18204,7 +18204,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         greeks_third_order_ticks_vec_to_pylist(py, ticks)
     }
 
@@ -21882,7 +21882,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         ohlc_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -21956,7 +21956,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         price_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -22030,7 +22030,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         market_value_ticks_to_pyclass_list(py, ticks)
     }
 
@@ -22484,7 +22484,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         calendar_days_vec_to_pylist(py, ticks)
     }
 
@@ -22547,7 +22547,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         calendar_days_vec_to_pylist(py, ticks)
     }
 
@@ -22614,7 +22614,7 @@ impl MarketDataView {
         if let Some(ms) = timeout_ms {
             request = request.with_deadline(std::time::Duration::from_millis(ms));
         }
-        let ticks = run_blocking_snapshot(py, async move { request.await })?;
+        let ticks = run_blocking(py, async move { request.await })?;
         calendar_days_vec_to_pylist(py, ticks)
     }
 

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -127,40 +127,6 @@ where
     })
 }
 
-/// Snapshot-endpoint fast path — runs a future under the runtime
-/// inside `py.detach` with a bounded `tokio::time::timeout`, skipping the
-/// `run_blocking` signal-check polling loop entirely.
-///
-/// Snapshot-kind endpoints (`stock_snapshot_*`, `option_snapshot_*`,
-/// `index_snapshot_*`, `calendar_*`) complete in under 200 ms on every
-/// observed production call; the 5-second upper bound is a liveness
-/// safeguard that adds zero steady-state cost. Dropping the `tokio::select!`
-/// ticker removes the +1-5 ms first-tick-jitter tax on 90-100 ms calls.
-///
-/// Ctrl+C during a snapshot call is still honoured after the future
-/// resolves or after the 5-second timeout fires, so the interpreter
-/// cannot be wedged indefinitely.
-pub(crate) const SNAPSHOT_UPPER_BOUND: std::time::Duration = std::time::Duration::from_secs(5);
-
-fn run_blocking_snapshot<F, T>(py: Python<'_>, fut: F) -> PyResult<T>
-where
-    F: std::future::Future<Output = Result<T, thetadatadx::Error>> + Send,
-    T: Send,
-{
-    py.detach(|| {
-        // VOCAB-OK: tokio Runtime::block_on in PyO3 bridge, not PyO3 allow_threads GIL-hold pattern
-        runtime().block_on(async move {
-            match tokio::time::timeout(SNAPSHOT_UPPER_BOUND, fut).await {
-                Ok(out) => out.map_err(to_py_err),
-                Err(_) => Err(PyRuntimeError::new_err(format!(
-                    "snapshot endpoint exceeded {} s upper bound",
-                    SNAPSHOT_UPPER_BOUND.as_secs()
-                ))),
-            }
-        })
-    })
-}
-
 // ── Credentials ──
 // Lifecycle: intentionally hand-written (language-specific constructor semantics).
 //

--- a/thetadatadx-rs/build_support_bin/endpoints/sdk_render/python.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/sdk_render/python.rs
@@ -403,13 +403,15 @@ fn render_python_endpoint_sync(endpoint: &GeneratedEndpoint) -> String {
     );
     out.push_str("        }\n");
     if is_snapshot {
-        // Snapshot wait fast-path: bounded-timeout future on the shared
-        // runtime, no signal-check polling ticker. Plain-list snapshots keep
-        // the low-allocation `PyList` materialiser; multi-symbol snapshots use
-        // the typed list wrapper so `ColumnPresence::symbols()` survives to
-        // DataFrame terminals.
+        // Snapshots run through the same interruptible `run_blocking` path as
+        // every other request: the timeout is the request's own deadline
+        // (`timeout_ms`, else the configured request timeout), never a
+        // wrapper-imposed cap. This branch exists only for the return-shape
+        // split: plain-list snapshots keep the low-allocation `PyList`
+        // materialiser; multi-symbol snapshots use the typed list wrapper so
+        // `ColumnPresence::symbols()` survives to DataFrame terminals.
         out.push_str(
-            "        let ticks = run_blocking_snapshot(py, async move { request.await })?;\n",
+            "        let ticks = run_blocking(py, async move { request.await })?;\n",
         );
         if snapshot_plain_list {
             writeln!(

--- a/thetadatadx-rs/build_support_bin/endpoints/sdk_render/python.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/sdk_render/python.rs
@@ -410,9 +410,7 @@ fn render_python_endpoint_sync(endpoint: &GeneratedEndpoint) -> String {
         // split: plain-list snapshots keep the low-allocation `PyList`
         // materialiser; multi-symbol snapshots use the typed list wrapper so
         // `ColumnPresence::symbols()` survives to DataFrame terminals.
-        out.push_str(
-            "        let ticks = run_blocking(py, async move { request.await })?;\n",
-        );
+        out.push_str("        let ticks = run_blocking(py, async move { request.await })?;\n");
         if snapshot_plain_list {
             writeln!(
                 out,


### PR DESCRIPTION
The Python sync snapshot methods wrapped every call in a hardcoded 5 s cap (`run_blocking_snapshot`) that fired before both the caller's `timeout_ms` and the configured request timeout (300 s), making large snapshots (bulk greeks, wide option chains) unusable from the sync API. A user hit this on an SPXW first-order greeks snapshot.

The cap had no parity grounding: the terminal has no request/read/snapshot timeout and runs every request on a single path. So this removes the invented fast path rather than patching it, and emits the normal `run_blocking` for snapshot endpoints — the timeout becomes the request's own deadline (`timeout_ms`, else the configured request timeout) and Ctrl+C stays responsive through the existing signal poll. The one real optimization in that branch (low-allocation plain-list materialiser) is kept.

Net -32 lines, same class of cleanup as #1055 / #1057. Codegen and comments only on the Python surface; TS / C++ / Rust unaffected.

Closes #1189
