### PR TITLE
chore(cleanup): remove invented complexity + fix two docs that overstate the code

### DIFF
--- a/thetadatadx-py/src/chunking.rs
+++ b/thetadatadx-py/src/chunking.rs
@@ -1,17 +1,14 @@
-//! Date-range split math for the 365-day auto-chunk path.
+//! Date-range split math for history requests beyond the 365-day server cap.
 //!
 //! The ThetaData server rejects history ranges exceeding 365 calendar days
-//! with a raw gRPC `InvalidArgument`. A pre-flight split divides the
-//! requested `(start, end)` span into ≤365-day chunks before dispatch so
-//! callers can ask for arbitrary multi-year ranges without hitting the
-//! server-side cap.
+//! with a raw gRPC `InvalidArgument`. `split_date_range` divides a requested
+//! `(start, end)` span into contiguous ≤365-day chunks, so a caller can turn
+//! an arbitrary multi-year range into a series of server-accepted requests
+//! and concatenate the results.
 //!
-//! This module is the pure date-arithmetic layer — no tokio, no
-//! `MarketDataClient`. The fan-out orchestrator (concurrent cell dispatch +
-//! concatenation) lives one layer up and coordinates with the Rust SDK's
-//! request semaphore. The math here is exercised by its own unit tests so
-//! a refactor of the orchestrator can never break the chunk boundary
-//! invariants.
+//! Pure date arithmetic — no tokio, no client. Exposed to Python as
+//! `split_date_range` (re-exported from `lib.rs`). The math carries its own
+//! unit tests.
 //!
 //! # Invariants (tested below)
 //!
@@ -24,12 +21,9 @@
 //!    `Err`, NOT a panic — called from pre-flight code that already
 //!    validated, but the redundant validation is harmless here.
 
-// The `chunking` module backs the auto-chunk fan-out activated once
-// `DirectConfig::auto_chunk` is threaded through `MarketDataClient`. The split
-// math is correctness-critical and self-contained, so it carries its own
-// tests independent of the orchestrator. The split entry point is
-// exported from `lib.rs` so the symbol participates in the public
-// surface and does not trip dead-code lints.
+// `split_date_range` is exported from `lib.rs`, so the symbol participates in
+// the public surface and does not trip dead-code lints. The split math is
+// correctness-critical and self-contained, so it carries its own tests.
 
 /// Failure modes of the date-range split.
 #[derive(Debug, thiserror::Error)]

--- a/thetadatadx-py/src/fluent.rs
+++ b/thetadatadx-py/src/fluent.rs
@@ -346,11 +346,12 @@ impl StrikeArg {
     }
 }
 
-/// Coerce a `Subscription`, `Contract`, or symbol-style string from
-/// Python into a `protocol::Subscription`. Bare strings are accepted
-/// for ergonomics but always interpreted as a stock-quote
-/// subscription — that is the most common shorthand in the existing
-/// compat helpers.
+/// Coerce a Python `Subscription` into a `protocol::Subscription`.
+///
+/// Only a `Subscription` value is accepted; anything else raises a
+/// `TypeError` pointing the caller at the builders that produce one
+/// (`Contract.quote()` / `.trade()` / `.open_interest()`,
+/// `SecType.OPTION.full_trades()`).
 pub(crate) fn coerce_subscription(obj: &Bound<'_, PyAny>) -> PyResult<protocol::Subscription> {
     if let Ok(sub) = obj.extract::<PyRef<PySubscription>>() {
         return Ok(sub.inner.clone());

--- a/thetadatadx-rs/src/fpss/decode.rs
+++ b/thetadatadx-rs/src/fpss/decode.rs
@@ -9,7 +9,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
-use std::time::Instant;
 
 use crate::tdbe::types::enums::StreamMsgType;
 use crate::tdbe::types::price::Price;
@@ -298,9 +297,8 @@ pub fn decode_frame(
     let warn_unknown_contract =
         |contract_id: i32,
          kind: &str,
-         delta_state: &DeltaState,
          cache: &HashMap<i32, Arc<Contract>>| {
-            if !cache.contains_key(&contract_id) && !delta_state.is_in_stop_suppression_window() {
+            if !cache.contains_key(&contract_id) {
                 static MISS_COUNT: AtomicU64 = AtomicU64::new(0);
                 let prev = MISS_COUNT.fetch_add(1, Ordering::Relaxed);
                 if prev.is_multiple_of(1024) {
@@ -371,7 +369,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "quote", delta_state, local_contracts);
+                    warn_unknown_contract(contract_id, "quote", local_contracts);
                     let pt = buf[9];
                     let (Some(bid_f64), Some(ask_f64)) =
                         (strict_fpss_price(buf[3], pt), strict_fpss_price(buf[7], pt))
@@ -414,7 +412,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, TRADE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "trade", delta_state, local_contracts);
+                    warn_unknown_contract(contract_id, "trade", local_contracts);
 
                     // `decode_tick` rejects any row whose width is not exactly
                     // TRADE_FIELDS (the only stream-trade layout; the 16-field
@@ -462,7 +460,6 @@ pub fn decode_frame(
                     warn_unknown_contract(
                         contract_id,
                         "open_interest",
-                        delta_state,
                         local_contracts,
                     );
                     FPSS_OI_EVENTS.increment(1);
@@ -486,7 +483,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OHLCVC_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "ohlcvc", delta_state, local_contracts);
+                    warn_unknown_contract(contract_id, "ohlcvc", local_contracts);
                     let pt = buf[7];
                     let (Some(o), Some(h), Some(l), Some(c)) = (
                         strict_fpss_price(buf[1], pt),
@@ -539,7 +536,6 @@ pub fn decode_frame(
                     warn_unknown_contract(
                         contract_id,
                         "market_value",
-                        delta_state,
                         local_contracts,
                     );
                     let pt = buf[9];
@@ -603,7 +599,6 @@ pub fn decode_frame(
 
         StreamMsgType::Stop => {
             tracing::info!("market close signal received");
-            delta_state.last_stop = Some(Instant::now());
             delta_state.clear();
             local_contracts.clear(); // mirrors idToContract.clear() on the wire
             Some(FpssEventInternal::Control(StreamControl::MarketClose))

--- a/thetadatadx-rs/src/fpss/decode.rs
+++ b/thetadatadx-rs/src/fpss/decode.rs
@@ -295,9 +295,7 @@ pub fn decode_frame(
     // global so the "1 of every 1024" rate aggregates across every
     // StreamingClient in the same process.
     let warn_unknown_contract =
-        |contract_id: i32,
-         kind: &str,
-         cache: &HashMap<i32, Arc<Contract>>| {
+        |contract_id: i32, kind: &str, cache: &HashMap<i32, Arc<Contract>>| {
             if !cache.contains_key(&contract_id) {
                 static MISS_COUNT: AtomicU64 = AtomicU64::new(0);
                 let prev = MISS_COUNT.fetch_add(1, Ordering::Relaxed);
@@ -457,11 +455,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OI_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(
-                        contract_id,
-                        "open_interest",
-                        local_contracts,
-                    );
+                    warn_unknown_contract(contract_id, "open_interest", local_contracts);
                     FPSS_OI_EVENTS.increment(1);
                     Some(FpssEventInternal::Data(StreamData::OpenInterest {
                         contract: resolve_contract(contract_id, local_contracts),
@@ -533,11 +527,7 @@ pub fn decode_frame(
             // bid/ask.
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(
-                        contract_id,
-                        "market_value",
-                        local_contracts,
-                    );
+                    warn_unknown_contract(contract_id, "market_value", local_contracts);
                     let pt = buf[9];
                     // Compute market value on the raw integer bid/ask/sizes,
                     // keeping wire scale, then reassemble to dollars at the

--- a/thetadatadx-rs/src/fpss/delta.rs
+++ b/thetadatadx-rs/src/fpss/delta.rs
@@ -6,7 +6,6 @@
 //! buffer used by [`DeltaState::decode_tick`].
 
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
 
 use crate::tdbe::codec::fit::{apply_deltas, FitReader};
 
@@ -79,15 +78,7 @@ pub struct DeltaState {
     /// unused slots zero-filled, so a stale width can only under-report which
     /// trailing fields a caller reads, never read out of bounds.
     field_counts: HashMap<(u8, i32), usize>,
-    /// Timestamp of last STOP (market close) signal. Used to suppress
-    /// "unknown `contract_id`" warnings for 5 seconds after STOP;
-    /// stale ticks are expected during teardown.
-    pub(super) last_stop: Option<Instant>,
 }
-
-/// Duration after a STOP signal during which "unknown `contract_id`" warnings
-/// are suppressed (stale ticks are expected during market-close teardown).
-const STOP_SUPPRESS_DURATION: Duration = Duration::from_secs(5);
 
 impl DeltaState {
     #[doc(hidden)]
@@ -100,7 +91,6 @@ impl DeltaState {
             alloc_buf: vec![0i32; MAX_DATA_FIELDS + 1],
             last_was_date: false,
             field_counts: HashMap::new(),
-            last_stop: None,
         }
     }
 
@@ -109,20 +99,10 @@ impl DeltaState {
     /// Called on START/STOP (market open/close) signals to reset delta
     /// decompression: the contract-id read starts fresh after a session
     /// boundary.
-    ///
-    /// Note: `last_stop` is intentionally NOT cleared here because STOP
-    /// itself calls `clear()`, and the timestamp must survive to suppress
-    /// stale-tick warnings for 5 seconds after the STOP signal.
     pub fn clear(&mut self) {
         self.prev.clear();
         self.last_was_date = false;
         self.field_counts.clear();
-    }
-
-    /// Whether we are within the post-STOP suppression window.
-    pub(super) fn is_in_stop_suppression_window(&self) -> bool {
-        self.last_stop
-            .is_some_and(|t| t.elapsed() < STOP_SUPPRESS_DURATION)
     }
 
     /// Decode FIT payload and apply delta decompression.

--- a/thetadatadx-ts/src/fpss_client.rs
+++ b/thetadatadx-ts/src/fpss_client.rs
@@ -643,15 +643,6 @@ impl StreamingClient {
         }
     }
 
-    fn stop_streaming_impl(&self) {
-        Self::stop_streaming_slots(
-            Arc::clone(&self.inner),
-            Arc::clone(&self.callback),
-            Arc::clone(&self.dispatcher),
-            Arc::clone(&self.prev_drained),
-        );
-    }
-
     /// Run a closure with a borrow of the live streaming client, rejecting with
     /// a typed napi error when nothing is connected.
     fn with_live<R>(
@@ -1194,7 +1185,12 @@ impl StreamingClient {
     /// Lock ordering: `callback` BEFORE `inner`, matching `startStreaming`.
     #[napi(js_name = "stopStreaming")]
     pub fn stop_streaming(&self) {
-        self.stop_streaming_impl();
+        Self::stop_streaming_slots(
+            Arc::clone(&self.inner),
+            Arc::clone(&self.callback),
+            Arc::clone(&self.dispatcher),
+            Arc::clone(&self.prev_drained),
+        );
     }
 
     /// Alias for `stopStreaming`. Mirrors the unified client's split surface
@@ -1664,18 +1660,6 @@ mod teardown_deadlock_tests {
                 // aborted. This is the exact wait the production dispatcher is
                 // stuck in when teardown runs.
                 depth = self.space.wait(depth).unwrap();
-            }
-        }
-
-        /// Drain one queued call (what the Node main thread does as it services
-        /// the napi `uv_async_t` queue). NOT called during the test's teardown,
-        /// reproducing the main thread being parked in the join.
-        #[allow(dead_code)]
-        fn drain_one(&self) {
-            let mut depth = self.depth.lock().unwrap();
-            if *depth > 0 {
-                *depth -= 1;
-                self.space.notify_one();
             }
         }
 


### PR DESCRIPTION
Small cleanup pass from a repo-wide over-engineering audit. Each item is unused/invented complexity or a doc that describes something the code does not do. No behavior change.

## Removed

- **post-STOP warn-suppression window** (`fpss/delta.rs`, `fpss/decode.rs`). A dedicated `Instant` field, a 5 s `STOP_SUPPRESS_DURATION`, an `is_in_stop_suppression_window()` method, and a "don't clear this in `clear()`" carve-out — all to gate a single diagnostic warn that is already rate-limited to 1-in-1024. The sampler alone bounds close-time log spam; the terminal emits no such warning and has no such window. The `warn_unknown_contract` closure loses its now-unused `delta_state` parameter across its call sites.

- **`stop_streaming_impl`** (`thetadatadx-ts/src/fpss_client.rs`). A one-caller intermediate that only cloned four `Arc`s into `stop_streaming_slots`; inlined into `stop_streaming`. The Python sibling never had this hop.

- **`drain_one` test helper** (`thetadatadx-ts/src/fpss_client.rs`). Dead `#[allow(dead_code)]` scaffolding, never called.

## Docs corrected to match the code

- **`chunking.rs`** described an "auto-chunk fan-out orchestrator" gated on a `DirectConfig::auto_chunk` that does not exist anywhere in the tree. The module is a standalone `split_date_range` helper; the docs now say so.

- **`coerce_subscription`** (`fluent.rs`) claimed it accepts a `Contract` or a bare symbol string "interpreted as a stock-quote subscription". The implementation only accepts a `Subscription` and raises otherwise; the docstring now matches.

net: ~40 lines removed, no public API change (both doc fixes and the TS/internal removals are non-surface).
