### PR TITLE
feat(streaming)!: trim reconnect_jitter to full/none; drop equal + decorrelated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`host_selection` / `host_shuffle_seed` streaming host-ordering knobs.** Removed from every binding (Rust `StreamingConfig::host_selection` / `host_shuffle_seed`, Python `Config.streaming_host_selection` / `streaming_host_shuffle_seed`, TypeScript `Config.streamingHostSelection` / `setStreamingHostSelection` and the shuffle-seed pair, C++ `set_streaming_host_selection` / `get_streaming_host_selection` and the shuffle-seed pair, C ABI `thetadatadx_config_*_streaming_host_selection` / `_host_shuffle_seed`), along with the `HostSelectionPolicy` enum. The client now cycles the declared host list left to right — the terminal's own behavior — and a reconnect tries the last-known-good host first. The per-client fault-domain shuffle and its seed existed only in the SDK, with no terminal counterpart. This is a breaking change to the configuration surface.
 
+- **`reconnect_jitter` trimmed to `"full"` / `"none"`.** The `"equal"` and `"decorrelated"` jitter variants are removed from every binding (the `JitterMode` enum drops them, and the C-ABI integer encoding is now `0 = Full`, `1 = None`). Full jitter — sampling uniformly from `[0, delay]` — stays the default and is the right choice for a recovering fleet; `"none"` (deterministic delays) remains for tests. The two removed variants were unused academic backoff modes with no operational benefit over full jitter. Setting `reconnect_jitter` to `"equal"` or `"decorrelated"` (or the C-ABI codes `1` / `2`) is now rejected. This is a breaking change to the configuration surface.
+
 ## [0.1.1] - 2026-07-07
 
 ### Added

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`host_selection` / `host_shuffle_seed` streaming host-ordering knobs.** Removed from every binding (Rust `StreamingConfig::host_selection` / `host_shuffle_seed`, Python `Config.streaming_host_selection` / `streaming_host_shuffle_seed`, TypeScript `Config.streamingHostSelection` / `setStreamingHostSelection` and the shuffle-seed pair, C++ `set_streaming_host_selection` / `get_streaming_host_selection` and the shuffle-seed pair, C ABI `thetadatadx_config_*_streaming_host_selection` / `_host_shuffle_seed`), along with the `HostSelectionPolicy` enum. The client now cycles the declared host list left to right — the terminal's own behavior — and a reconnect tries the last-known-good host first. The per-client fault-domain shuffle and its seed existed only in the SDK, with no terminal counterpart. This is a breaking change to the configuration surface.
 
+- **`reconnect_jitter` trimmed to `"full"` / `"none"`.** The `"equal"` and `"decorrelated"` jitter variants are removed from every binding (the `JitterMode` enum drops them, and the C-ABI integer encoding is now `0 = Full`, `1 = None`). Full jitter — sampling uniformly from `[0, delay]` — stays the default and is the right choice for a recovering fleet; `"none"` (deterministic delays) remains for tests. The two removed variants were unused academic backoff modes with no operational benefit over full jitter. Setting `reconnect_jitter` to `"equal"` or `"decorrelated"` (or the C-ABI codes `1` / `2`) is now rejected. This is a breaking change to the configuration surface.
+
 ## [0.1.1] - 2026-07-07
 
 ### Added

--- a/docs-site/docs/streaming/reliability.md
+++ b/docs-site/docs/streaming/reliability.md
@@ -27,7 +27,7 @@ All on the [configuration object](/articles/configuration), prefixed `reconnect_
 |---|---|---|
 | `reconnect_policy` | `"auto"` | `"auto"` recovers automatically; `"manual"` never reconnects (you call `reconnect()`); `"custom"` uses your callback. |
 | `reconnect_wait_ms` / `reconnect_wait_max_ms` | 250 / 30000 | Exponential backoff ladder: initial delay and cap. |
-| `reconnect_jitter` | `"full"` | Jitter mode: `"full"`, `"equal"`, `"decorrelated"`, `"none"`. |
+| `reconnect_jitter` | `"full"` | Jitter mode: `"full"`, `"none"`. |
 | `reconnect_max_attempts` | 30 | Attempt budget for transient drops. |
 | `reconnect_max_elapsed_secs` | 300 | Wall-clock cap on one recovery sequence; `0` disables. |
 | `reconnect_wait_rate_limited_ms` / `reconnect_max_rate_limited_attempts` | 130000 / 100 | Floor and budget for rate-limited drops. |

--- a/parity.toml
+++ b/parity.toml
@@ -1960,7 +1960,7 @@ cpp = true
 [method.signature]
 returns = "String"
 cpp_returns = "i32"
-python_pyi_returns = 'Literal["full", "equal", "decorrelated", "none"]'
+python_pyi_returns = 'Literal["full", "none"]'
 
 # Custom reconnect-policy callback registration. A field-shaped getter
 # is meaningless for a callback, so the registration is tracked as a

--- a/thetadatadx-cpp/include/config_accessors.hpp.inc
+++ b/thetadatadx-cpp/include/config_accessors.hpp.inc
@@ -497,8 +497,7 @@
         return s.str();
     }
 
-    /// Set the reconnect jitter mode: 0=Full (default), 1=Equal,
-    /// 2=Decorrelated, 3=None. Throws @c thetadatadx::InvalidParameterError on
+    /// Set the reconnect jitter mode: 0=Full (default), 1=None. Throws @c thetadatadx::InvalidParameterError on
     /// an out-of-domain mode (and @c thetadatadx::ThetaDataError on a null
     /// handle), routing through the typed leaf the FFI error code
     /// selects.

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -1378,11 +1378,9 @@ int32_t thetadatadx_config_get_reconnect_wait_server_restart_ms(const ThetaDataD
 /**
  * Set the jitter strategy applied to every reconnect delay.
  *   mode=0: Full (default) -- sample uniformly from [0, delay].
- *   mode=1: Equal -- delay/2 + uniform(0, delay/2).
- *   mode=2: Decorrelated -- walk relative to the previous delay.
- *   mode=3: None -- deterministic delays (tests only).
+ *   mode=1: None -- deterministic delays (tests only).
  * @param config Config handle to mutate.
- * @param mode Jitter strategy selector (0-3 per the list above).
+ * @param mode Jitter strategy selector (0 = Full, 1 = None).
  * @return 0 on success, -1 on an invalid mode or null config.
  */
 int32_t thetadatadx_config_set_reconnect_jitter(ThetaDataDxConfig* config, int32_t mode);

--- a/thetadatadx-cpp/tests/error_taxonomy.cpp
+++ b/thetadatadx-cpp/tests/error_taxonomy.cpp
@@ -208,7 +208,7 @@ TEST_CASE("config enum setters reject an out-of-domain value with InvalidParamet
     // throw.
     auto cfg = thetadatadx::Config::production();
 
-    REQUIRE_NOTHROW(cfg.set_reconnect_jitter(2));
+    REQUIRE_NOTHROW(cfg.set_reconnect_jitter(1));
     REQUIRE_THROWS_AS(cfg.set_reconnect_jitter(9), thetadatadx::InvalidParameterError);
 
 }

--- a/thetadatadx-ffi/src/auth.rs
+++ b/thetadatadx-ffi/src/auth.rs
@@ -2115,7 +2115,7 @@ mod resilience_knob_tests {
                 0
             );
             assert_eq!(mode, 0, "default jitter mode is Full");
-            for m in [1, 2, 3, 0] {
+            for m in [1, 0] {
                 assert_eq!(super::thetadatadx_config_set_reconnect_jitter(cfg, m), 0);
                 assert_eq!(
                     super::thetadatadx_config_get_reconnect_jitter(cfg, &mut mode),

--- a/thetadatadx-ffi/src/config_accessors.rs
+++ b/thetadatadx-ffi/src/config_accessors.rs
@@ -1462,12 +1462,10 @@ pub unsafe extern "C" fn thetadatadx_config_get_market_data_host(
 /// Set the jitter strategy applied to every reconnect delay.
 ///
 /// - `mode = 0`: Full (default) — sample uniformly from `[0, delay]`.
-/// - `mode = 1`: Equal — `delay/2 + uniform(0, delay/2)`.
-/// - `mode = 2`: Decorrelated — walk relative to the previous delay.
-/// - `mode = 3`: None — deterministic delays (tests only).
+/// - `mode = 1`: None — deterministic delays (tests only).
 ///
 /// Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
-/// `mode` is outside the documented `{0, 1, 2, 3}` set or `config` is
+/// `mode` is outside the documented `{0, 1}` set or `config` is
 /// null. A rejected `mode` value carries
 /// `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
 /// enum int surfaces the same typed class across every binding.
@@ -1483,13 +1481,11 @@ pub unsafe extern "C" fn thetadatadx_config_set_reconnect_jitter(
         }
         let value = match mode {
             0 => thetadatadx::JitterMode::Full,
-            1 => thetadatadx::JitterMode::Equal,
-            2 => thetadatadx::JitterMode::Decorrelated,
-            3 => thetadatadx::JitterMode::None,
+            1 => thetadatadx::JitterMode::None,
             other => {
                 crate::error::set_error_with_code(
                     &format!(
-                        "thetadatadx_config_set_reconnect_jitter: invalid mode {other}; expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
+                        "thetadatadx_config_set_reconnect_jitter: invalid mode {other}; expected 0 (Full) or 1 (None)"
                     ),
                     crate::error::THETADATADX_ERR_INVALID_PARAMETER,
                 );
@@ -1520,10 +1516,8 @@ pub unsafe extern "C" fn thetadatadx_config_get_reconnect_jitter(
         let config = unsafe { &*config };
         let value = match config.inner.reconnect.jitter {
             thetadatadx::JitterMode::Full => 0,
-            thetadatadx::JitterMode::Equal => 1,
-            thetadatadx::JitterMode::Decorrelated => 2,
-            thetadatadx::JitterMode::None => 3,
-            _ => 3,
+            thetadatadx::JitterMode::None => 1,
+            _ => 1,
         };
         // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
         unsafe {

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -225,8 +225,8 @@ class Config:
     """Back-off floor, in milliseconds, applied to the rate-limited (TooManyRequests) failure class (default 130_000)."""
     reconnect_wait_server_restart_ms: int
     """Flat reconnect cadence, in milliseconds, applied to the ServerRestarting failure class (default 5_000)."""
-    reconnect_jitter: Literal["full", "equal", "decorrelated", "none"]
-    """Jitter strategy applied to every reconnect delay: ``"full"`` (default), ``"equal"``, ``"decorrelated"``, or ``"none"``."""
+    reconnect_jitter: Literal["full", "none"]
+    """Jitter strategy applied to every reconnect delay: ``"full"`` (default) or ``"none"``."""
     reconnect_replay_burst_size: int
     """Number of subscription-replay frames sent per burst after an auto-reconnect (default 50, minimum 1)."""
     reconnect_replay_pace_ms: int

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -635,13 +635,12 @@ impl Config {
     }
 
     /// Set the jitter strategy applied to every reconnect delay.
-    /// Accepts ``"full"`` (default), ``"equal"``, ``"decorrelated"``,
-    /// or ``"none"`` (case-insensitive).
+    /// Accepts ``"full"`` (default) or ``"none"`` (case-insensitive).
     #[setter]
     fn set_reconnect_jitter(&self, mode: &str) -> PyResult<()> {
         let parsed = config::JitterMode::parse(mode).ok_or_else(|| {
             crate::errors::invalid_parameter_err(format!(
-                "unknown reconnect_jitter: {mode:?} (expected \"full\", \"equal\", \"decorrelated\", or \"none\")"
+                "unknown reconnect_jitter: {mode:?} (expected \"full\" or \"none\")"
             ))
         })?;
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/thetadatadx-py/tests/test_config_resilience.py
+++ b/thetadatadx-py/tests/test_config_resilience.py
@@ -48,7 +48,7 @@ def test_reconnect_jitter_round_trips_and_rejects_unknown():
     mod = _import_module()
     cfg = mod.Config.production()
     assert cfg.reconnect_jitter == "full"
-    for mode in ("equal", "DECORRELATED", "none", "Full"):
+    for mode in ("none", "Full"):
         cfg.reconnect_jitter = mode
         assert cfg.reconnect_jitter == mode.lower()
     with pytest.raises(ValueError, match=r"reconnect_jitter"):

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -1989,39 +1989,34 @@ path = "reconnect.jitter"
 enum_type = "thetadatadx::JitterMode"
 enum_core = "config::JitterMode"
 null_err = "other"
-enum_expected = "expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
-py_err = 'unknown reconnect_jitter: {mode:?} (expected "full", "equal", "decorrelated", or "none")'
-ts_err = 'setReconnectJitter: unknown mode {mode:?}; expected "full", "equal", "decorrelated", or "none"'
+enum_expected = "expected 0 (Full) or 1 (None)"
+py_err = 'unknown reconnect_jitter: {mode:?} (expected "full" or "none")'
+ts_err = 'setReconnectJitter: unknown mode {mode:?}; expected "full" or "none"'
 doc = """
 Set the jitter strategy applied to every reconnect delay.
 
 - `mode = 0`: Full (default) — sample uniformly from `[0, delay]`.
-- `mode = 1`: Equal — `delay/2 + uniform(0, delay/2)`.
-- `mode = 2`: Decorrelated — walk relative to the previous delay.
-- `mode = 3`: None — deterministic delays (tests only).
+- `mode = 1`: None — deterministic delays (tests only).
 
 Returns `0` on success. Returns `-1` and sets `thetadatadx_last_error` when
-`mode` is outside the documented `{0, 1, 2, 3}` set or `config` is
+`mode` is outside the documented `{0, 1}` set or `config` is
 null. A rejected `mode` value carries
 `thetadatadx_last_error_code = THETADATADX_ERR_INVALID_PARAMETER` so an out-of-domain
 enum int surfaces the same typed class across every binding.
 """
 cpp_doc = """
-Set the reconnect jitter mode: 0=Full (default), 1=Equal,
-2=Decorrelated, 3=None. Throws @c thetadatadx::InvalidParameterError on
+Set the reconnect jitter mode: 0=Full (default), 1=None. Throws @c thetadatadx::InvalidParameterError on
 an out-of-domain mode (and @c thetadatadx::ThetaDataError on a null
 handle), routing through the typed leaf the FFI error code
 selects.
 """
 py_doc = """
 Set the jitter strategy applied to every reconnect delay.
-Accepts ``"full"`` (default), ``"equal"``, ``"decorrelated"``,
-or ``"none"`` (case-insensitive).
+Accepts ``"full"`` (default) or ``"none"`` (case-insensitive).
 """
 ts_doc = """
 Set the jitter strategy applied to every reconnect delay.
-Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
-`"none"` (case-insensitive).
+Accepts `"full"` (default) or `"none"` (case-insensitive).
 """
 py_param = "mode"
 ts_param = "mode"
@@ -2031,14 +2026,6 @@ rust = "Full"
 label = "full"
 [[accessor.variant]]
 int = 1
-rust = "Equal"
-label = "equal"
-[[accessor.variant]]
-int = 2
-rust = "Decorrelated"
-label = "decorrelated"
-[[accessor.variant]]
-int = 3
 rust = "None"
 label = "none"
 
@@ -2070,14 +2057,6 @@ rust = "Full"
 label = "full"
 [[accessor.variant]]
 int = 1
-rust = "Equal"
-label = "equal"
-[[accessor.variant]]
-int = 2
-rust = "Decorrelated"
-label = "decorrelated"
-[[accessor.variant]]
-int = 3
 rust = "None"
 label = "none"
 

--- a/thetadatadx-rs/src/backoff.rs
+++ b/thetadatadx-rs/src/backoff.rs
@@ -17,7 +17,7 @@
 //!
 //! The default [`JitterMode::Full`] follows AWS's *full jitter*
 //! analysis: sampling uniformly from `[0, capped_delay]` minimises
-//! total work and contention versus equal jitter or no jitter; see
+//! total work and contention versus no jitter; see
 //! <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>.
 
 use std::time::Duration;
@@ -28,8 +28,7 @@ use rand::RngExt;
 ///
 /// The streaming reconnect driver exposes this knob through
 /// [`crate::config::ReconnectConfig::jitter`]; bindings encode it as
-/// the lowercase strings `"full"`, `"equal"`, `"decorrelated"`, and
-/// `"none"`.
+/// the lowercase strings `"full"` and `"none"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum JitterMode {
@@ -38,15 +37,6 @@ pub enum JitterMode {
     /// almost immediately.
     #[default]
     Full,
-    /// `delay / 2 + uniform(0, delay / 2)` (AWS equal jitter). Keeps a
-    /// per-attempt floor of half the deterministic delay while still
-    /// spreading a fleet across the upper half of the window.
-    Equal,
-    /// Decorrelated walk: `min(cap, uniform(initial, prev * 3))`. Each
-    /// delay is sampled relative to the previous one rather than the
-    /// attempt number, which spreads long-running retry sessions even
-    /// when their attempt counters align.
-    Decorrelated,
     /// No jitter — the deterministic capped delay. Useful for tests
     /// that assert exact timings; not recommended for fleets.
     None,
@@ -59,8 +49,6 @@ impl JitterMode {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Full => "full",
-            Self::Equal => "equal",
-            Self::Decorrelated => "decorrelated",
             Self::None => "none",
         }
     }
@@ -71,8 +59,6 @@ impl JitterMode {
     pub fn parse(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
             "full" => Some(Self::Full),
-            "equal" => Some(Self::Equal),
-            "decorrelated" => Some(Self::Decorrelated),
             "none" => Some(Self::None),
             _ => None,
         }
@@ -80,73 +66,36 @@ impl JitterMode {
 
     /// Jitter the deterministic `delay` for one retry attempt.
     ///
-    /// `schedule` carries the ladder bounds plus the previous jittered
-    /// delay that [`JitterMode::Decorrelated`] walks from; the other
-    /// modes ignore everything except `delay`. The returned value is
-    /// recorded back into `schedule` so the decorrelated walk advances.
-    ///
     /// Guarantees, by mode:
     ///
     /// * `Full` — result in `[0, delay]`.
-    /// * `Equal` — result in `[delay / 2, delay]`.
-    /// * `Decorrelated` — result in `[min(initial, cap), cap]`.
     /// * `None` — result is exactly `delay`.
-    pub(crate) fn sample(self, delay: Duration, schedule: &mut BackoffSchedule) -> Duration {
-        let sampled = match self {
+    #[must_use]
+    pub(crate) fn sample(self, delay: Duration) -> Duration {
+        match self {
             Self::None => delay,
             Self::Full => uniform_duration(Duration::ZERO, delay),
-            Self::Equal => {
-                let half = delay / 2;
-                half + uniform_duration(Duration::ZERO, delay - half)
-            }
-            Self::Decorrelated => {
-                let prev = schedule.prev.unwrap_or(schedule.initial);
-                let upper = prev
-                    .saturating_mul(3)
-                    .clamp(schedule.initial, schedule.cap.max(schedule.initial));
-                uniform_duration(schedule.initial.min(schedule.cap), upper)
-            }
-        };
-        schedule.prev = Some(sampled);
-        sampled
+        }
     }
 }
 
-/// Ladder bounds plus the per-burst state the decorrelated walk needs.
-///
-/// One value lives per retry burst (e.g. per consecutive-reconnect
-/// sequence in the streaming I/O loop); call
-/// [`BackoffSchedule::reset`] when the burst ends so the next burst
-/// starts the walk from `initial` again.
+/// Deterministic exponential-ladder bounds for a retry burst.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BackoffSchedule {
     /// First-attempt delay; doubles per attempt.
     pub(crate) initial: Duration,
     /// Upper bound on the deterministic ladder.
     pub(crate) cap: Duration,
-    /// Previous jittered delay ([`JitterMode::Decorrelated`] state).
-    pub(crate) prev: Option<Duration>,
 }
 
 impl BackoffSchedule {
     pub(crate) fn new(initial: Duration, cap: Duration) -> Self {
-        Self {
-            initial,
-            cap,
-            prev: None,
-        }
+        Self { initial, cap }
     }
 
     /// Deterministic capped delay for a 1-based `attempt` number.
     pub(crate) fn deterministic(&self, attempt: u32) -> Duration {
         capped_exponential(self.initial, self.cap, attempt)
-    }
-
-    /// Forget the decorrelated-walk state. Call when a retry burst
-    /// ends (successful data flow / stable window) so the next burst
-    /// restarts from `initial`.
-    pub(crate) fn reset(&mut self) {
-        self.prev = None;
     }
 }
 
@@ -242,49 +191,17 @@ mod tests {
 
     #[test]
     fn full_jitter_stays_within_zero_to_delay() {
-        let mut schedule =
-            BackoffSchedule::new(Duration::from_millis(250), Duration::from_secs(30));
         let delay = Duration::from_secs(4);
         for _ in 0..256 {
-            let sampled = JitterMode::Full.sample(delay, &mut schedule);
+            let sampled = JitterMode::Full.sample(delay);
             assert!(sampled <= delay, "full jitter must not exceed the delay");
         }
     }
 
     #[test]
-    fn equal_jitter_keeps_half_delay_floor() {
-        let mut schedule =
-            BackoffSchedule::new(Duration::from_millis(250), Duration::from_secs(30));
-        let delay = Duration::from_secs(4);
-        for _ in 0..256 {
-            let sampled = JitterMode::Equal.sample(delay, &mut schedule);
-            assert!(sampled >= delay / 2, "equal jitter floor is delay/2");
-            assert!(sampled <= delay, "equal jitter must not exceed the delay");
-        }
-    }
-
-    #[test]
-    fn decorrelated_jitter_walks_within_initial_and_cap() {
-        let initial = Duration::from_millis(250);
-        let cap = Duration::from_secs(30);
-        let mut schedule = BackoffSchedule::new(initial, cap);
-        for attempt in 1..64_u32 {
-            let base = schedule.deterministic(attempt);
-            let sampled = JitterMode::Decorrelated.sample(base, &mut schedule);
-            assert!(
-                sampled >= initial,
-                "decorrelated floor is the initial delay"
-            );
-            assert!(sampled <= cap, "decorrelated ceiling is the cap");
-        }
-    }
-
-    #[test]
     fn none_jitter_returns_exact_delay() {
-        let mut schedule =
-            BackoffSchedule::new(Duration::from_millis(250), Duration::from_secs(30));
         let delay = Duration::from_millis(1_234);
-        assert_eq!(JitterMode::None.sample(delay, &mut schedule), delay);
+        assert_eq!(JitterMode::None.sample(delay), delay);
     }
 
     #[test]
@@ -300,12 +217,7 @@ mod tests {
 
     #[test]
     fn jitter_mode_string_round_trip() {
-        for mode in [
-            JitterMode::Full,
-            JitterMode::Equal,
-            JitterMode::Decorrelated,
-            JitterMode::None,
-        ] {
+        for mode in [JitterMode::Full, JitterMode::None] {
             assert_eq!(JitterMode::parse(mode.as_str()), Some(mode));
         }
         assert_eq!(JitterMode::parse("FULL"), Some(JitterMode::Full));
@@ -318,14 +230,5 @@ mod tests {
         let a = entropy_u64();
         let b = entropy_u64();
         assert_ne!(a, b, "consecutive entropy words must differ");
-    }
-
-    #[test]
-    fn backoff_schedule_reset_clears_walk_state() {
-        let mut schedule = BackoffSchedule::new(Duration::from_millis(100), Duration::from_secs(5));
-        let _ = JitterMode::Decorrelated.sample(Duration::from_millis(100), &mut schedule);
-        assert!(schedule.prev.is_some());
-        schedule.reset();
-        assert!(schedule.prev.is_none());
     }
 }

--- a/thetadatadx-rs/src/config/retry.rs
+++ b/thetadatadx-rs/src/config/retry.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 /// With `jitter = true` (default) the sleep duration follows AWS's
 /// *full jitter* pattern: `delay = rand(0, min(max_delay, initial *
 /// 2^attempt))`. Full jitter provably minimises retry-storm contention
-/// relative to equal jitter or no jitter; see
+/// relative to no jitter; see
 /// <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
 /// and [`crate::backoff`] for the shared sampler.
 ///

--- a/thetadatadx-rs/src/fpss/io_loop/mod.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/mod.rs
@@ -1208,13 +1208,13 @@ where
                         // Exponential ladder `wait_ms * 2^(n-1)`
                         // capped at `wait_max_ms`, then jittered.
                         let base = reconnect_state.schedule.deterministic(attempt);
-                        jitter.sample(base, &mut reconnect_state.schedule)
+                        jitter.sample(base)
                     }
                     ReconnectAttemptClass::ServerRestart => {
                         // Flat patient cadence for a pool bounce,
                         // jittered so a fleet spreads its retries.
                         let base = Duration::from_millis(wait_server_restart_ms);
-                        jitter.sample(base, &mut reconnect_state.schedule)
+                        jitter.sample(base)
                     }
                     ReconnectAttemptClass::RateLimited => {
                         // The floor is an upstream-instructed cooldown
@@ -2028,8 +2028,7 @@ struct ReconnectCounters {
     /// consecutive-reconnect sequence; `None` outside a sequence.
     /// Anchors the `max_elapsed` envelope.
     burst_started_at: Option<Instant>,
-    /// Exponential-ladder bounds + decorrelated-jitter walk state for
-    /// the generic-transient class.
+    /// Exponential-ladder bounds for the generic-transient class.
     schedule: BackoffSchedule,
 }
 
@@ -2059,13 +2058,12 @@ impl ReconnectCounters {
     }
 
     /// Zero every per-class counter and end the current reconnect
-    /// sequence (envelope anchor + jitter walk state).
+    /// sequence (envelope anchor).
     fn reset_counters(&mut self) {
         self.transient = 0;
         self.rate_limited = 0;
         self.server_restart = 0;
         self.burst_started_at = None;
-        self.schedule.reset();
     }
 
     /// Decide whether the connection that just disconnected ran long

--- a/thetadatadx-ts/__tests__/config_resilience.test.mjs
+++ b/thetadatadx-ts/__tests__/config_resilience.test.mjs
@@ -25,7 +25,7 @@ test("reconnect ladder defaults and round-trip", () => {
 test("reconnect jitter round-trips and rejects unknown", () => {
   const cfg = Config.production();
   assert.equal(cfg.reconnectJitter, "full");
-  for (const mode of ["equal", "DECORRELATED", "none", "Full"]) {
+  for (const mode of ["none", "Full"]) {
     cfg.setReconnectJitter(mode);
     assert.equal(cfg.reconnectJitter, mode.toLowerCase());
   }

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -567,8 +567,7 @@ export declare class Config {
   get marketDataHost(): string
   /**
    * Set the jitter strategy applied to every reconnect delay.
-   * Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
-   * `"none"` (case-insensitive).
+   * Accepts `"full"` (default) or `"none"` (case-insensitive).
    */
   setReconnectJitter(mode: string): void
   /** Current reconnect jitter mode as a lowercase string. */

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -920,13 +920,12 @@ impl Config {
     }
 
     /// Set the jitter strategy applied to every reconnect delay.
-    /// Accepts `"full"` (default), `"equal"`, `"decorrelated"`, or
-    /// `"none"` (case-insensitive).
+    /// Accepts `"full"` (default) or `"none"` (case-insensitive).
     #[napi(js_name = "setReconnectJitter")]
     pub fn set_reconnect_jitter(&self, mode: String) -> napi::Result<()> {
         let parsed = config::JitterMode::parse(&mode).ok_or_else(|| {
             crate::invalid_parameter_err(format!(
-                "setReconnectJitter: unknown mode {mode:?}; expected \"full\", \"equal\", \"decorrelated\", or \"none\""
+                "setReconnectJitter: unknown mode {mode:?}; expected \"full\" or \"none\""
             ))
         })?;
         let mut guard = self


### PR DESCRIPTION
## Why

The reconnect backoff exposed four AWS jitter modes — `Full`, `Equal`, `Decorrelated`, `None`. **Full** jitter (sample uniformly from `[0, delay]`) is the right default for a recovering fleet and stays; **None** (deterministic delays) is kept for tests. `Equal` and `Decorrelated` were unused academic backoff variants with no operational benefit over full jitter — config nobody sets — so they're removed.

## What

- **`JitterMode`** drops the `Equal` and `Decorrelated` variants. Its `sample` no longer needs the per-burst `BackoffSchedule`, so the now-dead decorrelated-walk state — the schedule's `prev` field and `reset()` — is removed too (`sample(self, delay)` is now a two-arm match).
- **C-ABI encoding** collapses to `0 = Full`, `1 = None` (was `0/1/2/3`).
- Removed across every binding (Python `reconnect_jitter`, TypeScript `reconnectJitter` / `setReconnectJitter`, C++ + C ABI), the config surface, the `parity.toml` `Literal` row, and the docs. Setting a removed mode (or the old C-ABI codes `1` / `2`) is now rejected with the typed invalid-parameter error.

## Breaking

Removes two enum values from a public config knob — targeted for `0.2.0`.

## Verification

- Rust `backoff` (6, incl. rewritten full/none sampler) + `config` tests pass; FFI suite passes (jitter round-trip updated to the 2-mode encoding); Python/TypeScript clippy clean.
- `check_binding_parity` clean + `--selftest` 209/0; `generate_docs_site --check` + `generate_sdk_surfaces --check` pass (llms.txt regenerated); doc-defaults / docs-consistency / vocab gates pass; changelogs byte-identical.

Net: **+49 / −177**.
