### PR TITLE
fix(fpss): terminal-parity corrections from the post-removal audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`ping_interval_ms` default is now `100`, matching the terminal.** The client heartbeat previously defaulted to `250 ms`; the Theta Terminal pings on a fixed `100 ms` period, and with `flush_mode` removed the ping is the sole flush trigger for queued outbound control frames, so the default now matches the terminal exactly (subscribe / unsubscribe reach the server within one `100 ms` interval instead of `250 ms`). The knob and its `[100, 300_000]` range are unchanged; override it if you prefer the old cadence.
+
 ### Removed
 
 - **`flush_mode` streaming write-flush knob.** The `flush_mode` setting is removed from every binding (Rust `StreamingConfig::flush_mode`, Python `Config.flush_mode`, TypeScript `Config.flushMode` / `setFlushMode`, C++ `set_flush_mode` / `get_flush_mode`, C ABI `thetadatadx_config_set_flush_mode` / `_get_flush_mode`). Outbound streaming writes now always coalesce and flush on the ping heartbeat, so a subscription burst leaves as fewer, larger packets — the terminal's own behavior — with received-data latency unaffected as before. The `"immediate"` per-frame-flush mode existed only to defeat that server-friendly coalescing and is gone. This is a breaking change to the configuration surface.
 
 - **`host_selection` / `host_shuffle_seed` streaming host-ordering knobs.** Removed from every binding (Rust `StreamingConfig::host_selection` / `host_shuffle_seed`, Python `Config.streaming_host_selection` / `streaming_host_shuffle_seed`, TypeScript `Config.streamingHostSelection` / `setStreamingHostSelection` and the shuffle-seed pair, C++ `set_streaming_host_selection` / `get_streaming_host_selection` and the shuffle-seed pair, C ABI `thetadatadx_config_*_streaming_host_selection` / `_host_shuffle_seed`), along with the `HostSelectionPolicy` enum. The client now cycles the declared host list left to right — the terminal's own behavior — and a reconnect tries the last-known-good host first. The per-client fault-domain shuffle and its seed existed only in the SDK, with no terminal counterpart. This is a breaking change to the configuration surface.
 
-- **`reconnect_jitter` trimmed to `"full"` / `"none"`.** The `"equal"` and `"decorrelated"` jitter variants are removed from every binding (the `JitterMode` enum drops them, and the C-ABI integer encoding is now `0 = Full`, `1 = None`). Full jitter — sampling uniformly from `[0, delay]` — stays the default and is the right choice for a recovering fleet; `"none"` (deterministic delays) remains for tests. The two removed variants were unused academic backoff modes with no operational benefit over full jitter. Setting `reconnect_jitter` to `"equal"` or `"decorrelated"` (or the C-ABI codes `1` / `2`) is now rejected. This is a breaking change to the configuration surface.
+- **`reconnect_jitter` trimmed to `"full"` / `"none"`.** The `"equal"` and `"decorrelated"` jitter variants are removed from every binding (the `JitterMode` enum drops them, and the C-ABI integer encoding is now `0 = Full`, `1 = None`). Full jitter — sampling uniformly from `[0, delay]` — stays the default and is the right choice for a recovering fleet; `"none"` (deterministic delays) remains for tests. The two removed variants were unused academic backoff modes with no operational benefit over full jitter. Setting `reconnect_jitter` to `"equal"` or `"decorrelated"` is now rejected. The C-ABI integer encoding renumbered — `1` now means `None` (it was `Equal`), and `2` / `3` are rejected — so a C caller that passed a numeric jitter code must be re-audited: passing `1` now selects no jitter rather than erroring. This is a breaking change to the configuration surface.
+
+- **Config-file migration.** A `config.toml` that still sets `flush_mode`, `streaming.host_selection`, `streaming.host_shuffle_seed`, or a `reconnect_jitter` of `"equal"` / `"decorrelated"` now fails to load with a typed error rather than being silently ignored — remove those keys / values when upgrading.
 
 ## [0.1.1] - 2026-07-07
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`ping_interval_ms` default is now `100`, matching the terminal.** The client heartbeat previously defaulted to `250 ms`; the Theta Terminal pings on a fixed `100 ms` period, and with `flush_mode` removed the ping is the sole flush trigger for queued outbound control frames, so the default now matches the terminal exactly (subscribe / unsubscribe reach the server within one `100 ms` interval instead of `250 ms`). The knob and its `[100, 300_000]` range are unchanged; override it if you prefer the old cadence.
+
 ### Removed
 
 - **`flush_mode` streaming write-flush knob.** The `flush_mode` setting is removed from every binding (Rust `StreamingConfig::flush_mode`, Python `Config.flush_mode`, TypeScript `Config.flushMode` / `setFlushMode`, C++ `set_flush_mode` / `get_flush_mode`, C ABI `thetadatadx_config_set_flush_mode` / `_get_flush_mode`). Outbound streaming writes now always coalesce and flush on the ping heartbeat, so a subscription burst leaves as fewer, larger packets — the terminal's own behavior — with received-data latency unaffected as before. The `"immediate"` per-frame-flush mode existed only to defeat that server-friendly coalescing and is gone. This is a breaking change to the configuration surface.
 
 - **`host_selection` / `host_shuffle_seed` streaming host-ordering knobs.** Removed from every binding (Rust `StreamingConfig::host_selection` / `host_shuffle_seed`, Python `Config.streaming_host_selection` / `streaming_host_shuffle_seed`, TypeScript `Config.streamingHostSelection` / `setStreamingHostSelection` and the shuffle-seed pair, C++ `set_streaming_host_selection` / `get_streaming_host_selection` and the shuffle-seed pair, C ABI `thetadatadx_config_*_streaming_host_selection` / `_host_shuffle_seed`), along with the `HostSelectionPolicy` enum. The client now cycles the declared host list left to right — the terminal's own behavior — and a reconnect tries the last-known-good host first. The per-client fault-domain shuffle and its seed existed only in the SDK, with no terminal counterpart. This is a breaking change to the configuration surface.
 
-- **`reconnect_jitter` trimmed to `"full"` / `"none"`.** The `"equal"` and `"decorrelated"` jitter variants are removed from every binding (the `JitterMode` enum drops them, and the C-ABI integer encoding is now `0 = Full`, `1 = None`). Full jitter — sampling uniformly from `[0, delay]` — stays the default and is the right choice for a recovering fleet; `"none"` (deterministic delays) remains for tests. The two removed variants were unused academic backoff modes with no operational benefit over full jitter. Setting `reconnect_jitter` to `"equal"` or `"decorrelated"` (or the C-ABI codes `1` / `2`) is now rejected. This is a breaking change to the configuration surface.
+- **`reconnect_jitter` trimmed to `"full"` / `"none"`.** The `"equal"` and `"decorrelated"` jitter variants are removed from every binding (the `JitterMode` enum drops them, and the C-ABI integer encoding is now `0 = Full`, `1 = None`). Full jitter — sampling uniformly from `[0, delay]` — stays the default and is the right choice for a recovering fleet; `"none"` (deterministic delays) remains for tests. The two removed variants were unused academic backoff modes with no operational benefit over full jitter. Setting `reconnect_jitter` to `"equal"` or `"decorrelated"` is now rejected. The C-ABI integer encoding renumbered — `1` now means `None` (it was `Equal`), and `2` / `3` are rejected — so a C caller that passed a numeric jitter code must be re-audited: passing `1` now selects no jitter rather than erroring. This is a breaking change to the configuration surface.
+
+- **Config-file migration.** A `config.toml` that still sets `flush_mode`, `streaming.host_selection`, `streaming.host_shuffle_seed`, or a `reconnect_jitter` of `"equal"` / `"decorrelated"` now fails to load with a typed error rather than being silently ignored — remove those keys / values when upgrading.
 
 ## [0.1.1] - 2026-07-07
 

--- a/thetadatadx-cpp/include/config_accessors.hpp.inc
+++ b/thetadatadx-cpp/include/config_accessors.hpp.inc
@@ -108,13 +108,13 @@
         return out;
     }
 
-    /// Set the streaming heartbeat ping interval (ms). Default 250;
+    /// Set the streaming heartbeat ping interval (ms). Default 100;
     /// validated to [100, 300_000] at connect.
     void set_streaming_ping_interval_ms(std::uint64_t v) {
         thetadatadx_config_set_streaming_ping_interval_ms(handle_.get(), v);
     }
 
-    /// Current streaming ping_interval_ms (default 250).
+    /// Current streaming ping_interval_ms (default 100).
     std::uint64_t get_streaming_ping_interval_ms() const {
         std::uint64_t out{};
         thetadatadx_config_get_streaming_ping_interval_ms(handle_.get(), &out);

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -1495,7 +1495,7 @@ void thetadatadx_config_set_streaming_connect_timeout_ms(ThetaDataDxConfig* conf
 int32_t thetadatadx_config_get_streaming_connect_timeout_ms(const ThetaDataDxConfig* config, uint64_t* out);
 
 /**
- * Set the streaming heartbeat ping interval (ms). Default 250; validated to
+ * Set the streaming heartbeat ping interval (ms). Default 100; validated to
  * [100, 300_000] at connect.
  * @param config Config handle to mutate; no-op when NULL.
  * @param v Ping interval in milliseconds.
@@ -1503,7 +1503,7 @@ int32_t thetadatadx_config_get_streaming_connect_timeout_ms(const ThetaDataDxCon
 void thetadatadx_config_set_streaming_ping_interval_ms(ThetaDataDxConfig* config, uint64_t v);
 
 /**
- * Read the current streaming ping_interval_ms setting (default 250).
+ * Read the current streaming ping_interval_ms setting (default 100).
  * @param config Config handle to read.
  * @param out Receives the interval in milliseconds on success.
  * @return 0 on success, -1 if either pointer is null.

--- a/thetadatadx-ffi/src/auth.rs
+++ b/thetadatadx-ffi/src/auth.rs
@@ -2169,7 +2169,7 @@ mod resilience_knob_tests {
                 super::thetadatadx_config_get_streaming_ping_interval_ms(cfg, &mut got),
                 0
             );
-            assert_eq!(got, 250);
+            assert_eq!(got, 100);
             assert_eq!(
                 super::thetadatadx_config_get_streaming_io_read_slice_ms(cfg, &mut got),
                 0

--- a/thetadatadx-ffi/src/config_accessors.rs
+++ b/thetadatadx-ffi/src/config_accessors.rs
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_streaming_connect_timeout_ms(
     })
 }
 
-/// Set the streaming heartbeat ping interval (ms). Default `250`; validated to `[100, 300_000]` at connect.
+/// Set the streaming heartbeat ping interval (ms). Default `100`; validated to `[100, 300_000]` at connect.
 #[no_mangle]
 pub unsafe extern "C" fn thetadatadx_config_set_streaming_ping_interval_ms(
     config: *mut ThetaDataDxConfig,
@@ -314,7 +314,7 @@ pub unsafe extern "C" fn thetadatadx_config_set_streaming_ping_interval_ms(
     })
 }
 
-/// Read the current streaming `ping_interval_ms` setting (default `250`).
+/// Read the current streaming `ping_interval_ms` setting (default `100`).
 ///
 /// Writes the configured value into `*out`. Returns `0` on success,
 /// `-1` if either pointer is null.

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -134,7 +134,7 @@ impl Config {
         guard.streaming.connect_timeout_ms
     }
 
-    /// Set the streaming heartbeat ping interval (ms). Default ``250``;
+    /// Set the streaming heartbeat ping interval (ms). Default ``100``;
     /// validated to ``[100, 300_000]``.
     #[setter]
     fn set_streaming_ping_interval_ms(&self, ms: u64) {
@@ -142,7 +142,7 @@ impl Config {
         guard.streaming.ping_interval_ms = ms;
     }
 
-    /// Current ``streaming.ping_interval_ms`` value (default ``250``).
+    /// Current ``streaming.ping_interval_ms`` value (default ``100``).
     #[getter]
     fn get_streaming_ping_interval_ms(&self) -> u64 {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/thetadatadx-py/tests/test_config_resilience.py
+++ b/thetadatadx-py/tests/test_config_resilience.py
@@ -99,7 +99,7 @@ def test_streaming_transport_defaults_and_round_trip():
     cfg = mod.Config.production()
     assert cfg.streaming_timeout_ms == 10_000
     assert cfg.streaming_connect_timeout_ms == 2_000
-    assert cfg.streaming_ping_interval_ms == 250
+    assert cfg.streaming_ping_interval_ms == 100
     assert cfg.streaming_ring_size == 131_072
     assert cfg.streaming_io_read_slice_ms == 25
     assert cfg.streaming_keepalive_idle_secs == 5

--- a/thetadatadx-rs/config.default.toml
+++ b/thetadatadx-rs/config.default.toml
@@ -42,11 +42,12 @@ connect_timeout = 2000
 # to the server, not an inbound heartbeat; inbound frames arrive ~250 ms.
 read_timeout = 10000
 
-# Client outbound ping interval (ms). This ping proves write-side health at a
-# 4 Hz cadence without adding inbound-frame pressure on a recovering upstream.
-# Reverse-direction liveness is the inbound frame and ping stream (~250 ms),
-# which read_timeout guards.
-ping_interval = 250
+# Client outbound ping interval (ms). Matches the terminal's pinger (a fixed
+# 100 ms period after a 2 s warm-up). The ping also flushes queued outbound
+# control frames, so this interval bounds subscribe / unsubscribe latency.
+# Reverse-direction liveness is the inbound frame stream, which read_timeout
+# guards.
+ping_interval = 100
 
 # Initial reconnect wait after an involuntary disconnect (ms). The auto-
 # reconnect driver doubles this per consecutive attempt up to its cap, then

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -418,18 +418,18 @@ param = "v"
 abi_type = "u64"
 path = "streaming.ping_interval_ms"
 doc = """
-Set the streaming heartbeat ping interval (ms). Default `250`; validated to `[100, 300_000]` at connect.
+Set the streaming heartbeat ping interval (ms). Default `100`; validated to `[100, 300_000]` at connect.
 """
 cpp_doc = """
-Set the streaming heartbeat ping interval (ms). Default 250;
+Set the streaming heartbeat ping interval (ms). Default 100;
 validated to [100, 300_000] at connect.
 """
 py_doc = """
-Set the streaming heartbeat ping interval (ms). Default ``250``;
+Set the streaming heartbeat ping interval (ms). Default ``100``;
 validated to ``[100, 300_000]``.
 """
 ts_doc = """
-Set the streaming heartbeat ping interval (ms). Default `250n`; validated to `[100, 300_000]` at connect.
+Set the streaming heartbeat ping interval (ms). Default `100n`; validated to `[100, 300_000]` at connect.
 """
 py_param = "ms"
 ts_param = "ms"
@@ -441,19 +441,19 @@ param = "out"
 abi_type = "u64"
 path = "streaming.ping_interval_ms"
 doc = """
-Read the current streaming `ping_interval_ms` setting (default `250`).
+Read the current streaming `ping_interval_ms` setting (default `100`).
 
 Writes the configured value into `*out`. Returns `0` on success,
 `-1` if either pointer is null.
 """
 cpp_doc = """
-Current streaming ping_interval_ms (default 250).
+Current streaming ping_interval_ms (default 100).
 """
 py_doc = """
-Current ``streaming.ping_interval_ms`` value (default ``250``).
+Current ``streaming.ping_interval_ms`` value (default ``100``).
 """
 ts_doc = """
-Current `streaming.ping_interval_ms` value (default `250n`).
+Current `streaming.ping_interval_ms` value (default `100n`).
 """
 
 [[accessor]]

--- a/thetadatadx-rs/src/config/fpss.rs
+++ b/thetadatadx-rs/src/config/fpss.rs
@@ -61,13 +61,13 @@ pub struct StreamingConfig {
     /// Streaming heartbeat ping interval in milliseconds.
     ///
     /// This is the client's outbound ping cadence to the server, and the
-    /// server may disconnect if it falls silent. Default `250` — the ping
-    /// mainly proves write-side health at a 4 Hz cadence without adding
-    /// inbound-frame pressure on a recovering upstream. Reverse-direction
-    /// liveness is the inbound frame and ping stream (~250 ms on an active
-    /// session), which [`Self::timeout_ms`] guards. Validated to the range
-    /// `[100, 300_000]` ms — sub-100 ms values are rejected so a
-    /// misconfiguration does not flood the upstream.
+    /// server may disconnect if it falls silent. Default `100`, matching
+    /// the terminal's pinger (a fixed 100 ms period after a 2 s warm-up).
+    /// The ping also flushes any queued outbound control frames, so this
+    /// interval bounds subscribe / unsubscribe latency. Reverse-direction
+    /// liveness is the inbound frame stream, which [`Self::timeout_ms`]
+    /// guards. Validated to the range `[100, 300_000]` ms — sub-100 ms
+    /// values are rejected so a misconfiguration does not flood the upstream.
     pub ping_interval_ms: u64,
 
     /// Per-server TCP connect timeout in milliseconds. Default `2000`.
@@ -153,7 +153,7 @@ impl StreamingConfig {
             ],
             timeout_ms: 10_000,
             ring_size: 131_072,
-            ping_interval_ms: 250,
+            ping_interval_ms: 100,
             connect_timeout_ms: 2_000,
             io_read_slice_ms: 25,
             keepalive_idle_secs: 5,
@@ -197,7 +197,7 @@ mod tests {
     fn production_defaults_resilience_shape() {
         let cfg = StreamingConfig::production_defaults();
         assert_eq!(cfg.timeout_ms, 10_000);
-        assert_eq!(cfg.ping_interval_ms, 250);
+        assert_eq!(cfg.ping_interval_ms, 100);
         assert_eq!(cfg.io_read_slice_ms, 25);
         assert_eq!(cfg.keepalive_idle_secs, 5);
         assert_eq!(cfg.keepalive_interval_secs, 2);

--- a/thetadatadx-rs/src/config/mod.rs
+++ b/thetadatadx-rs/src/config/mod.rs
@@ -2090,7 +2090,7 @@ mod tests {
         let validated = config.validate().expect("production defaults validate");
         assert_eq!(validated.market_data.window_size_kb, 64);
         assert_eq!(validated.streaming.timeout_ms, 10_000);
-        assert_eq!(validated.streaming.ping_interval_ms, 250);
+        assert_eq!(validated.streaming.ping_interval_ms, 100);
         assert_eq!(validated.streaming.connect_timeout_ms, 2_000);
         assert_eq!(validated.streaming.io_read_slice_ms, 25);
         assert_eq!(validated.streaming.keepalive_idle_secs, 5);

--- a/thetadatadx-rs/src/fpss/connection.rs
+++ b/thetadatadx-rs/src/fpss/connection.rs
@@ -10,9 +10,10 @@
 //!   by the transport long before the platform default of 2+ hours
 //! - Connect timeout: 2 seconds (configurable)
 //! - Read timeout: configurable (default 10 seconds)
-//! - Host order: the declared order (see [`order_hosts`]); the terminal
-//!   cycles its host list left to right, and a reconnect promotes the
-//!   last-known-good host to the front
+//! - Host order: the declared order (see [`order_hosts`]) — the terminal
+//!   cycles its host list left to right, and the SDK matches that. On a
+//!   reconnect the SDK additionally promotes the last-known-good host to
+//!   the front (an SDK-only resilience choice; the terminal does not)
 //!
 //! # Implementation
 //!

--- a/thetadatadx-rs/src/fpss/decode.rs
+++ b/thetadatadx-rs/src/fpss/decode.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
+use std::time::Instant;
 
 use crate::tdbe::types::enums::StreamMsgType;
 use crate::tdbe::types::price::Price;
@@ -295,8 +296,11 @@ pub fn decode_frame(
     // global so the "1 of every 1024" rate aggregates across every
     // StreamingClient in the same process.
     let warn_unknown_contract =
-        |contract_id: i32, kind: &str, cache: &HashMap<i32, Arc<Contract>>| {
-            if !cache.contains_key(&contract_id) {
+        |contract_id: i32,
+         kind: &str,
+         delta_state: &DeltaState,
+         cache: &HashMap<i32, Arc<Contract>>| {
+            if !cache.contains_key(&contract_id) && !delta_state.is_in_stop_suppression_window() {
                 static MISS_COUNT: AtomicU64 = AtomicU64::new(0);
                 let prev = MISS_COUNT.fetch_add(1, Ordering::Relaxed);
                 if prev.is_multiple_of(1024) {
@@ -367,7 +371,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "quote", local_contracts);
+                    warn_unknown_contract(contract_id, "quote", delta_state, local_contracts);
                     let pt = buf[9];
                     let (Some(bid_f64), Some(ask_f64)) =
                         (strict_fpss_price(buf[3], pt), strict_fpss_price(buf[7], pt))
@@ -410,7 +414,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, TRADE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "trade", local_contracts);
+                    warn_unknown_contract(contract_id, "trade", delta_state, local_contracts);
 
                     // `decode_tick` rejects any row whose width is not exactly
                     // TRADE_FIELDS (the only stream-trade layout; the 16-field
@@ -455,7 +459,12 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OI_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "open_interest", local_contracts);
+                    warn_unknown_contract(
+                        contract_id,
+                        "open_interest",
+                        delta_state,
+                        local_contracts,
+                    );
                     FPSS_OI_EVENTS.increment(1);
                     Some(FpssEventInternal::Data(StreamData::OpenInterest {
                         contract: resolve_contract(contract_id, local_contracts),
@@ -477,7 +486,7 @@ pub fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OHLCVC_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "ohlcvc", local_contracts);
+                    warn_unknown_contract(contract_id, "ohlcvc", delta_state, local_contracts);
                     let pt = buf[7];
                     let (Some(o), Some(h), Some(l), Some(c)) = (
                         strict_fpss_price(buf[1], pt),
@@ -527,7 +536,12 @@ pub fn decode_frame(
             // bid/ask.
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
-                    warn_unknown_contract(contract_id, "market_value", local_contracts);
+                    warn_unknown_contract(
+                        contract_id,
+                        "market_value",
+                        delta_state,
+                        local_contracts,
+                    );
                     let pt = buf[9];
                     // Compute market value on the raw integer bid/ask/sizes,
                     // keeping wire scale, then reassemble to dollars at the
@@ -589,6 +603,7 @@ pub fn decode_frame(
 
         StreamMsgType::Stop => {
             tracing::info!("market close signal received");
+            delta_state.last_stop = Some(Instant::now());
             delta_state.clear();
             local_contracts.clear(); // mirrors idToContract.clear() on the wire
             Some(FpssEventInternal::Control(StreamControl::MarketClose))

--- a/thetadatadx-rs/src/fpss/delta.rs
+++ b/thetadatadx-rs/src/fpss/delta.rs
@@ -6,6 +6,7 @@
 //! buffer used by [`DeltaState::decode_tick`].
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use crate::tdbe::codec::fit::{apply_deltas, FitReader};
 
@@ -78,7 +79,19 @@ pub struct DeltaState {
     /// unused slots zero-filled, so a stale width can only under-report which
     /// trailing fields a caller reads, never read out of bounds.
     field_counts: HashMap<(u8, i32), usize>,
+    /// Timestamp of last STOP (market close) signal. Used to suppress
+    /// "unknown `contract_id`" warnings for 5 seconds after STOP;
+    /// stale ticks are expected during teardown.
+    pub(super) last_stop: Option<Instant>,
 }
+
+/// Duration after a STOP signal during which "unknown `contract_id`" warnings
+/// are suppressed (stale ticks are expected during market-close teardown).
+///
+/// Mirrors the terminal, which gates its own "No trade/quote/OHLC/open
+/// interest contract for ID" logs on `now - lastStop > 5000ms` — this is
+/// terminal-derived behaviour, not an SDK invention.
+const STOP_SUPPRESS_DURATION: Duration = Duration::from_secs(5);
 
 impl DeltaState {
     #[doc(hidden)]
@@ -91,6 +104,7 @@ impl DeltaState {
             alloc_buf: vec![0i32; MAX_DATA_FIELDS + 1],
             last_was_date: false,
             field_counts: HashMap::new(),
+            last_stop: None,
         }
     }
 
@@ -99,10 +113,20 @@ impl DeltaState {
     /// Called on START/STOP (market open/close) signals to reset delta
     /// decompression: the contract-id read starts fresh after a session
     /// boundary.
+    ///
+    /// Note: `last_stop` is intentionally NOT cleared here because STOP
+    /// itself calls `clear()`, and the timestamp must survive to suppress
+    /// stale-tick warnings for 5 seconds after the STOP signal.
     pub fn clear(&mut self) {
         self.prev.clear();
         self.last_was_date = false;
         self.field_counts.clear();
+    }
+
+    /// Whether we are within the post-STOP suppression window.
+    pub(super) fn is_in_stop_suppression_window(&self) -> bool {
+        self.last_stop
+            .is_some_and(|t| t.elapsed() < STOP_SUPPRESS_DURATION)
     }
 
     /// Decode FIT payload and apply delta decompression.

--- a/thetadatadx-rs/src/fpss/io_loop/mod.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/mod.rs
@@ -478,9 +478,8 @@ pub(in crate::fpss) struct IoLoopArgs<P> {
     /// Mirrors [`crate::config::ReconnectConfig::replay_pace_ms`].
     pub replay_pace_ms: u64,
     pub creds: Credentials,
-    /// Declared FPSS host list. Reconnect re-applies the configured
-    /// selection policy to this list, optionally pinning the last
-    /// stable host first.
+    /// Declared FPSS host list. A reconnect walks it in declared order,
+    /// pinning the last stable host first.
     pub hosts: Vec<(String, u16)>,
     pub active_subs: ActiveSubs,
     pub active_full_subs: ActiveFullSubs,
@@ -1344,8 +1343,8 @@ where
 
         // --- Attempt new TLS connection and re-authenticate ---
         // Pin the most recent host that survived the stable window,
-        // then re-apply the configured policy to the remaining hosts.
-        // Cold connects and unstable sessions stay pure-policy.
+        // then walk the remaining hosts in declared order. Cold connects
+        // and unstable sessions use pure declared order.
         let new_stream = {
             let ordered_hosts = connection::order_hosts(&hosts, last_known_good_host);
             let ordered: Vec<(&str, u16)> = ordered_hosts
@@ -1792,7 +1791,8 @@ where
         }
 
         // Replay is proven on the fresh socket: re-subscribe and the
-        // queued-command drain both wrote and flushed without error. ONLY
+        // queued-command drain both wrote without error (control frames
+        // flush on the next ping; a broken socket surfaces on the write). ONLY
         // now is the session marked live and the success announced. Doing
         // this here (rather than right after login) is the invariant that
         // keeps a socket which accepted the login but broke on the next

--- a/thetadatadx-rs/src/fpss/io_loop/ping.rs
+++ b/thetadatadx-rs/src/fpss/io_loop/ping.rs
@@ -183,8 +183,8 @@ mod tests {
         });
 
         // Skip the 2 s startup grace, then drain pings for 600 ms.
-        // At 250 ms cadence we expect ~2-3 pings; at the legacy
-        // hardcoded 100 ms cadence we'd see ~6.
+        // At 250 ms cadence we expect ~2-3 pings; at the 100 ms default
+        // cadence we'd see ~6.
         let start = Instant::now();
         let deadline = start + Duration::from_millis(2_000) + Duration::from_millis(600);
         let mut count = 0usize;

--- a/thetadatadx-rs/src/fpss/mod.rs
+++ b/thetadatadx-rs/src/fpss/mod.rs
@@ -1077,7 +1077,6 @@ impl StreamingClient {
                 i64::from(*crate::config::streaming_bounds::KEEPALIVE_RETRIES.end()),
             ));
         }
-        // Apply the host-selection policy once for the cold connect.
         // Cold connect: walk the declared host order left to right.
         let ordered_hosts = connection::order_hosts(hosts, None);
         let keepalive = connection::TcpKeepaliveSpec {
@@ -1134,9 +1133,9 @@ impl StreamingClient {
 
     /// Connect using a pre-established stream (for testing with mock sockets).
     ///
-    /// `hosts` is the declared FPSS server list, needed for auto-reconnect to
-    /// re-apply the host-selection policy. Pass an empty slice to disable
-    /// reconnection to other servers.
+    /// `hosts` is the declared FPSS server list, walked in declared order on
+    /// auto-reconnect. Pass an empty slice to disable reconnection to other
+    /// servers.
     ///
     /// Returns the connected client with its internal poller bundled
     /// in; drain via [`Self::next_event`] / [`Self::poll_batch`] /

--- a/thetadatadx-ts/__tests__/config_resilience.test.mjs
+++ b/thetadatadx-ts/__tests__/config_resilience.test.mjs
@@ -69,7 +69,7 @@ test("streaming transport defaults and round-trip", () => {
   const cfg = Config.production();
   assert.equal(cfg.streamingTimeoutMs, 10_000n);
   assert.equal(cfg.streamingConnectTimeoutMs, 2_000n);
-  assert.equal(cfg.streamingPingIntervalMs, 250n);
+  assert.equal(cfg.streamingPingIntervalMs, 100n);
   assert.equal(cfg.streamingRingSize, 131_072n);
   assert.equal(cfg.streamingIoReadSliceMs, 25n);
   assert.equal(cfg.streamingKeepaliveIdleSecs, 5n);

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -302,9 +302,9 @@ export declare class Config {
   setStreamingConnectTimeoutMs(ms: bigint): void
   /** Current `streaming.connect_timeout_ms` value (default `2_000n`). */
   get streamingConnectTimeoutMs(): bigint
-  /** Set the streaming heartbeat ping interval (ms). Default `250n`; validated to `[100, 300_000]` at connect. */
+  /** Set the streaming heartbeat ping interval (ms). Default `100n`; validated to `[100, 300_000]` at connect. */
   setStreamingPingIntervalMs(ms: bigint): void
-  /** Current `streaming.ping_interval_ms` value (default `250n`). */
+  /** Current `streaming.ping_interval_ms` value (default `100n`). */
   get streamingPingIntervalMs(): bigint
   /** Set the per-iteration blocking-read slice (ms) for the streaming I/O loop. Default `25n`; validated to `[10, 500]` at connect. */
   setStreamingIoReadSliceMs(ms: bigint): void

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -196,7 +196,7 @@ impl Config {
         Ok(napi::bindgen_prelude::BigInt::from(guard.streaming.connect_timeout_ms))
     }
 
-    /// Set the streaming heartbeat ping interval (ms). Default `250n`; validated to `[100, 300_000]` at connect.
+    /// Set the streaming heartbeat ping interval (ms). Default `100n`; validated to `[100, 300_000]` at connect.
     #[napi(js_name = "setStreamingPingIntervalMs")]
     pub fn set_streaming_ping_interval_ms(&self, ms: napi::bindgen_prelude::BigInt) -> napi::Result<()> {
         let value = bigint_to_u64("setStreamingPingIntervalMs", &ms)?;
@@ -208,7 +208,7 @@ impl Config {
         Ok(())
     }
 
-    /// Current `streaming.ping_interval_ms` value (default `250n`).
+    /// Current `streaming.ping_interval_ms` value (default `100n`).
     #[napi(getter, js_name = "streamingPingIntervalMs")]
     pub fn streaming_ping_interval_ms(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
         let guard = self


### PR DESCRIPTION
Terminal-parity corrections surfaced by a fable + codex audit of everything since v0.1.1 (the flush_mode / host_selection / JitterMode removals + snapshot fix), traced against the decompiled terminal. Both auditors confirmed the removals themselves are sound; these are the real gaps they found.

## Parity fixes

- **`ping_interval_ms` default `250` → `100`.** The terminal pings on a fixed 100 ms period (`FPSSClient.startPinging`: `scheduleAtFixedRate(task, 2000L, 100L)`); the SDK had diverged to 250 ms. With `flush_mode` gone the ping is the *only* flush trigger for queued outbound control frames, so this default now bounds subscribe / unsubscribe latency at the terminal's 100 ms. The knob and its `[100, 300_000]` range are unchanged.
- **Restore the post-STOP warn-suppression window** (`fpss/delta.rs`, `fpss/decode.rs`). A prior cleanup removed the 5 s post-STOP suppression of "unknown contract_id" warnings as "invented complexity" — but the terminal has exactly this (`if now - lastStop > 5000L` gating its "No … contract for ID" logs). Restored and annotated as terminal-derived so it is not re-removed.

## Doc / comment corrections

- CHANGELOG jitter note was wrong: it claimed C-ABI code `1` is rejected, but the encoding renumbered — `1` now means `None` (was `Equal`), so a legacy C caller passing `1` silently gets *no jitter*. Corrected + added a config-file migration note (old `config.toml` keys now fail to load with a typed error).
- Comments misattributed the last-known-good host promotion to the terminal (it's an SDK-only reconnect choice — the terminal rebuilds and walks declared order); removed stale "selection policy" comments from the host_selection removal; stopped overstating that the reconnect drain flushes non-ping frames.

## Verification

Rust lib 1066 tests pass (config default now 100, restored post-STOP window, ping pacing); FFI suite passes (ping/reconnect/retry defaults disambiguated); Python/TypeScript clippy clean. `check_binding_parity` clean + `--selftest` 209/0; `generate_docs_site --check` + `generate_sdk_surfaces --check` pass (llms.txt regenerated); doc-defaults / docs-consistency / vocab gates pass; changelogs byte-identical.
