### PR TITLE
refactor(mdds): forward list order and interval verbatim, matching the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Config-file migration.** A `config.toml` that still sets `flush_mode`, `streaming.host_selection`, `streaming.host_shuffle_seed`, or a `reconnect_jitter` of `"equal"` / `"decorrelated"` now fails to load with a typed error rather than being silently ignored — remove those keys / values when upgrading.
 
+- **`QuoteTick.midpoint` derived column.** Removed from every binding (Python `QuoteTick.midpoint`, TypeScript `QuoteTick.midpoint`, C `ThetaDataDxQuoteTick.midpoint`, and the Arrow / Polars `midpoint` column). The quote wire carries `bid` and `ask`; `midpoint` was an SDK-computed `(bid + ask) / 2` column the server never sends and the terminal never exposes — compute it from `bid` / `ask` at the call site if you need it. The `IvTick.midpoint` field is a real wire column and is unaffected. This is a breaking change to the quote tick schema.
+
+- **List endpoints now preserve wire order.** `list_*` results (roots / symbols, expirations, strikes, dates) come back in the server's row order rather than re-sorted ascending by the SDK. The terminal streams these lists in wire order untouched; the SDK's numeric-aware ascending sort had no terminal counterpart. Sort client-side if you need a specific order. This is a behavioral change to the `list_*` returns.
+
+- **`interval` is forwarded verbatim.** The `interval` argument is no longer snapped to the nearest preset: a raw-millisecond value such as `"250"` or `"60000"` is now rejected client-side rather than silently mapped to `"500ms"` / `"1m"`. The server accepts only the closed preset enum (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`); the SDK now forwards the string as-is and validates against that set. Pass an explicit preset. This is a breaking change to the `interval` parameter.
+
 ## [0.1.1] - 2026-07-07
 
 ### Added

--- a/docs-site/docs/articles/symbology.md
+++ b/docs-site/docs/articles/symbology.md
@@ -29,7 +29,7 @@ Strikes are dollars across every surface, including the bundled server's [WebSoc
 - Dates are `YYYYMMDD` strings (`"20250303"`). The HTTP server also accepts ISO `YYYY-MM-DD`.
 - Date ranges are inclusive on both ends.
 - Time-of-day inputs (`start_time`, `end_time`, `time_of_day`) are Eastern Time wall-clock `HH:MM:SS` (at-time endpoints take milliseconds: `HH:MM:SS.SSS`).
-- `interval` accepts a preset (`1s`, `1m`, `1h`, …) or a millisecond count as a string (`"60000"`).
+- `interval` is one of the presets: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
 
 ## Timestamps out
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Config-file migration.** A `config.toml` that still sets `flush_mode`, `streaming.host_selection`, `streaming.host_shuffle_seed`, or a `reconnect_jitter` of `"equal"` / `"decorrelated"` now fails to load with a typed error rather than being silently ignored — remove those keys / values when upgrading.
 
+- **`QuoteTick.midpoint` derived column.** Removed from every binding (Python `QuoteTick.midpoint`, TypeScript `QuoteTick.midpoint`, C `ThetaDataDxQuoteTick.midpoint`, and the Arrow / Polars `midpoint` column). The quote wire carries `bid` and `ask`; `midpoint` was an SDK-computed `(bid + ask) / 2` column the server never sends and the terminal never exposes — compute it from `bid` / `ask` at the call site if you need it. The `IvTick.midpoint` field is a real wire column and is unaffected. This is a breaking change to the quote tick schema.
+
+- **List endpoints now preserve wire order.** `list_*` results (roots / symbols, expirations, strikes, dates) come back in the server's row order rather than re-sorted ascending by the SDK. The terminal streams these lists in wire order untouched; the SDK's numeric-aware ascending sort had no terminal counterpart. Sort client-side if you need a specific order. This is a behavioral change to the `list_*` returns.
+
+- **`interval` is forwarded verbatim.** The `interval` argument is no longer snapped to the nearest preset: a raw-millisecond value such as `"250"` or `"60000"` is now rejected client-side rather than silently mapped to `"500ms"` / `"1m"`. The server accepts only the closed preset enum (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`); the SDK now forwards the string as-is and validates against that set. Pass an explicit preset. This is a breaking change to the `interval` parameter.
+
 ## [0.1.1] - 2026-07-07
 
 ### Added

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -11,7 +11,7 @@ info:
     bindings backed by the same Rust core.
 
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
-    Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
+    Intervals are one of the presets: tick, 10ms, 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
   version: 0.1.1
   contact:
@@ -152,7 +152,7 @@ x-anchors:
     required: true
     schema:
       type: string
-    description: 'Accepts milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.'
+    description: 'One of the interval presets: tick, 10ms, 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.'
 
   time_of_day-param: &time_of_day-param
     name: time_of_day
@@ -871,7 +871,7 @@ paths:
       summary: Stock intraday OHLC bars
       description: |
         Intraday OHLC bars. Supply `date` for a single day, or `start_date`/`end_date` for a date range on the same route.
-        Interval accepts milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
+        Interval is one of the presets: tick, 10ms, 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
         gRPC: GetStockHistoryOhlc
       tags: [Stock / History]
       parameters:
@@ -889,15 +889,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.market_data().stock_history_ohlc("AAPL").date("20240315").interval("60000").await?;
+            let bars = client.market_data().stock_history_ohlc("AAPL").date("20240315").interval("1m").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.market_data.stock_history_ohlc("AAPL", date="20240315", interval="60000")
+            bars = client.market_data.stock_history_ohlc("AAPL", date="20240315", interval="1m")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.market_data().stock_history_ohlc("AAPL", thetadatadx::EndpointRequestOptions{}.with_date("20240315").with_interval("60000"));
+            auto bars = client.market_data().stock_history_ohlc("AAPL", thetadatadx::EndpointRequestOptions{}.with_date("20240315").with_interval("1m"));
 
   /v3/stock/history/trade:
     x-min-subscription: standard
@@ -975,15 +975,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.market_data().stock_history_quote("AAPL").date("20240315").interval("60000").await?;
+            let quotes = client.market_data().stock_history_quote("AAPL").date("20240315").interval("1m").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.market_data.stock_history_quote("AAPL", date="20240315", interval="60000")
+            quotes = client.market_data.stock_history_quote("AAPL", date="20240315", interval="1m")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.market_data().stock_history_quote("AAPL", thetadatadx::EndpointRequestOptions{}.with_date("20240315").with_interval("60000"));
+            auto quotes = client.market_data().stock_history_quote("AAPL", thetadatadx::EndpointRequestOptions{}.with_date("20240315").with_interval("1m"));
   /v3/stock/history/trade_quote:
     x-min-subscription: standard
     get:
@@ -1772,15 +1772,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.market_data().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let bars = client.market_data().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.market_data.option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000")
+            bars = client.market_data.option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.market_data().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto bars = client.market_data().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "1m");
 
   /v3/option/history/trade:
     x-min-subscription: standard
@@ -1866,15 +1866,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.market_data().option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let quotes = client.market_data().option_history_quote("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.market_data.option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000")
+            quotes = client.market_data.option_history_quote("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.market_data().option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto quotes = client.market_data().option_history_quote("SPY", "20240419", "500", "C", "20240315", "1m");
   /v3/option/history/trade_quote:
     x-min-subscription: standard
     get:
@@ -2052,15 +2052,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let greeks = client.market_data().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let greeks = client.market_data().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            greeks = client.market_data.option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000")
+            greeks = client.market_data.option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto greeks = client.market_data().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto greeks = client.market_data().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "1m");
 
   /v3/option/history/greeks/first_order:
     x-min-subscription: standard
@@ -2103,15 +2103,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g1 = client.market_data().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let g1 = client.market_data().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            g1 = client.market_data.option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000")
+            g1 = client.market_data.option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto g1 = client.market_data().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto g1 = client.market_data().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "1m");
 
   /v3/option/history/greeks/second_order:
     x-min-subscription: professional
@@ -2154,15 +2154,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g2 = client.market_data().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let g2 = client.market_data().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            g2 = client.market_data.option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000")
+            g2 = client.market_data.option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto g2 = client.market_data().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto g2 = client.market_data().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "1m");
 
   /v3/option/history/greeks/third_order:
     x-min-subscription: professional
@@ -2205,15 +2205,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g3 = client.market_data().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let g3 = client.market_data().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            g3 = client.market_data.option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000")
+            g3 = client.market_data.option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto g3 = client.market_data().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto g3 = client.market_data().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "1m");
 
   /v3/option/history/greeks/implied_volatility:
     x-min-subscription: standard
@@ -2256,15 +2256,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let iv = client.market_data().option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let iv = client.market_data().option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            iv = client.market_data.option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000")
+            iv = client.market_data.option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto iv = client.market_data().option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto iv = client.market_data().option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "1m");
 
   # =========================================================================
   # OPTION / HISTORY TRADE GREEKS
@@ -2799,15 +2799,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.market_data().index_history_ohlc("SPX", "20240101", "20240301", "60000").await?;
+            let bars = client.market_data().index_history_ohlc("SPX", "20240101", "20240301", "1m").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.market_data.index_history_ohlc("SPX", "20240101", "20240301", "60000")
+            bars = client.market_data.index_history_ohlc("SPX", "20240101", "20240301", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.market_data().index_history_ohlc("SPX", "20240101", "20240301", "60000");
+            auto bars = client.market_data().index_history_ohlc("SPX", "20240101", "20240301", "1m");
 
   /v3/index/history/price:
     x-min-subscription: value
@@ -2842,15 +2842,15 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let prices = client.market_data().index_history_price("SPX", "20240315", "60000").await?;
+            let prices = client.market_data().index_history_price("SPX", "20240315", "1m").await?;
         - lang: python
           label: Python
           source: |
-            prices = client.market_data.index_history_price("SPX", "20240315", "60000")
+            prices = client.market_data.index_history_price("SPX", "20240315", "1m")
         - lang: cpp
           label: C++
           source: |
-            auto prices = client.market_data().index_history_price("SPX", "20240315", "60000");
+            auto prices = client.market_data().index_history_price("SPX", "20240315", "1m");
 
   # =========================================================================
   # INDEX / AT-TIME

--- a/docs-site/docs/reference/index/history/ohlc.md
+++ b/docs-site/docs/reference/index/history/ohlc.md
@@ -41,7 +41,7 @@ Fetch intraday OHLC bars for an index.
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `start_date` | date | yes | — | Start date YYYYMMDD |
 | `end_date` | date | yes | — | End date YYYYMMDD |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `timeout_ms` | int | no | — | Per-request deadline in milliseconds. 0 means no deadline. |

--- a/docs-site/docs/reference/index/history/price.md
+++ b/docs-site/docs/reference/index/history/price.md
@@ -41,7 +41,7 @@ Fetch intraday price history for an index.
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `start_date` | date | no | — | Start date YYYYMMDD |

--- a/docs-site/docs/reference/option/history/greeks/all.md
+++ b/docs-site/docs/reference/option/history/greeks/all.md
@@ -44,7 +44,7 @@ Fetch all Greeks history for an option contract (intraday, sampled by interval).
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/greeks/first-order.md
@@ -44,7 +44,7 @@ Fetch first-order Greeks history (intraday, sampled by interval).
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/greeks/implied-volatility.md
@@ -43,7 +43,7 @@ Fetch implied volatility history (intraday, sampled by interval).
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/greeks/second-order.md
@@ -44,7 +44,7 @@ Fetch second-order Greeks history (intraday, sampled by interval).
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/greeks/third-order.md
@@ -44,7 +44,7 @@ Fetch third-order Greeks history (intraday, sampled by interval).
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `annual_dividend` | float | no | — | Annualized expected dividend amount, in dollars per share, used in the Greeks calculation (e.g. 2.5 is $2.50 per share per year). |

--- a/docs-site/docs/reference/option/history/ohlc.md
+++ b/docs-site/docs/reference/option/history/ohlc.md
@@ -43,7 +43,7 @@ Fetch intraday OHLC bars for an option contract.
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `strike_range` | int | no | — | Strike range filter |

--- a/docs-site/docs/reference/option/history/quote.md
+++ b/docs-site/docs/reference/option/history/quote.md
@@ -43,7 +43,7 @@ Fetch NBBO quotes for an option contract on a given date.
 | `strike` | string | no | `*` | Strike price in dollars as a string (e.g. 500 or 17.5). Use `*` for wildcard selection. |
 | `right` | string | no | `both` | Option side. Use `both` or `*` (alias) for calls and puts. Accepted values: `call`, `put`, `both`, `*`. |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `max_dte` | int | no | — | Maximum days to expiration |

--- a/docs-site/docs/reference/stock/history/ohlc.md
+++ b/docs-site/docs/reference/stock/history/ohlc.md
@@ -40,7 +40,7 @@ Fetch intraday OHLC bars for a stock on a single date.
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `venue` | string | no | `nqb` | Venue/exchange filter. Accepted values: `nqb`, `utp_cta`. |

--- a/docs-site/docs/reference/stock/history/quote.md
+++ b/docs-site/docs/reference/stock/history/quote.md
@@ -41,7 +41,7 @@ Fetch NBBO quotes for a stock on a given date at a given interval.
 |---|---|---|---|---|
 | `symbol` | string | yes | — | Ticker symbol (e.g. AAPL) |
 | `date` | date | no | — | Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. |
-| `interval` | string | no | `1s` | Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
+| `interval` | string | no | `1s` | Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. |
 | `start_time` | string | no | `09:30:00` | Start time filter |
 | `end_time` | string | no | `16:00:00` | End time filter |
 | `venue` | string | no | `nqb` | Venue/exchange filter. Accepted values: `nqb`, `utp_cta`. |

--- a/thetadatadx-cpp/include/endpoint_options.hpp.inc
+++ b/thetadatadx-cpp/include/endpoint_options.hpp.inc
@@ -22,7 +22,7 @@ struct EndpointRequestOptions {
     std::optional<std::string> min_time;
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     std::optional<std::string> date;
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     std::optional<std::string> interval;
     /// Start time filter
     std::optional<std::string> start_time;

--- a/thetadatadx-ffi/src/endpoint_request_options.rs
+++ b/thetadatadx-ffi/src/endpoint_request_options.rs
@@ -17,7 +17,7 @@ pub struct ThetaDataDxEndpointRequestOptions {
     pub min_time: *const c_char,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: *const c_char,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: *const c_char,
     /// Start time filter
     pub start_time: *const c_char,

--- a/thetadatadx-rs/build_support/endpoints/proto_parser.rs
+++ b/thetadatadx-rs/build_support/endpoints/proto_parser.rs
@@ -246,7 +246,7 @@ fn map_field(name: &str, proto_type: &str, is_repeated: bool) -> (String, String
         ("string", "date") => ("Date".into(), "Date YYYYMMDD".into()),
         ("string", "interval") => (
             "Interval".into(),
-            "Accepts milliseconds (60000) or shorthand (1m). Presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.".into(),
+            "One of the interval presets: tick, 10ms, 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.".into(),
         ),
         ("string", "right") => ("Right".into(), "C for call, P for put".into()),
         ("string", "strike") => (

--- a/thetadatadx-rs/build_support/endpoints/render/mdds.rs
+++ b/thetadatadx-rs/build_support/endpoints/render/mdds.rs
@@ -544,7 +544,6 @@ pub(super) fn mdds_query_field_expr(
                 format!("vec![{arg_name}.clone()]")
             }
         }
-        "interval" => format!("normalize_interval(&{arg_name})"),
         "time_of_day" => format!("normalize_time_of_day(&{arg_name})"),
         // Date-semantic wire fields. The validators accept both
         // `YYYYMMDD` and `YYYY-MM-DD`; the wire contract is the compact

--- a/thetadatadx-rs/endpoint_surface.toml
+++ b/thetadatadx-rs/endpoint_surface.toml
@@ -192,7 +192,7 @@ binding = "builder"
 
 [[param_groups.interval.params]]
 name = "interval"
-description = "Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library."
+description = "Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library."
 param_type = "Interval"
 enum = "Interval"
 required = false

--- a/thetadatadx-rs/endpoint_surface.toml
+++ b/thetadatadx-rs/endpoint_surface.toml
@@ -1884,7 +1884,7 @@ category_symbol = { stock = "AAPL", option = "SPY", index = "SPX", rate = "SOFR"
 # `category_symbol` above, and params listed in `concrete_overrides` below.
 # 20250303 is a Monday the pinned upstream snapshot confirms is a trading day
 # for every category we emit cells for.
-concrete_by_type = { Date = "20250303", Expiration = "20250321", Strike = "570", Right = "C", Interval = "60000", RequestType = "TRADE", Year = "2025", Str = "12:00:00.000" }
+concrete_by_type = { Date = "20250303", Expiration = "20250321", Strike = "570", Right = "C", Interval = "1m", RequestType = "TRADE", Year = "2025", Str = "12:00:00.000" }
 
 # Per-param-name overrides that beat `concrete_by_type`. Used to compress
 # date ranges so bulk cells stack multiple 60s timeouts without blowing the

--- a/thetadatadx-rs/src/mdds/decode/extract.rs
+++ b/thetadatadx-rs/src/mdds/decode/extract.rs
@@ -90,8 +90,7 @@ pub fn extract_number_column(table: &proto::DataTable, header: &str) -> Vec<Opti
 /// `list_dates` / `list_expirations` carry `YYYYMMDD` values as
 /// `Number` cells and `list_strikes` carries the strike as a `Number`
 /// or `Price` cell, yet every binding presents these lists as
-/// `Vec<String>` with a numeric-aware sort (see [`sorted_list_values`]).
-/// Rejecting numeric cells here would break those endpoints on every
+/// `Vec<String>`. Rejecting numeric cells here would break those endpoints on every
 /// call, so the coercion is intentional rather than a swallowed drift.
 ///
 /// To keep an unexpected numeric cell observable (a text column that
@@ -286,61 +285,9 @@ pub fn response_symbol(table: &proto::DataTable) -> ResponseSymbol {
     )
 }
 
-/// Sort list-endpoint values ascending for the public `list_*` returns.
-///
-/// Numeric-aware: when every value parses as a finite `f64` (strikes,
-/// dates, expirations) the sort is numeric — a lexicographic sort would
-/// order `"1000"` before `"320"`. Otherwise (symbols, roots) the sort
-/// is lexicographic. The wire returns these lists unsorted; one
-/// deterministic ascending order on every binding is part of the
-/// public contract.
-#[must_use]
-pub fn sorted_list_values(mut values: Vec<String>) -> Vec<String> {
-    let all_numeric = !values.is_empty()
-        && values
-            .iter()
-            .all(|v| v.parse::<f64>().is_ok_and(f64::is_finite));
-    if all_numeric {
-        values.sort_by(|a, b| {
-            // The `all_numeric` gate already proved every element parses
-            // as a finite `f64`, and `values` is not mutated between that
-            // check and this sort, so the `unwrap_or` fallbacks are
-            // unreachable; they keep the comparator total without
-            // re-introducing the gate's invariant as a `expect`.
-            let a: f64 = a.parse().unwrap_or(f64::MAX);
-            let b: f64 = b.parse().unwrap_or(f64::MAX);
-            a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        values.sort();
-    }
-    values
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn sorted_list_values_orders_numeric_strings_numerically() {
-        let values = vec!["661", "725", "320", "789", "1000", "640"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-        assert_eq!(
-            sorted_list_values(values),
-            vec!["320", "640", "661", "725", "789", "1000"]
-        );
-    }
-
-    #[test]
-    fn sorted_list_values_orders_symbols_lexicographically() {
-        let values = vec!["MSFT", "AAPL", "SPY"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-        assert_eq!(sorted_list_values(values), vec!["AAPL", "MSFT", "SPY"]);
-    }
 
     /// `extract_text_column` must resolve the schema-side `root`
     /// against an upstream-renamed `symbol` column via

--- a/thetadatadx-rs/src/mdds/decode/mod.rs
+++ b/thetadatadx-rs/src/mdds/decode/mod.rs
@@ -39,7 +39,7 @@ pub use extract::{extract_number_column, extract_price_column};
 // broadcast / per-row) so the offline decode bench projects the leading
 // `symbol` column exactly as the live collector does; workspace bindings reach
 // it via `__internal`.
-pub use extract::{extract_text_column, sorted_list_values};
+pub use extract::extract_text_column;
 #[cfg(feature = "__internal")]
 pub use extract::{response_symbol, ResponseSymbol};
 // `decode_data_table` and `decompress_response` (non-`_with_max` variants)

--- a/thetadatadx-rs/src/mdds/endpoints.rs
+++ b/thetadatadx-rs/src/mdds/endpoints.rs
@@ -100,59 +100,6 @@ impl From<&[String]> for SymbolInput {
 // from `wire_semantics` above are shared with build-time code via
 // `#[path]` reuse and stay out of this file.
 
-/// Convert an interval to the format the MDDS server accepts.
-///
-/// Users can pass either:
-/// - Shorthand directly: `"tick"`, `"10ms"`, `"100ms"`, `"500ms"`,
-///   `"1s"`, `"5s"`, `"10s"`, `"15s"`, `"30s"`, `"1m"`, `"5m"`,
-///   `"10m"`, `"15m"`, `"30m"`, `"1h"`.
-/// - Milliseconds as a string (e.g. `"60000"` or `"300000"`). Values
-///   are snapped to the nearest documented preset.
-///
-/// The full upstream enum is reproduced verbatim in
-/// `docs.thetadata.us/operations/option_history_quote.html` (and every
-/// other endpoint with an `interval` parameter). The enum tops out at
-/// `1h`: larger shorthand (`2h` / `4h` / `1d`) is rejected by the
-/// service with `Invalid interval` (verified live), so millisecond
-/// inputs past one hour snap DOWN to `1h` — the largest legal bar —
-/// rather than forwarding a string the upstream cannot serve. Daily
-/// bars come from the `*_history_eod` endpoints.
-///
-/// The `"0"` sentinel snaps to `"tick"` — the upstream every-event
-/// vocabulary — so the zero input maps to every-event sampling rather
-/// than a silent fixed-bar default. Callers wanting a fixed bar should
-/// pass an explicit preset.
-fn normalize_interval(interval: &str) -> String {
-    if interval.ends_with('s') || interval.ends_with('m') || interval.ends_with('h') {
-        return interval.to_string();
-    }
-    if interval == "tick" {
-        return "tick".to_string();
-    }
-
-    match interval.parse::<u64>() {
-        Ok(ms) => match ms {
-            0 => "tick".to_string(),
-            1..=10 => "10ms".to_string(),
-            11..=100 => "100ms".to_string(),
-            101..=500 => "500ms".to_string(),
-            501..=1000 => "1s".to_string(),
-            1_001..=5_000 => "5s".to_string(),
-            5_001..=10_000 => "10s".to_string(),
-            10_001..=15_000 => "15s".to_string(),
-            15_001..=30_000 => "30s".to_string(),
-            30_001..=60_000 => "1m".to_string(),
-            60_001..=300_000 => "5m".to_string(),
-            300_001..=600_000 => "10m".to_string(),
-            600_001..=900_000 => "15m".to_string(),
-            900_001..=1_800_000 => "30m".to_string(),
-            _ => "1h".to_string(),
-        },
-        // Not a number -- pass through and let the server decide.
-        Err(_) => interval.to_string(),
-    }
-}
-
 /// Convert `time_of_day` values into the canonical `HH:MM:SS.SSS` format.
 ///
 /// ThetaData's v3 at-time endpoints expect a formatted ET wall-clock time
@@ -282,47 +229,5 @@ mod tests {
         assert_eq!(normalize_time_of_day("86400000"), "86400000");
         assert_eq!(normalize_time_of_day("09:61"), "09:61");
         assert_eq!(normalize_time_of_day("not-a-time"), "not-a-time");
-    }
-
-    #[test]
-    fn normalize_interval_passes_shorthand_through() {
-        assert_eq!(normalize_interval("tick"), "tick");
-        assert_eq!(normalize_interval("10ms"), "10ms");
-        assert_eq!(normalize_interval("1m"), "1m");
-        assert_eq!(normalize_interval("5m"), "5m");
-        assert_eq!(normalize_interval("1h"), "1h");
-    }
-
-    #[test]
-    fn normalize_interval_rounds_milliseconds_to_preset() {
-        assert_eq!(normalize_interval("60000"), "1m");
-        assert_eq!(normalize_interval("300000"), "5m");
-        assert_eq!(normalize_interval("900000"), "15m");
-        assert_eq!(normalize_interval("3600000"), "1h");
-        // Millisecond inputs past one hour snap DOWN to `1h`, the
-        // largest bar in the upstream enum — `2h` / `4h` / `1d` wire
-        // strings are rejected by the service with `Invalid interval`
-        // (verified live), so forwarding them would turn a servable
-        // request into an upstream failure.
-        assert_eq!(normalize_interval("7200000"), "1h");
-        assert_eq!(normalize_interval("86400000"), "1h");
-    }
-
-    #[test]
-    fn normalize_interval_snaps_zero_to_tick() {
-        // The upstream `tick` keyword is the every-event vocabulary, so
-        // the zero sentinel snaps to it (every-event sampling) rather
-        // than a fixed sub-second bar.
-        assert_eq!(normalize_interval("0"), "tick");
-    }
-
-    #[test]
-    fn normalize_interval_snaps_small_milliseconds_to_documented_presets() {
-        // 10ms-and-under -> 10ms; 11-100ms -> 100ms. Each sub-100ms
-        // input snaps to the nearest documented preset, including the
-        // 10ms bar.
-        assert_eq!(normalize_interval("10"), "10ms");
-        assert_eq!(normalize_interval("11"), "100ms");
-        assert_eq!(normalize_interval("100"), "100ms");
     }
 }

--- a/thetadatadx-rs/src/mdds/macros.rs
+++ b/thetadatadx-rs/src/mdds/macros.rs
@@ -711,14 +711,12 @@ macro_rules! list_endpoint_impl_body {
             ).await?;
             metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
                 .record(_metrics_start.elapsed().as_secs_f64() * 1_000.0);
-            // List returns are sorted ascending (numeric-aware for
-            // strike / date lists) — the wire order is unspecified.
-            Ok(decode::sorted_list_values(
-                decode::extract_text_column(&table, $col)
-                    .into_iter()
-                    .flatten()
-                    .collect(),
-            ))
+            // List returns preserve the server's row order verbatim
+            // (terminal parity — the wire order is the contract).
+            Ok(decode::extract_text_column(&table, $col)
+                .into_iter()
+                .flatten()
+                .collect())
         }).await
     }};
 }

--- a/thetadatadx-rs/src/mdds/mod.rs
+++ b/thetadatadx-rs/src/mdds/mod.rs
@@ -31,7 +31,7 @@
 //! - `stream` — gRPC response stream helpers (`collect_stream`, `for_each_chunk`)
 //! - `validate` — runtime parameter validators invoked by generated macros
 //! - `endpoints` — generated endpoint method bodies (`include!` sites);
-//!   wire-format canonicalizers (`normalize_interval`, `normalize_time_of_day`,
+//!   wire-format canonicalizers (`normalize_time_of_day`,
 //!   `contract_spec!`) live at the top of that file. The cross-cutting wire
 //!   helpers (`normalize_expiration`, `wire_strike_opt`, `wire_right_opt`)
 //!   live in the in-crate `wire_semantics` module.

--- a/thetadatadx-rs/src/mdds/validate.rs
+++ b/thetadatadx-rs/src/mdds/validate.rs
@@ -207,11 +207,9 @@ pub(crate) fn validate_symbol(value: &str, param_name: &str) -> Result<(), Endpo
 ///
 /// Mirrors the upstream enum at
 /// `https://docs.thetadata.us/operations/option_history_quote.html`.
-/// The SDK additionally accepts decimal millisecond shorthand
-/// (`"60000"`, `"300000"`, ...) and snaps it to the nearest preset via
-/// [`crate::mdds::endpoints::normalize_interval`]; this validator
-/// recognises both shapes so the CLI / MCP layer rejects garbage
-/// before the gRPC dispatch.
+/// This is a closed set: the server accepts these preset strings and
+/// nothing else, so the validator rejects anything outside it (including
+/// raw-millisecond shorthand) before the gRPC dispatch.
 ///
 /// Only compiled under `__internal` — used by `validate_interval`.
 ///
@@ -226,16 +224,17 @@ const VALID_INTERVAL_PRESETS: &[&str] = &[
     "30m", "1h",
 ];
 
-/// Validate an `interval` parameter against the upstream enum and the
-/// millisecond-shorthand shape.
+/// Validate an `interval` parameter against the upstream enum.
 ///
-/// Accepts any preset in [`VALID_INTERVAL_PRESETS`] or a positive integer
-/// of milliseconds (snapped to the nearest preset downstream).
+/// Accepts only the presets in [`VALID_INTERVAL_PRESETS`] — the closed
+/// set the server serves. The interval string is forwarded to the wire
+/// verbatim, so anything outside the enum is rejected here rather than
+/// silently reshaped.
 ///
 /// # Errors
 ///
 /// Returns [`EndpointError::InvalidParams`] when `value` is empty, names
-/// a bar size beyond the `1h` ceiling, or matches no accepted shape. The
+/// a bar size beyond the `1h` ceiling, or matches no preset. The
 /// beyond-`1h` case carries a diagnostic pointing at `1h` / the
 /// `*_history_eod` endpoints.
 ///
@@ -244,17 +243,11 @@ const VALID_INTERVAL_PRESETS: &[&str] = &[
 pub(crate) fn validate_interval(value: &str, param_name: &str) -> Result<(), EndpointError> {
     if value.is_empty() {
         return Err(EndpointError::InvalidParams(format!(
-            "'{param_name}' must be a non-empty string from the upstream enum ({}) or a millisecond value (e.g. '60000'), got empty string",
+            "'{param_name}' must be one of the upstream presets ({}), got empty string",
             VALID_INTERVAL_PRESETS.join(", "),
         )));
     }
     if VALID_INTERVAL_PRESETS.contains(&value) {
-        return Ok(());
-    }
-    if value.bytes().all(|b| b.is_ascii_digit()) {
-        // Millisecond shorthand: `normalize_interval` will snap to the
-        // nearest documented preset. Any positive integer is accepted
-        // here; the snap range covers `0` (-> "tick") through `1h`.
         return Ok(());
     }
     // Targeted diagnostic for multi-hour / daily / weekly shorthand
@@ -268,7 +261,7 @@ pub(crate) fn validate_interval(value: &str, param_name: &str) -> Result<(), End
         )));
     }
     Err(EndpointError::InvalidParams(format!(
-        "'{param_name}' must be one of the upstream presets ({}) or a millisecond value (e.g. '60000'), got: '{value}'",
+        "'{param_name}' must be one of the upstream presets ({}), got: '{value}'",
         VALID_INTERVAL_PRESETS.join(", "),
     )))
 }
@@ -576,12 +569,18 @@ mod internal_tests {
     }
 
     #[test]
-    fn interval_accepts_upstream_enum_and_ms_shorthand() {
+    fn interval_accepts_only_upstream_enum() {
         for good in [
             "tick", "10ms", "100ms", "500ms", "1s", "5s", "10s", "15s", "30s", "1m", "5m", "10m",
-            "15m", "30m", "1h", "0", "60000", "300000",
+            "15m", "30m", "1h",
         ] {
             assert!(validate_interval(good, "interval").is_ok(), "{good}");
+        }
+        // Raw-millisecond shorthand is not in the upstream enum — the
+        // wire forwards the interval verbatim, so these are rejected
+        // rather than snapped to a preset.
+        for bad in ["0", "60000", "300000", "250", "7"] {
+            assert!(validate_interval(bad, "interval").is_err(), "{bad}");
         }
     }
 

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -4149,7 +4149,7 @@ export interface IndexHistoryEodOptions {
  * returned Promise rejects and the underlying request is cancelled.
  */
 export interface IndexHistoryOhlcOptions {
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -4173,7 +4173,7 @@ export interface IndexHistoryOhlcOptions {
 export interface IndexHistoryPriceOptions {
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5023,7 +5023,7 @@ export interface OptionHistoryGreeksAllOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5099,7 +5099,7 @@ export interface OptionHistoryGreeksFirstOrderOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5141,7 +5141,7 @@ export interface OptionHistoryGreeksImpliedVolatilityOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5183,7 +5183,7 @@ export interface OptionHistoryGreeksSecondOrderOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5225,7 +5225,7 @@ export interface OptionHistoryGreeksThirdOrderOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5267,7 +5267,7 @@ export interface OptionHistoryOhlcOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -5331,7 +5331,7 @@ export interface OptionHistoryQuoteOptions {
   right?: string
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -6406,7 +6406,7 @@ export interface StockHistoryEodOptions {
 export interface StockHistoryOhlcOptions {
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date
@@ -6436,7 +6436,7 @@ export interface StockHistoryOhlcOptions {
 export interface StockHistoryQuoteOptions {
   /** Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range. */
   date?: string | Date
-  /** Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
+  /** Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`. */
   interval?: string
   /** Start time filter */
   startTime?: string | Date

--- a/thetadatadx-ts/src/_generated/market_data_methods.rs
+++ b/thetadatadx-ts/src/_generated/market_data_methods.rs
@@ -123,7 +123,7 @@ pub struct StockHistoryEODOptions {
 pub struct StockHistoryOHLCOptions {
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -177,7 +177,7 @@ pub struct StockHistoryTradeOptions {
 pub struct StockHistoryQuoteOptions {
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -663,7 +663,7 @@ pub struct OptionHistoryOHLCOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -727,7 +727,7 @@ pub struct OptionHistoryQuoteOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -855,7 +855,7 @@ pub struct OptionHistoryGreeksAllOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -935,7 +935,7 @@ pub struct OptionHistoryGreeksFirstOrderOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1015,7 +1015,7 @@ pub struct OptionHistoryGreeksSecondOrderOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1095,7 +1095,7 @@ pub struct OptionHistoryGreeksThirdOrderOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1175,7 +1175,7 @@ pub struct OptionHistoryGreeksImpliedVolatilityOptions {
     pub right: Option<String>,
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1383,7 +1383,7 @@ pub struct IndexHistoryEODOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct IndexHistoryOHLCOptions {
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
@@ -1405,7 +1405,7 @@ pub struct IndexHistoryOHLCOptions {
 pub struct IndexHistoryPriceOptions {
     /// Single date YYYYMMDD. Supply this for a single-day pull, or supply `start_date`/`end_date` for a range. When present, `date` takes precedence over the range.
     pub date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Interval preset or millisecond string. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
+    /// Interval preset. Defaults to `1s` when omitted — matching the upstream ThetaData Python library. Accepted values: `tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`.
     pub interval: Option<String>,
     /// Start time filter
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,

--- a/tools/server/src/validation.rs
+++ b/tools/server/src/validation.rs
@@ -259,7 +259,7 @@ pub fn validate_right(value: &str, field: &str) -> Result<(), ValidationError> {
     Ok(())
 }
 
-/// Validate an interval string (e.g. `"60000"` or `"1m"`).
+/// Validate an interval string (e.g. `"1m"` or `"tick"`).
 ///
 /// # Errors
 /// Returns a `ValidationError` when `value` exceeds [`MAX_INTERVAL_LEN`] or


### PR DESCRIPTION
The terminal REST layer is a pure pass-through (it streams the server DataTable in wire order and forwards the interval string unchanged). Two SDK behaviors diverged and are removed on terminal-parity grounds, verified against the decompiled terminal.

## List endpoints preserve wire order
`sorted_list_values` re-sorted every `list_*` return (roots / symbols, expirations, strikes, dates) into numeric-aware ascending order. The terminal streams these lists in wire order untouched (`AbstractGrpcBridge` iterates rows in received order), so the sort had no terminal counterpart. Lists now come back in server order.

## Interval forwarded verbatim
`normalize_interval` silently snapped an arbitrary millisecond string (`"250"` to `"500ms"`, `"60000"` to `"1m"`) to the nearest documented preset. The terminal forwards the interval string as-is and the server accepts only the closed preset enum, throwing on anything else. The codegen no longer wraps interval args, and `validate_interval` now rejects non-preset input (including raw milliseconds) client-side. Interval parameter docs regenerated to drop the millisecond-string mention.

## Changelog catch-up
Also adds the `[Unreleased]` entry for the `QuoteTick.midpoint` removal that shipped in the previous change without a note. All three land in the same 0.2.0 window.

Part of the ongoing terminal-parity work; the calendar `is_open` derived boolean follows separately (it is a POD-struct-layout change).