### PR TITLE
refactor(calendar): drop the derived CalendarDay.is_open column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`interval` is forwarded verbatim.** The `interval` argument is no longer snapped to the nearest preset: a raw-millisecond value such as `"250"` or `"60000"` is now rejected client-side rather than silently mapped to `"500ms"` / `"1m"`. The server accepts only the closed preset enum (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`); the SDK now forwards the string as-is and validates against that set. Pass an explicit preset. This is a breaking change to the `interval` parameter.
 
+- **`CalendarDay.is_open` derived boolean.** Removed from every binding (Python `CalendarDay.is_open`, TypeScript `CalendarDay.isOpen`, C `ThetaDataDxCalendarDay.is_open`, and the Arrow / Polars `is_open` column). The calendar wire carries a single day-type column; `is_open` was an SDK-derived boolean (`status in {open, early_close}`) that the terminal never exposes. Read `status` instead — it carries the full `open` / `early_close` / `full_close` / `weekend` vocabulary — and treat `open` / `early_close` as trading days. This is a breaking change to the calendar tick schema.
+
 ## [0.1.1] - 2026-07-07
 
 ### Added

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`interval` is forwarded verbatim.** The `interval` argument is no longer snapped to the nearest preset: a raw-millisecond value such as `"250"` or `"60000"` is now rejected client-side rather than silently mapped to `"500ms"` / `"1m"`. The server accepts only the closed preset enum (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`); the SDK now forwards the string as-is and validates against that set. Pass an explicit preset. This is a breaking change to the `interval` parameter.
 
+- **`CalendarDay.is_open` derived boolean.** Removed from every binding (Python `CalendarDay.is_open`, TypeScript `CalendarDay.isOpen`, C `ThetaDataDxCalendarDay.is_open`, and the Arrow / Polars `is_open` column). The calendar wire carries a single day-type column; `is_open` was an SDK-derived boolean (`status in {open, early_close}`) that the terminal never exposes. Read `status` instead — it carries the full `open` / `early_close` / `full_close` / `weekend` vocabulary — and treat `open` / `early_close` as trading days. This is a breaking change to the calendar tick schema.
+
 ## [0.1.1] - 2026-07-07
 
 ### Added

--- a/docs-site/docs/reference/calendar/on-date.md
+++ b/docs-site/docs/reference/calendar/on-date.md
@@ -12,7 +12,7 @@ const cfg = {
   method: { rust: "calendar_on_date", python: "calendar_on_date", ts: "calendarOnDate", cpp: "calendar_on_date" },
   required: [{ key: "date", type: "date", default: "20250303" }],
   optional: [],
-  print: ["date", "is_open", "status"],
+  print: ["date", "open_time", "close_time", "status"],
   returns: "CalendarDay",
 }
 </script>
@@ -44,7 +44,6 @@ Rows of `CalendarDay`:
 | Field | Type | Description |
 |---|---|---|
 | `date` | i32 | Calendar date as a YYYYMMDD integer. 0 when the server omits the column (single-day endpoints). |
-| `is_open` | bool | Whether the market trades at all on this date (true for open and early-close days). |
 | `open_time` | i32 | Market open time, milliseconds since midnight ET. |
 | `close_time` | i32 | Market close time, milliseconds since midnight ET. |
 | `status` | string | Vendor day classification: open, early_close, full_close, or weekend. |

--- a/docs-site/docs/reference/calendar/open-today.md
+++ b/docs-site/docs/reference/calendar/open-today.md
@@ -12,7 +12,7 @@ const cfg = {
   method: { rust: "calendar_open_today", python: "calendar_open_today", ts: "calendarOpenToday", cpp: "calendar_open_today" },
   required: [],
   optional: [],
-  print: ["date", "is_open", "status"],
+  print: ["date", "open_time", "close_time", "status"],
   returns: "CalendarDay",
 }
 </script>
@@ -42,7 +42,6 @@ Rows of `CalendarDay`:
 | Field | Type | Description |
 |---|---|---|
 | `date` | i32 | Calendar date as a YYYYMMDD integer. 0 when the server omits the column (single-day endpoints). |
-| `is_open` | bool | Whether the market trades at all on this date (true for open and early-close days). |
 | `open_time` | i32 | Market open time, milliseconds since midnight ET. |
 | `close_time` | i32 | Market close time, milliseconds since midnight ET. |
 | `status` | string | Vendor day classification: open, early_close, full_close, or weekend. |

--- a/docs-site/docs/reference/calendar/year.md
+++ b/docs-site/docs/reference/calendar/year.md
@@ -12,7 +12,7 @@ const cfg = {
   method: { rust: "calendar_year", python: "calendar_year", ts: "calendarYear", cpp: "calendar_year" },
   required: [{ key: "year", type: "string", default: "2025" }],
   optional: [],
-  print: ["date", "is_open", "status"],
+  print: ["date", "open_time", "close_time", "status"],
   returns: "CalendarDay",
 }
 </script>
@@ -44,7 +44,6 @@ Rows of `CalendarDay`:
 | Field | Type | Description |
 |---|---|---|
 | `date` | i32 | Calendar date as a YYYYMMDD integer. 0 when the server omits the column (single-day endpoints). |
-| `is_open` | bool | Whether the market trades at all on this date (true for open and early-close days). |
 | `open_time` | i32 | Market open time, milliseconds since midnight ET. |
 | `close_time` | i32 | Market close time, milliseconds since midnight ET. |
 | `status` | string | Vendor day classification: open, early_close, full_close, or weekend. |

--- a/parity.toml
+++ b/parity.toml
@@ -2478,12 +2478,6 @@ typescript = "i32"
 
 [[value_field]]
 class = "CalendarDay"
-name = "is_open"
-python = "bool"
-typescript = "bool"
-
-[[value_field]]
-class = "CalendarDay"
 name = "status"
 python = "String"
 typescript = "String"

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -65,15 +65,12 @@ typedef struct ThetaDataDxClient ThetaDataDxClient;
  * session open/close times and a THETADATADX_CALENDAR_STATUS_* day-type code. */
 THETADATADX_ALIGN64_BEGIN typedef struct {
     int32_t date;
-    /* C99 bool (1 byte): whether the market trades at all on this date
-     * (true for open and early-close days). 3 bytes padding follow. */
-    bool is_open;
     int32_t open_time;
     int32_t close_time;
     /* One of the THETADATADX_CALENDAR_STATUS_* codes; string form via
      * thetadatadx_calendar_status_name(). */
     int32_t status;
-    uint8_t _tail_padding[44];
+    uint8_t _tail_padding[48];
 } ThetaDataDxCalendarDay THETADATADX_ALIGN64_END;
 
 /* End-of-day OHLC + closing-quote tick (*_history_eod) -- one row per

--- a/thetadatadx-cpp/include/tick_layout_asserts.hpp.inc
+++ b/thetadatadx-cpp/include/tick_layout_asserts.hpp.inc
@@ -4,13 +4,11 @@ static_assert(sizeof(CalendarDay) == 64 && alignof(CalendarDay) == 64,
               "ThetaDataDxCalendarDay layout drifted from Rust");
 static_assert(offsetof(CalendarDay, date) == 0,
               "ThetaDataDxCalendarDay.date offset drifted from Rust");
-static_assert(offsetof(CalendarDay, is_open) == 4,
-              "ThetaDataDxCalendarDay.is_open offset drifted from Rust");
-static_assert(offsetof(CalendarDay, open_time) == 8,
+static_assert(offsetof(CalendarDay, open_time) == 4,
               "ThetaDataDxCalendarDay.open_time offset drifted from Rust");
-static_assert(offsetof(CalendarDay, close_time) == 12,
+static_assert(offsetof(CalendarDay, close_time) == 8,
               "ThetaDataDxCalendarDay.close_time offset drifted from Rust");
-static_assert(offsetof(CalendarDay, status) == 16,
+static_assert(offsetof(CalendarDay, status) == 12,
               "ThetaDataDxCalendarDay.status offset drifted from Rust");
 static_assert(sizeof(EodTick) == 128 && alignof(EodTick) == 64,
               "ThetaDataDxEodTick layout drifted from Rust");

--- a/thetadatadx-ffi/src/types.rs
+++ b/thetadatadx-ffi/src/types.rs
@@ -875,8 +875,7 @@ macro_rules! tick_array_to_arrow_ipc_projected {
         /// `rows` must point to `len` initialised `$tick` values valid for the
         /// call; `presence` must be a valid [`ThetaDataDxColumnPresence`] (its
         /// name pointers valid for the call), typically from
-        /// `thetadatadx_<tick>_present_columns`. For calendar rows, `is_open`
-        /// must contain a valid C `bool` value.
+        /// `thetadatadx_<tick>_present_columns`.
         #[no_mangle]
         pub unsafe extern "C" fn $fn_name(
             rows: *const $tick,

--- a/thetadatadx-py/src/_generated/tick_arrow.rs
+++ b/thetadatadx-py/src/_generated/tick_arrow.rs
@@ -18,7 +18,6 @@ pub(crate) fn arrow_schema_for_qualname(qualname: &str) -> Option<Arc<Schema>> {
     match qualname {
         "CalendarDay" => Some(Arc::new(Schema::new(vec![
             Field::new("date", DataType::Int32, false),
-            Field::new("is_open", DataType::Boolean, false),
             Field::new("open_time", DataType::Int32, false),
             Field::new("close_time", DataType::Int32, false),
             Field::new("status", DataType::Utf8, false),
@@ -501,7 +500,7 @@ pub(crate) fn record_batch_to_pyarrow_table(py: Python<'_>, batch: RecordBatch) 
 pub(crate) mod slice_arrow {
     use super::*;
     use super::tick;
-    use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray};
+    use arrow::array::{ArrayRef, Float64Array, Int32Array, Int64Array, StringArray};
     use arrow::array::RecordBatchOptions;
     use arrow::record_batch::RecordBatch;
     use arrow::datatypes::{DataType, Field, Schema};
@@ -510,18 +509,15 @@ pub(crate) mod slice_arrow {
     fn read_arrow_batch_from_calendar_day_slice_projected(ticks: &[tick::CalendarDay], present: &thetadatadx::columns::ColumnPresence) -> PyResult<RecordBatch> {
         let n = ticks.len();
         let has_date = present.contains("date");
-        let has_is_open = present.contains("is_open");
         let has_open_time = present.contains("open_time");
         let has_close_time = present.contains("close_time");
         let has_status = present.contains("status");
         let mut col_date: Vec<i32> = Vec::with_capacity(if has_date { n } else { 0 });
-        let mut col_is_open: Vec<bool> = Vec::with_capacity(if has_is_open { n } else { 0 });
         let mut col_open_time: Vec<i32> = Vec::with_capacity(if has_open_time { n } else { 0 });
         let mut col_close_time: Vec<i32> = Vec::with_capacity(if has_close_time { n } else { 0 });
         let mut col_status: Vec<String> = Vec::with_capacity(if has_status { n } else { 0 });
         for t in ticks {
             if has_date { col_date.push(t.date); }
-            if has_is_open { col_is_open.push(t.is_open); }
             if has_open_time { col_open_time.push(t.open_time); }
             if has_close_time { col_close_time.push(t.close_time); }
             if has_status { col_status.push(t.status.as_str().to_string()); }
@@ -538,10 +534,6 @@ pub(crate) mod slice_arrow {
         if has_date {
             fields.push(Field::new("date", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_date)) as ArrayRef);
-        }
-        if has_is_open {
-            fields.push(Field::new("is_open", DataType::Boolean, false));
-            columns.push(Arc::new(BooleanArray::from(col_is_open)) as ArrayRef);
         }
         if has_open_time {
             fields.push(Field::new("open_time", DataType::Int32, false));

--- a/thetadatadx-py/src/_generated/tick_classes.rs
+++ b/thetadatadx-py/src/_generated/tick_classes.rs
@@ -25,7 +25,6 @@ use arrow::record_batch::RecordBatch;
 #[derive(Clone)]
 pub(crate) struct CalendarDay {
     #[pyo3(get)] pub date: i32,
-    #[pyo3(get)] pub is_open: bool,
     #[pyo3(get)] pub open_time: i32,
     #[pyo3(get)] pub close_time: i32,
     #[pyo3(get)] pub status: String,
@@ -33,18 +32,17 @@ pub(crate) struct CalendarDay {
 #[pymethods]
 impl CalendarDay {
     #[new]
-    #[pyo3(signature = (*, date = 0i32, is_open = false, open_time = 0i32, close_time = 0i32, status = "full_close".to_string()))]
-    fn new(date: i32, is_open: bool, open_time: i32, close_time: i32, status: String) -> Self {
+    #[pyo3(signature = (*, date = 0i32, open_time = 0i32, close_time = 0i32, status = "full_close".to_string()))]
+    fn new(date: i32, open_time: i32, close_time: i32, status: String) -> Self {
         Self {
             date,
-            is_open,
             open_time,
             close_time,
             status,
         }
     }
     fn __repr__(&self) -> String {
-        format!("CalendarDay(date={}, is_open={}, open_time={}, close_time={}, status={:?})", self.date, self.is_open, self.open_time, self.close_time, self.status)
+        format!("CalendarDay(date={}, open_time={}, close_time={}, status={:?})", self.date, self.open_time, self.close_time, self.status)
     }
 }
 
@@ -1701,7 +1699,6 @@ impl CalendarDayList {
         for t in &ticks {
             inner.push(            tick::CalendarDay {
                 date: t.date,
-                is_open: t.is_open,
                 open_time: t.open_time,
                 close_time: t.close_time,
                 status: match thetadatadx::CalendarStatus::from_wire_text(&t.status) { Some(status) => status, None => return Err(pyo3::exceptions::PyValueError::new_err(format!("status must be one of open, early_close, full_close, weekend; got {:?}", t.status))) },
@@ -1757,7 +1754,6 @@ impl CalendarDayList {
         let t = &self.inner[resolved as usize];
         let obj =             CalendarDay {
                 date: t.date,
-                is_open: t.is_open,
                 open_time: t.open_time,
                 close_time: t.close_time,
                 status: t.status.as_str().to_string(),
@@ -1778,7 +1774,6 @@ impl CalendarDayList {
         for t in &self.inner {
             let obj =                 CalendarDay {
                     date: t.date,
-                    is_open: t.is_open,
                     open_time: t.open_time,
                     close_time: t.close_time,
                     status: t.status.as_str().to_string(),
@@ -1845,7 +1840,6 @@ impl CalendarDayListIter {
         self.cursor += 1;
         Some(            CalendarDay {
                 date: t.date,
-                is_open: t.is_open,
                 open_time: t.open_time,
                 close_time: t.close_time,
                 status: t.status.as_str().to_string(),
@@ -7038,7 +7032,6 @@ pub(crate) fn calendar_days_vec_to_pylist(py: Python<'_>, ticks: thetadatadx::Ti
     for t in &ticks {
         let obj =             CalendarDay {
                 date: t.date,
-                is_open: t.is_open,
                 open_time: t.open_time,
                 close_time: t.close_time,
                 status: t.status.as_str().to_string(),

--- a/thetadatadx-py/tests/test_typed_surface.py
+++ b/thetadatadx-py/tests/test_typed_surface.py
@@ -8,8 +8,7 @@ Pins the cross-binding type semantics on the Python surface:
   ``lambda``.
 * The fluent ``Contract`` builder takes the strike in dollars as a
   number or string, and reads the same dollar value back.
-* ``CalendarDay.status`` carries the vendor day-type vocabulary and
-  ``is_open`` is a boolean.
+* ``CalendarDay.status`` carries the vendor day-type vocabulary.
 * Absent contract identity on historical rows is ``None`` (the same
   convention the streaming ``ContractRef`` uses), and populated
   identity round-trips through Arrow as nullable columns.
@@ -104,16 +103,12 @@ def test_contract_stock_has_no_option_identity():
 
 
 def test_calendar_day_status_carries_vendor_vocabulary():
-    day = thetadatadx.CalendarDay(
-        date=20260102, is_open=True, status="early_close"
-    )
-    assert day.is_open is True
+    day = thetadatadx.CalendarDay(date=20260102, status="early_close")
     assert day.status == "early_close"
 
 
 def test_calendar_day_defaults_to_closed():
     day = thetadatadx.CalendarDay()
-    assert day.is_open is False
     assert day.status == "full_close"
 
 
@@ -125,15 +120,13 @@ def test_calendar_day_list_rejects_unknown_status_text():
         thetadatadx.CalendarDayList([bad])
 
 
-def test_calendar_day_arrow_status_is_string_and_is_open_boolean():
+def test_calendar_day_arrow_status_is_string():
     pyarrow = pytest.importorskip("pyarrow")
-    day = thetadatadx.CalendarDay(date=20260102, is_open=True, status="open")
+    day = thetadatadx.CalendarDay(date=20260102, status="open")
     table = thetadatadx.CalendarDayList([day]).to_arrow()
     schema = {f.name: str(f.type) for f in table.schema}
     assert schema["status"] == "string"
-    assert schema["is_open"] == "bool"
     assert table.column("status")[0].as_py() == "open"
-    assert table.column("is_open")[0].as_py() is True
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/thetadatadx-rs/build_support/ticks/parser.rs
+++ b/thetadatadx-rs/build_support/ticks/parser.rs
@@ -83,10 +83,8 @@ fn column_decoder(def: &TickTypeDef, col: &ColumnDef) -> (&'static str, &'static
         "String" => ("row_text", "String::new()"),
         // Logical char: `'\0'` is the absent fill (no contract right).
         "right" => ("row_contract_right", "'\\0'"),
-        "bool" => ("row_bool", "false"),
-        // Conservative absent fill: pairs with the `is_open: false`
-        // seed so a (never observed) type-less calendar row reads as a
-        // closed day rather than an open one.
+        // Conservative absent fill: a (never observed) type-less
+        // calendar row reads as a closed day rather than an open one.
         "calendar_status" => (
             "row_calendar_status",
             "crate::tdbe::CalendarStatus::FullClose",
@@ -255,9 +253,10 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
 /// The set names the public schema *field* (e.g. `condition_flags`,
 /// `expiration`) — the name the Arrow / Polars builders key on — not the
 /// wire spelling the alias table resolves. `CalendarDay` is the exception:
-/// the hand-written v3 parser maps the single `type` wire column to both
-/// `is_open` and `status`, so its generated impl delegates to the matching
-/// calendar-specific presence table instead of the generic first-claim helper.
+/// the hand-written v3 parser renames the wire columns (`type` -> `status`,
+/// `open`/`close` -> the time fields), so its generated impl delegates to the
+/// matching calendar-specific presence table instead of the generic
+/// first-claim helper.
 fn generate_present_columns(out: &mut String, type_name: &str, def: &TickTypeDef) {
     writeln!(out, "impl crate::columns::WireColumns for {type_name} {{").unwrap();
     out.push_str("    fn present_columns(headers: &[&str]) -> crate::columns::ColumnPresence {\n");

--- a/thetadatadx-rs/build_support_bin/endpoints/docs_render/response.rs
+++ b/thetadatadx-rs/build_support_bin/endpoints/docs_render/response.rs
@@ -41,7 +41,7 @@ pub(super) fn display_fields(collection: &str) -> &'static [&'static str] {
         "TradeGreeksImpliedVolatilityTicks" => &["ms_of_day", "price", "implied_volatility"],
         "PriceTicks" => &["date", "ms_of_day", "price"],
         "IndexPriceAtTimeTicks" => &["date", "ms_of_day", "price"],
-        "CalendarDays" => &["date", "is_open", "status"],
+        "CalendarDays" => &["date", "open_time", "close_time", "status"],
         "InterestRateTicks" => &["date", "rate"],
         "OptionContracts" => &["symbol", "expiration", "strike", "right"],
         other => panic!("no display fields declared for collection {other}"),

--- a/thetadatadx-rs/build_support_bin/ticks/python_arrow.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/python_arrow.rs
@@ -114,7 +114,7 @@ fn render_python_slice_to_arrow_converters(schema: &Schema) -> String {
     out.push_str("    use super::*;\n");
     out.push_str("    use super::tick;\n");
     out.push_str(
-        "    use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray};\n",
+        "    use arrow::array::{ArrayRef, Float64Array, Int32Array, Int64Array, StringArray};\n",
     );
     out.push_str("    use arrow::array::RecordBatchOptions;\n");
     out.push_str("    use arrow::record_batch::RecordBatch;\n");

--- a/thetadatadx-rs/build_support_bin/ticks/python_classes.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/python_classes.rs
@@ -593,9 +593,8 @@ fn render_python_tick_class_new(type_name: &str, def: &TickTypeDef) -> String {
     for column in &def.columns {
         let rust_type = pyclass_field_type(column.r#type.as_str(), type_name);
         let default = match column.r#type.as_str() {
-            // The calendar day-type default pairs with the
-            // `is_open = false` default: a bare fixture row reads as a
-            // closed day, never as a phantom open session.
+            // A bare fixture row reads as a closed day, never as a
+            // phantom open session.
             "calendar_status" => "\"full_close\".to_string()",
             _ => match rust_type {
                 "i32" => "0i32",

--- a/thetadatadx-rs/build_support_bin/ticks/rust_frames.rs
+++ b/thetadatadx-rs/build_support_bin/ticks/rust_frames.rs
@@ -56,7 +56,7 @@ pub(super) fn render_rust_frames(schema: &Schema) -> String {
 
     out.push_str("#[cfg(feature = \"arrow\")]\n");
     out.push_str(
-        "use arrow_array::{ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray};\n",
+        "use arrow_array::{ArrayRef, Float64Array, Int32Array, Int64Array, StringArray};\n",
     );
     out.push_str("#[cfg(feature = \"arrow\")]\n");
     out.push_str("use arrow_array::{RecordBatch, RecordBatchOptions};\n");

--- a/thetadatadx-rs/src/columns.rs
+++ b/thetadatadx-rs/src/columns.rs
@@ -240,11 +240,11 @@ pub fn present_columns_from(
 /// headers.
 ///
 /// Calendar rows are parsed by `parse_calendar_days_v3`, not the generated
-/// parser, because the server's `type` column feeds two public fields:
-/// `is_open` and `status`. The generic one-physical-header/one-field
-/// projection helper intentionally deduplicates aliases and cannot model
-/// that fan-out, so the generated `WireColumns` impl for `CalendarDay` routes
-/// through this table.
+/// parser, because the server renames columns (`type` -> `status`,
+/// `open` -> `open_time`, `close` -> `close_time`) and sends text-formatted
+/// dates and times the generated parser does not model. This table maps the
+/// wire headers to the public column set, so the generated `WireColumns` impl
+/// for `CalendarDay` routes through it.
 #[must_use]
 pub fn present_calendar_day_columns(headers: &[&str]) -> ColumnPresence {
     let has = |name| headers.contains(&name);
@@ -252,9 +252,6 @@ pub fn present_calendar_day_columns(headers: &[&str]) -> ColumnPresence {
 
     if has("date") {
         present.push("date");
-    }
-    if has("type") || has("is_open") {
-        present.push("is_open");
     }
     if has("open") || has("open_time") {
         present.push("open_time");
@@ -525,14 +522,14 @@ mod tests {
         assert_eq!(got, ["ms_of_day", "date", "rate"]);
     }
 
-    /// The v3 calendar `type` header fans out to both `is_open` and
-    /// `status`; `open` / `close` feed the public time fields. The single-day
-    /// calendar endpoints omit `date`, so it must not be fabricated.
+    /// The v3 calendar `type` header maps to `status`; `open` / `close` feed
+    /// the public time fields. The single-day calendar endpoints omit `date`,
+    /// so it must not be fabricated.
     #[test]
     fn present_calendar_day_maps_v3_type_and_times() {
         let p = present_calendar_day_columns(&["type", "open", "close"]);
         let got: Vec<&str> = p.present_names().collect();
-        assert_eq!(got, ["is_open", "open_time", "close_time", "status"]);
+        assert_eq!(got, ["open_time", "close_time", "status"]);
     }
 
     /// The year-style calendar response carries `date` in addition to the
@@ -541,9 +538,6 @@ mod tests {
     fn present_calendar_day_keeps_year_date() {
         let p = present_calendar_day_columns(&["date", "type", "open", "close"]);
         let got: Vec<&str> = p.present_names().collect();
-        assert_eq!(
-            got,
-            ["date", "is_open", "open_time", "close_time", "status"]
-        );
+        assert_eq!(got, ["date", "open_time", "close_time", "status"]);
     }
 }

--- a/thetadatadx-rs/src/frames/generated.rs
+++ b/thetadatadx-rs/src/frames/generated.rs
@@ -6,7 +6,7 @@
 // and the trait definitions share a single compilation unit.
 
 #[cfg(feature = "arrow")]
-use arrow_array::{ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, StringArray};
+use arrow_array::{ArrayRef, Float64Array, Int32Array, Int64Array, StringArray};
 #[cfg(feature = "arrow")]
 use arrow_array::{RecordBatch, RecordBatchOptions};
 #[cfg(feature = "arrow")]
@@ -24,27 +24,23 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::CalendarDay] {
     fn to_arrow(&self) -> ::core::result::Result<RecordBatch, arrow_schema::ArrowError> {
         let n = self.len();
         let mut col_date: Vec<i32> = Vec::with_capacity(n);
-        let mut col_is_open: Vec<bool> = Vec::with_capacity(n);
         let mut col_open_time: Vec<i32> = Vec::with_capacity(n);
         let mut col_close_time: Vec<i32> = Vec::with_capacity(n);
         let mut col_status: Vec<String> = Vec::with_capacity(n);
         for t in self {
             col_date.push(t.date);
-            col_is_open.push(t.is_open);
             col_open_time.push(t.open_time);
             col_close_time.push(t.close_time);
             col_status.push(t.status.as_str().to_string());
         }
         let schema = Arc::new(ArrowSchema::new(vec![
             Field::new("date", DataType::Int32, false),
-            Field::new("is_open", DataType::Boolean, false),
             Field::new("open_time", DataType::Int32, false),
             Field::new("close_time", DataType::Int32, false),
             Field::new("status", DataType::Utf8, false),
         ]));
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int32Array::from(col_date)) as ArrayRef,
-            Arc::new(BooleanArray::from(col_is_open)) as ArrayRef,
             Arc::new(Int32Array::from(col_open_time)) as ArrayRef,
             Arc::new(Int32Array::from(col_close_time)) as ArrayRef,
             Arc::new(StringArray::from(col_status)) as ArrayRef,
@@ -56,18 +52,15 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::CalendarDay] {
     fn to_arrow_projected(&self, present: &crate::columns::ColumnPresence) -> ::core::result::Result<RecordBatch, arrow_schema::ArrowError> {
         let n = self.len();
         let has_date = present.contains("date");
-        let has_is_open = present.contains("is_open");
         let has_open_time = present.contains("open_time");
         let has_close_time = present.contains("close_time");
         let has_status = present.contains("status");
         let mut col_date: Vec<i32> = Vec::with_capacity(if has_date { n } else { 0 });
-        let mut col_is_open: Vec<bool> = Vec::with_capacity(if has_is_open { n } else { 0 });
         let mut col_open_time: Vec<i32> = Vec::with_capacity(if has_open_time { n } else { 0 });
         let mut col_close_time: Vec<i32> = Vec::with_capacity(if has_close_time { n } else { 0 });
         let mut col_status: Vec<String> = Vec::with_capacity(if has_status { n } else { 0 });
         for t in self {
             if has_date { col_date.push(t.date); }
-            if has_is_open { col_is_open.push(t.is_open); }
             if has_open_time { col_open_time.push(t.open_time); }
             if has_close_time { col_close_time.push(t.close_time); }
             if has_status { col_status.push(t.status.as_str().to_string()); }
@@ -84,10 +77,6 @@ impl crate::frames::TicksArrowExt for [crate::tdbe::types::tick::CalendarDay] {
         if has_date {
             fields.push(Field::new("date", DataType::Int32, false));
             columns.push(Arc::new(Int32Array::from(col_date)) as ArrayRef);
-        }
-        if has_is_open {
-            fields.push(Field::new("is_open", DataType::Boolean, false));
-            columns.push(Arc::new(BooleanArray::from(col_is_open)) as ArrayRef);
         }
         if has_open_time {
             fields.push(Field::new("open_time", DataType::Int32, false));
@@ -112,20 +101,17 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::CalendarDay] {
     fn to_polars(&self) -> PolarsResult<DataFrame> {
         let n = self.len();
         let mut col_date: Vec<i32> = Vec::with_capacity(n);
-        let mut col_is_open: Vec<bool> = Vec::with_capacity(n);
         let mut col_open_time: Vec<i32> = Vec::with_capacity(n);
         let mut col_close_time: Vec<i32> = Vec::with_capacity(n);
         let mut col_status: Vec<String> = Vec::with_capacity(n);
         for t in self {
             col_date.push(t.date);
-            col_is_open.push(t.is_open);
             col_open_time.push(t.open_time);
             col_close_time.push(t.close_time);
             col_status.push(t.status.as_str().to_string());
         }
         DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("date"), col_date).into(),
-            Series::new(PlSmallStr::from_static("is_open"), col_is_open).into(),
             Series::new(PlSmallStr::from_static("open_time"), col_open_time).into(),
             Series::new(PlSmallStr::from_static("close_time"), col_close_time).into(),
             Series::new(PlSmallStr::from_static("status"), col_status).into(),
@@ -136,18 +122,15 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::CalendarDay] {
     fn to_polars_projected(&self, present: &crate::columns::ColumnPresence) -> PolarsResult<DataFrame> {
         let n = self.len();
         let has_date = present.contains("date");
-        let has_is_open = present.contains("is_open");
         let has_open_time = present.contains("open_time");
         let has_close_time = present.contains("close_time");
         let has_status = present.contains("status");
         let mut col_date: Vec<i32> = Vec::with_capacity(if has_date { n } else { 0 });
-        let mut col_is_open: Vec<bool> = Vec::with_capacity(if has_is_open { n } else { 0 });
         let mut col_open_time: Vec<i32> = Vec::with_capacity(if has_open_time { n } else { 0 });
         let mut col_close_time: Vec<i32> = Vec::with_capacity(if has_close_time { n } else { 0 });
         let mut col_status: Vec<String> = Vec::with_capacity(if has_status { n } else { 0 });
         for t in self {
             if has_date { col_date.push(t.date); }
-            if has_is_open { col_is_open.push(t.is_open); }
             if has_open_time { col_open_time.push(t.open_time); }
             if has_close_time { col_close_time.push(t.close_time); }
             if has_status { col_status.push(t.status.as_str().to_string()); }
@@ -160,9 +143,6 @@ impl crate::frames::TicksPolarsExt for [crate::tdbe::types::tick::CalendarDay] {
         }
         if has_date {
             series.push(Series::new(PlSmallStr::from_static("date"), col_date).into());
-        }
-        if has_is_open {
-            series.push(Series::new(PlSmallStr::from_static("is_open"), col_is_open).into());
         }
         if has_open_time {
             series.push(Series::new(PlSmallStr::from_static("open_time"), col_open_time).into());

--- a/thetadatadx-rs/src/mdds/decode/cell.rs
+++ b/thetadatadx-rs/src/mdds/decode/cell.rs
@@ -545,42 +545,6 @@ pub(crate) fn row_contract_right(
     }
 }
 
-/// Decode a logical boolean cell (`Number` 0 / 1 → `bool`).
-///
-/// Used by schema columns typed `bool` (e.g. `CalendarDay.is_open`).
-/// `NullValue` yields `Ok(None)` so the absent-column fill stays
-/// `false`.
-///
-/// # Errors
-///
-/// Returns [`DecodeError::UnknownEnumVariant`] for numeric payloads
-/// outside `{0, 1}`, [`DecodeError::TypeMismatch`] on any other
-/// variant, and [`DecodeError::MissingCell`] when the row is shorter
-/// than `idx`.
-#[inline]
-pub(crate) fn row_bool(
-    row: &proto::DataValueList,
-    idx: usize,
-) -> Result<Option<bool>, DecodeError> {
-    let Some(dv) = row.values.get(idx) else {
-        return Err(DecodeError::MissingCell { column: idx });
-    };
-    match dv.data_type.as_ref() {
-        Some(proto::data_value::DataType::Number(0)) => Ok(Some(false)),
-        Some(proto::data_value::DataType::Number(1)) => Ok(Some(true)),
-        Some(proto::data_value::DataType::Number(n)) => Err(DecodeError::UnknownEnumVariant {
-            field: "bool",
-            raw: n.to_string(),
-        }),
-        Some(proto::data_value::DataType::NullValue(_)) => Ok(None),
-        other => Err(DecodeError::TypeMismatch {
-            column: idx,
-            expected: "Number",
-            observed: observed_name(other),
-        }),
-    }
-}
-
 /// Decode a calendar day-type cell to the typed
 /// [`crate::tdbe::types::enums::CalendarStatus`].
 ///

--- a/thetadatadx-rs/src/mdds/decode/dual_type_columns.rs
+++ b/thetadatadx-rs/src/mdds/decode/dual_type_columns.rs
@@ -159,7 +159,7 @@ pub(crate) fn parse_time_text(s: &str) -> Result<i32, DecodeError> {
     Err(DecodeError::InvalidTime { raw: s.to_string() })
 }
 
-/// Map a v3 calendar `type` text to `(is_open, status)`.
+/// Map a v3 calendar `type` text to a [`crate::tdbe::CalendarStatus`].
 ///
 /// The status vocabulary is the exported [`crate::tdbe::CalendarStatus`] enum
 /// — the typed form of the vendor's text values (`open` /
@@ -167,14 +167,11 @@ pub(crate) fn parse_time_text(s: &str) -> Result<i32, DecodeError> {
 /// [`DecodeError::UnknownEnumVariant`] when the text falls outside the
 /// documented vendor vocabulary so a future schema change surfaces as
 /// a loud typed error instead of a silent mis-classification.
-fn calendar_type_text(s: &str) -> Result<(bool, crate::tdbe::CalendarStatus), DecodeError> {
-    match crate::tdbe::CalendarStatus::from_wire_text(s) {
-        Some(status) => Ok((status.is_open(), status)),
-        None => Err(DecodeError::UnknownEnumVariant {
-            field: "calendar.type",
-            raw: s.to_string(),
-        }),
-    }
+fn calendar_type_text(s: &str) -> Result<crate::tdbe::CalendarStatus, DecodeError> {
+    crate::tdbe::CalendarStatus::from_wire_text(s).ok_or(DecodeError::UnknownEnumVariant {
+        field: "calendar.type",
+        raw: s.to_string(),
+    })
 }
 
 /// Hand-written parser for `CalendarDay` that handles the v3 server's
@@ -186,15 +183,14 @@ fn calendar_type_text(s: &str) -> Result<(bool, crate::tdbe::CalendarStatus), De
 /// | Schema field | Server header | Server type | Mapping                               |
 /// |--------------|---------------|-------------|---------------------------------------|
 /// | `date`       | `date`        | Text        | "2025-01-01" -> 20250101              |
-/// | `is_open`    | `type`        | Text        | "`open"/"early_close`" -> true, else -> false |
 /// | `open_time`  | `open`        | Text / Null | "09:30:00" -> 34200000 ms             |
 /// | `close_time` | `close`       | Text / Null | "16:00:00" -> 57600000 ms             |
 /// | `status`     | `type`        | Text        | [`crate::tdbe::CalendarStatus`] vocabulary   |
 ///
 /// Note: `calendar_on_date` and `calendar_open_today` omit the `date`
 /// column (the `date` field is `0` on those rows). The `type` column is
-/// required whenever the response has rows — it is the sole source of
-/// both `is_open` and `status`, so its absence is schema drift and
+/// required whenever the response has rows — it is the source of
+/// `status`, so its absence is schema drift and
 /// surfaces as [`DecodeError::MissingRequiredHeader`] rather than a
 /// silent closed-day fill. Each column dispatches on the cell's own
 /// type rather than coalescing silently — mismatched types propagate as
@@ -245,7 +241,7 @@ pub fn parse_calendar_days_v3(
 
             // type: Text "open"/"full_close"/"early_close"/"weekend"
             // (the documented v3 wire shape). The `type` column is the
-            // sole source of both `is_open` and `status`, so a present-
+            // source of `status`, so a present-
             // but-null cell on a rows-present response is malformed: a
             // calendar row that carries no day type cannot be classified.
             // Reject it as a typed decode error rather than coalescing to
@@ -253,7 +249,7 @@ pub fn parse_calendar_days_v3(
             // `row_calendar_status` applies on every other typed column.
             // The column itself is required (guard above), so the `None`
             // (Unset) arm is unreachable but kept total.
-            let (is_open, status) = match type_idx {
+            let status = match type_idx {
                 Some(i) => match cell_type(row, i)? {
                     Some(proto::data_value::DataType::Text(s)) => calendar_type_text(s)?,
                     Some(proto::data_value::DataType::NullValue(_)) => {
@@ -278,7 +274,7 @@ pub fn parse_calendar_days_v3(
                         });
                     }
                 },
-                None => (false, crate::tdbe::CalendarStatus::FullClose),
+                None => crate::tdbe::CalendarStatus::FullClose,
             };
 
             let open_time = decode_calendar_time(row, open_idx)?;
@@ -286,7 +282,6 @@ pub fn parse_calendar_days_v3(
 
             Ok(CalendarDay {
                 date,
-                is_open,
                 open_time,
                 close_time,
                 status,

--- a/thetadatadx-rs/src/mdds/decode/tests.rs
+++ b/thetadatadx-rs/src/mdds/decode/tests.rs
@@ -469,7 +469,6 @@ fn parse_calendar_v3_holiday() {
     assert_eq!(days.len(), 1);
     let d = &days[0];
     assert_eq!(d.date, 20250101);
-    assert!(!d.is_open);
     assert_eq!(d.open_time, 0);
     assert_eq!(d.close_time, 0);
     assert_eq!(d.status, crate::tdbe::CalendarStatus::FullClose);
@@ -493,7 +492,6 @@ fn parse_calendar_v3_open_day() {
     assert_eq!(days.len(), 1);
     let d = &days[0];
     assert_eq!(d.date, 0); // no date column
-    assert!(d.is_open);
     assert_eq!(d.open_time, 34_200_000); // 9:30 AM = 9*3600+30*60 = 34200 seconds = 34200000 ms
     assert_eq!(d.close_time, 57_600_000); // 4:00 PM = 16*3600 = 57600 seconds = 57600000 ms
     assert_eq!(d.status, crate::tdbe::CalendarStatus::Open);
@@ -517,7 +515,6 @@ fn parse_calendar_v3_early_close() {
     assert_eq!(days.len(), 1);
     let d = &days[0];
     assert_eq!(d.date, 20251128);
-    assert!(d.is_open);
     assert_eq!(d.open_time, 34_200_000);
     assert_eq!(d.close_time, 46_800_000); // 1:00 PM = 13*3600 = 46800 seconds = 46800000 ms
     assert_eq!(d.status, crate::tdbe::CalendarStatus::EarlyClose);
@@ -534,7 +531,6 @@ fn parse_calendar_v3_weekend() {
     let days = parse_calendar_days_v3(&table).unwrap();
     assert_eq!(days.len(), 1);
     let d = &days[0];
-    assert!(!d.is_open);
     assert_eq!(d.status, crate::tdbe::CalendarStatus::Weekend);
 }
 
@@ -1447,7 +1443,7 @@ fn parse_calendar_days_v3_errors_on_unknown_type_text() {
 
 #[test]
 fn parse_calendar_days_v3_errors_on_null_type_cell() {
-    // `type` is the sole source of both `is_open` and `status`. A present-
+    // `type` is the source of `status`. A present-
     // but-null cell on a rows-present response cannot be classified, so it is
     // a typed decode error rather than a silent closed-day fill.
     let table = proto::DataTable {

--- a/thetadatadx-rs/src/tdbe/types/generated/tick.rs
+++ b/thetadatadx-rs/src/tdbe/types/generated/tick.rs
@@ -8,7 +8,7 @@
 // `Display` / `OptionContract` impls, then re-exports through
 // `tdbe::types::tick`.
 
-/// Calendar day -- 5 fields. Market open/close schedule.
+/// Calendar day -- 4 fields. Market open/close schedule.
 ///
 /// `status` carries the vendor's own day-type vocabulary (`open` /
 /// `early_close` / `full_close` / `weekend`); unknown wire text fails
@@ -21,8 +21,6 @@
 pub struct CalendarDay {
     /// Calendar date as a YYYYMMDD integer. 0 when the server omits the column (single-day endpoints).
     pub date: i32,
-    /// Whether the market trades at all on this date (true for open and early-close days).
-    pub is_open: bool,
     /// Market open time, milliseconds since midnight ET.
     pub open_time: i32,
     /// Market close time, milliseconds since midnight ET.

--- a/thetadatadx-rs/src/tdbe/types/generated/tick_layout_asserts.rs
+++ b/thetadatadx-rs/src/tdbe/types/generated/tick_layout_asserts.rs
@@ -17,10 +17,9 @@ mod layout_asserts {
         assert_eq!(size_of::<CalendarDay>(), 64);
         assert_eq!(align_of::<CalendarDay>(), 64);
         assert_eq!(offset_of!(CalendarDay, date), 0);
-        assert_eq!(offset_of!(CalendarDay, is_open), 4);
-        assert_eq!(offset_of!(CalendarDay, open_time), 8);
-        assert_eq!(offset_of!(CalendarDay, close_time), 12);
-        assert_eq!(offset_of!(CalendarDay, status), 16);
+        assert_eq!(offset_of!(CalendarDay, open_time), 4);
+        assert_eq!(offset_of!(CalendarDay, close_time), 8);
+        assert_eq!(offset_of!(CalendarDay, status), 12);
     }
 
     #[test]

--- a/thetadatadx-rs/tests/fixtures/captures/calendar_open_today.meta.toml
+++ b/thetadatadx-rs/tests/fixtures/captures/calendar_open_today.meta.toml
@@ -9,7 +9,6 @@ expected_rows = 1
 expected_headers = ["type", "open", "close"]
 
 # First row: regular open session, 09:30 - 16:00 ET.
-first_row_is_open = 1
 first_row_open_time = 34200000   # 09:30:00.000 ET in ms.
 first_row_close_time = 57600000  # 16:00:00.000 ET in ms.
 first_row_status = 0             # CALENDAR_STATUS_OPEN.

--- a/thetadatadx-rs/tests/test_column_projection.rs
+++ b/thetadatadx-rs/tests/test_column_projection.rs
@@ -545,7 +545,7 @@ fn index_snapshot_market_value_drops_bid_ask() {
 }
 
 /// `calendar_open_today` sends `type,open,close` with no `date` column. The
-/// hand-written parser maps `type` to both `is_open` and `status`; the
+/// hand-written parser maps `type` to `status`; the
 /// projected frame must carry those decoded fields plus the two session times
 /// and must not fabricate `date`.
 #[test]
@@ -557,7 +557,7 @@ fn calendar_open_today_projects_v3_fields_from_fixture() {
 
     let batch = days.as_slice().to_arrow_projected(&present).unwrap();
     let cols = arrow_columns(&batch);
-    assert_eq!(cols, ["is_open", "open_time", "close_time", "status"]);
+    assert_eq!(cols, ["open_time", "close_time", "status"]);
 
     let df = days.as_slice().to_polars_projected(&present).unwrap();
     assert_eq!(
@@ -574,10 +574,7 @@ fn calendar_open_today_projects_v3_fields_from_fixture() {
 #[test]
 fn calendar_year_headers_project_all_v3_fields() {
     let cols = projected_columns::<CalendarDay>(&["date", "type", "open", "close"]);
-    assert_eq!(
-        cols,
-        ["date", "is_open", "open_time", "close_time", "status"]
-    );
+    assert_eq!(cols, ["date", "open_time", "close_time", "status"]);
 }
 
 // ── The full (hand-built) path is unchanged ───────────────────────────────

--- a/thetadatadx-rs/tests/test_decode_captures.rs
+++ b/thetadatadx-rs/tests/test_decode_captures.rs
@@ -387,7 +387,6 @@ fn decode_captures_calendar_open_today() {
     assert_eq!(days.len(), table.data_table.len());
 
     let first = days.first().unwrap();
-    assert_eq!(first.is_open as i64, meta_int(&meta, "first_row_is_open"));
     assert_eq!(
         first.open_time as i64,
         meta_int(&meta, "first_row_open_time")

--- a/thetadatadx-rs/tests/test_frames_arrow.rs
+++ b/thetadatadx-rs/tests/test_frames_arrow.rs
@@ -33,7 +33,6 @@ fn dtype_of(batch: &RecordBatch, name: &str) -> DataType {
 fn calendar_day_to_arrow() {
     let ticks = vec![tick::CalendarDay {
         date: 20240102,
-        is_open: true,
         open_time: 34200000,
         close_time: 57600000,
         status: thetadatadx::CalendarStatus::Open,
@@ -42,7 +41,7 @@ fn calendar_day_to_arrow() {
     assert_eq!(batch.num_rows(), 1);
     assert_eq!(
         columns(&batch),
-        vec!["date", "is_open", "open_time", "close_time", "status"]
+        vec!["date", "open_time", "close_time", "status"]
     );
     assert_eq!(dtype_of(&batch, "date"), DataType::Int32);
 }

--- a/thetadatadx-rs/tests/test_frames_polars.rs
+++ b/thetadatadx-rs/tests/test_frames_polars.rs
@@ -26,7 +26,6 @@ fn dtype_of(df: &DataFrame, name: &str) -> DataType {
 fn calendar_day_to_polars() {
     let ticks = vec![tick::CalendarDay {
         date: 20240102,
-        is_open: true,
         open_time: 34200000,
         close_time: 57600000,
         status: thetadatadx::CalendarStatus::Open,
@@ -35,7 +34,7 @@ fn calendar_day_to_polars() {
     assert_eq!(df.height(), 1);
     assert_eq!(
         columns(&df),
-        vec!["date", "is_open", "open_time", "close_time", "status"]
+        vec!["date", "open_time", "close_time", "status"]
     );
     assert_eq!(dtype_of(&df, "date"), DataType::Int32);
     assert_eq!(dtype_of(&df, "open_time"), DataType::Int32);

--- a/thetadatadx-rs/tick_schema.toml
+++ b/thetadatadx-rs/tick_schema.toml
@@ -1074,7 +1074,7 @@ ts_class_vec = "index_price_at_time_ticks_to_class_vec"
 pyclass = "IndexPriceAtTimeTick"
 
 [types.CalendarDay]
-doc = """Calendar day -- 5 fields. Market open/close schedule.
+doc = """Calendar day -- 4 fields. Market open/close schedule.
 
 `status` carries the vendor's own day-type vocabulary (`open` /
 `early_close` / `full_close` / `weekend`); unknown wire text fails
@@ -1087,7 +1087,6 @@ parser = "parse_calendar_days"
 required = ["date"]
 columns = [
     { name = "date",       field = "date",       type = "i32", doc = "Calendar date as a YYYYMMDD integer. 0 when the server omits the column (single-day endpoints)." },
-    { name = "is_open",    field = "is_open",    type = "bool", doc = "Whether the market trades at all on this date (true for open and early-close days)." },
     { name = "open_time",  field = "open_time",  type = "i32", doc = "Market open time, milliseconds since midnight ET." },
     { name = "close_time", field = "close_time", type = "i32", doc = "Market close time, milliseconds since midnight ET." },
     { name = "status",     field = "status",     type = "calendar_status", doc = "Vendor day classification: open, early_close, full_close, or weekend." },

--- a/thetadatadx-ts/__tests__/native_typed_errors.test.mjs
+++ b/thetadatadx-ts/__tests__/native_typed_errors.test.mjs
@@ -83,7 +83,6 @@ function looksLikeArrowIpcStream(buf) {
 function validCalendarDay(status) {
   return {
     date: 20260102,
-    isOpen: true,
     openTime: 34200000,
     closeTime: 57600000,
     status,

--- a/thetadatadx-ts/__tests__/typed_surface.test.mjs
+++ b/thetadatadx-ts/__tests__/typed_surface.test.mjs
@@ -10,8 +10,7 @@
 //   payload and historical rows type it `number`.
 // * `EodTick` carries `createdMsOfDay` / `lastTradeMsOfDay` (the
 //   vendor's v3 semantics) instead of an enumerated `msOfDay2`.
-// * `CalendarDay.isOpen` is boolean and `status` is the vendor
-//   vocabulary string.
+// * `CalendarDay.status` is the vendor vocabulary string.
 // * Absent contract identity is `undefined`/`null` (optional fields),
 //   matching the streaming payload convention.
 
@@ -184,11 +183,11 @@ describe('EOD and calendar row shapes', () => {
     assert.ok(!/msOfDay2/.test(block[0]), 'msOfDay2 must not survive the rename');
   });
 
-  it('CalendarDay carries boolean isOpen and the vendor status vocabulary', () => {
+  it('CalendarDay carries the vendor status vocabulary', () => {
     const block = dts.match(/export interface CalendarDay\s*\{[^}]*\}/s);
     assert.ok(block, 'CalendarDay interface missing from index.d.ts');
-    assert.match(block[0], /isOpen\s*:\s*boolean/);
     assert.match(block[0], /status\s*:\s*string/);
+    assert.ok(!/isOpen/.test(block[0]), 'isOpen must not survive on CalendarDay');
   });
 
   it('contract identity on rows is optional (absent = undefined)', () => {

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -3278,7 +3278,6 @@ export interface BatchesOptions {
 /** Calendar day. Market open/close schedule. */
 export interface CalendarDay {
   date: number
-  isOpen: boolean
   openTime: number
   closeTime: number
   status: string

--- a/thetadatadx-ts/src/_generated/tick_classes.rs
+++ b/thetadatadx-ts/src/_generated/tick_classes.rs
@@ -10,7 +10,6 @@ use napi::bindgen_prelude::BigInt;
 #[derive(Clone)]
 pub struct CalendarDay {
     pub date: i32,
-    pub is_open: bool,
     pub open_time: i32,
     pub close_time: i32,
     pub status: String,
@@ -705,7 +704,6 @@ fn calendar_days_to_class_vec(ticks: &[tick::CalendarDay]) -> Vec<CalendarDay> {
         .map(|t| {
             CalendarDay {
                 date: t.date,
-                is_open: t.is_open,
                 open_time: t.open_time,
                 close_time: t.close_time,
                 status: t.status.as_str().to_string(),
@@ -1403,7 +1401,6 @@ fn calendar_day_reconstruct_rows(rows: Vec<CalendarDay>) -> napi::Result<Vec<tic
         .map(|r| -> napi::Result<tick::CalendarDay> {
             Ok(tick::CalendarDay {
                 date: r.date,
-                is_open: r.is_open,
                 open_time: r.open_time,
                 close_time: r.close_time,
                 status: match thetadatadx::CalendarStatus::from_wire_text(&r.status) { Some(status) => status, None => return Err(napi::Error::from_reason(format!("[InvalidParameterError] status must be one of open, early_close, full_close, weekend; got {:?}", r.status))) },

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -1065,7 +1065,7 @@ fn serialize_calendar_days(days: &[thetadatadx::CalendarDay]) -> Value {
         .iter()
         .map(|d| {
             json!({
-                "date": d.date, "is_open": d.is_open,
+                "date": d.date,
                 "open_time": d.open_time, "close_time": d.close_time,
                 "status": d.status.as_str(),
             })

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -2062,7 +2062,6 @@ fn representative_output(ep: &EndpointMeta) -> EndpointOutput {
         ReturnType::CalendarDays => {
             EndpointOutput::CalendarDays(thetadatadx::columns::Ticks::from(vec![CalendarDay {
                 date: calendar_date,
-                is_open: true,
                 open_time: 0,
                 close_time: 0,
                 status: thetadatadx::CalendarStatus::Open,
@@ -3449,7 +3448,6 @@ mod tests {
     fn calendar_single_day_header_is_date_leading_when_present() {
         let open_day = |date: i32| CalendarDay {
             date,
-            is_open: true,
             open_time: 34_200_000,
             close_time: 57_600_000,
             status: thetadatadx::CalendarStatus::Open,


### PR DESCRIPTION
The calendar wire carries a single day-type column. The SDK fanned it into two public fields: `status` (the vendor vocabulary) and `is_open`, a boolean derived as `status in {open, early_close}`. The terminal exposes no such boolean (its calendar model carries only date/type/open/close), so `is_open` was an SDK-only derivation in the same class as the removed `QuoteTick.midpoint`.

Verified against the decompiled terminal: its only calendar model has exactly `date` / `type` / `open` / `close`, and the REST layer streams server columns verbatim.

## What changed
Removes `is_open` from `CalendarDay` on every surface: the schema, the generated Rust struct + layout asserts, the Arrow/Polars frame builders, the Python and TypeScript classes, and the C ABI struct (tail padding grows from 44 to 48 bytes to keep the 64-byte aligned layout at size 64). The calendar parser maps the wire day-type to `status` alone. C++ layout `static_assert`s recompute to date@0 / open_time@4 / close_time@8 / status@12 and compile clean.

## Kept
`CalendarStatus::is_open()` stays: it is a plain enum predicate the local server uses for display, not a wire-derived column. `status` (the single wire column, rendered) is unchanged. Dropping the last `bool` schema column also removed the now-dead `row_bool` cell decoder and the unused `BooleanArray` imports in the generated frame builders.

## Migration
Read `status` (values `open` / `early_close` / `full_close` / `weekend`) and treat `open` / `early_close` as trading days.

Completes the terminal-parity derivation removals (midpoint, list-sort, interval-snap, is_open).