### PR TITLE
expose stream_window_size and connection_window_size for h2 (grpc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`ping_interval_ms` default is now `100`, matching the terminal.** The client heartbeat previously defaulted to `250 ms`; the Theta Terminal pings on a fixed `100 ms` period, and with `flush_mode` removed the ping is the sole flush trigger for queued outbound control frames, so the default now matches the terminal exactly (subscribe / unsubscribe reach the server within one `100 ms` interval instead of `250 ms`). The knob and its `[100, 300_000]` range are unchanged; override it if you prefer the old cadence.
- 
-- **exposed `stream_window_size` and `connection_window_size` to client libraries and raised default window sizes
+
+- **HTTP/2 flow-control window sizes are tunable across every binding, and the market-data `window_size_kb` field is renamed to `stream_window_size_kb`.** The per-stream and per-connection HTTP/2 windows (`stream_window_size_kb`, `connection_window_size_kb`) are now exposed through the Python, TypeScript, C++, and C bindings, not just Rust. The validation clamp is raised from `[64, 1024]` to `[64, 2_097_151]` KB — the largest whole-KB value under the HTTP/2 `2^31 - 1` byte window cap — so bulk pulls are no longer throttled by a 1 MiB per-stream ceiling, and the defaults are raised to `stream_window_size_kb = 8192` / `connection_window_size_kb = 16384`. The Rust field `MarketDataConfig::window_size_kb` and the `[grpc] window_size_kb` config-file key are renamed to `stream_window_size_kb`; because the grpc config section rejects unknown keys, an existing `config.toml` using the old key now fails to load until it is renamed. This is a breaking change to the configuration surface.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`ping_interval_ms` default is now `100`, matching the terminal.** The client heartbeat previously defaulted to `250 ms`; the Theta Terminal pings on a fixed `100 ms` period, and with `flush_mode` removed the ping is the sole flush trigger for queued outbound control frames, so the default now matches the terminal exactly (subscribe / unsubscribe reach the server within one `100 ms` interval instead of `250 ms`). The knob and its `[100, 300_000]` range are unchanged; override it if you prefer the old cadence.
+ 
+- **exposed `stream_window_size` and `connection_window_size` to client libraries and raised default window sizes
 
 ### Removed
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`ping_interval_ms` default is now `100`, matching the terminal.** The client heartbeat previously defaulted to `250 ms`; the Theta Terminal pings on a fixed `100 ms` period, and with `flush_mode` removed the ping is the sole flush trigger for queued outbound control frames, so the default now matches the terminal exactly (subscribe / unsubscribe reach the server within one `100 ms` interval instead of `250 ms`). The knob and its `[100, 300_000]` range are unchanged; override it if you prefer the old cadence.
- 
-- **exposed `stream_window_size` and `connection_window_size` to client libraries and raised default window sizes
+
+- **HTTP/2 flow-control window sizes are tunable across every binding, and the market-data `window_size_kb` field is renamed to `stream_window_size_kb`.** The per-stream and per-connection HTTP/2 windows (`stream_window_size_kb`, `connection_window_size_kb`) are now exposed through the Python, TypeScript, C++, and C bindings, not just Rust. The validation clamp is raised from `[64, 1024]` to `[64, 2_097_151]` KB — the largest whole-KB value under the HTTP/2 `2^31 - 1` byte window cap — so bulk pulls are no longer throttled by a 1 MiB per-stream ceiling, and the defaults are raised to `stream_window_size_kb = 8192` / `connection_window_size_kb = 16384`. The Rust field `MarketDataConfig::window_size_kb` and the `[grpc] window_size_kb` config-file key are renamed to `stream_window_size_kb`; because the grpc config section rejects unknown keys, an existing `config.toml` using the old key now fails to load until it is renamed. This is a breaking change to the configuration surface.
 
 ### Removed
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`ping_interval_ms` default is now `100`, matching the terminal.** The client heartbeat previously defaulted to `250 ms`; the Theta Terminal pings on a fixed `100 ms` period, and with `flush_mode` removed the ping is the sole flush trigger for queued outbound control frames, so the default now matches the terminal exactly (subscribe / unsubscribe reach the server within one `100 ms` interval instead of `250 ms`). The knob and its `[100, 300_000]` range are unchanged; override it if you prefer the old cadence.
+ 
+- **exposed `stream_window_size` and `connection_window_size` to client libraries and raised default window sizes
 
 ### Removed
 

--- a/parity.toml
+++ b/parity.toml
@@ -573,20 +573,18 @@ rust_only = true
 issue = "#595"
 
 [[class]]
-name = "MarketDataConfig.window_size_kb"
-python = false
-typescript = false
-cpp = false
-rust_only = true
-issue = "#595"
+name = "MarketDataConfig.stream_window_size_kb"
+python = true       # `Config.market_data_stream_window_size_kb` property
+typescript = true   # `Config.setMarketDataStreamWindowSizeKb` / `marketDataStreamWindowSizeKb` napi setter+getter
+cpp = true          # `Config::set_market_data_stream_window_size_kb` over `thetadatadx_config_set_market_data_stream_window_size_kb`
+setter = "market_data_stream_window_size_kb"
 
 [[class]]
 name = "MarketDataConfig.connection_window_size_kb"
-python = false
-typescript = false
-cpp = false
-rust_only = true
-issue = "#595"
+python = true       # `Config.market_data_connection_window_size_kb` property
+typescript = true   # `Config.setMarketDataConnectionWindowSizeKb` / `marketDataConnectionWindowSizeKb` napi setter+getter
+cpp = true          # `Config::set_market_data_connection_window_size_kb` over `thetadatadx_config_set_market_data_connection_window_size_kb`
+setter = "market_data_connection_window_size_kb"
 
 [[class]]
 name = "MarketDataConfig.connect_timeout_secs"

--- a/scripts/ci/check_client_facing_vocab.py
+++ b/scripts/ci/check_client_facing_vocab.py
@@ -61,6 +61,7 @@ SWEEP_GLOBS = (
     "thetadatadx-py/examples/**/*",
     "thetadatadx-ts/examples/**/*",
     "thetadatadx-cpp/examples/**/*",
+    "thetadatadx-rs/examples/**/*",
     # Published type declarations (the IDE-hover surface).
     "thetadatadx-py/**/*.pyi",
     "thetadatadx-ts/**/*.d.ts",

--- a/scripts/ci/check_doc_defaults.py
+++ b/scripts/ci/check_doc_defaults.py
@@ -237,7 +237,7 @@ def load_canonical(root: pathlib.Path = REPO_ROOT) -> dict[str, int]:
     canon["market_data.connect_timeout_secs"] = _norm_int(market_data["connect_timeout_secs"])
     canon["market_data.keepalive_secs"] = _norm_int(market_data["keepalive_secs"])
     canon["market_data.keepalive_timeout_secs"] = _norm_int(market_data["keepalive_timeout_secs"])
-    canon["market_data.window_size_kb"] = _norm_int(market_data["window_size_kb"])
+    canon["market_data.stream_window_size_kb"] = _norm_int(market_data["stream_window_size_kb"])
     canon["market_data.connection_window_size_kb"] = _norm_int(
         market_data["connection_window_size_kb"]
     )
@@ -898,7 +898,7 @@ impl MddsConfig {
             max_message_size: 4 * 1024 * 1024,
             keepalive_secs: 30,
             keepalive_timeout_secs: 10,
-            window_size_kb: 64,
+            stream_window_size_kb: 64,
             connection_window_size_kb: 64,
             connect_timeout_secs: 10,
             warn_on_buffered_threshold_bytes: 100 * 1024 * 1024,

--- a/thetadatadx-cpp/include/config_accessors.hpp.inc
+++ b/thetadatadx-cpp/include/config_accessors.hpp.inc
@@ -363,6 +363,46 @@
         return out;
     }
 
+    /// Set the initial per-stream HTTP/2 flow-control window, in KB, for the
+    /// market-data gRPC channel. A larger window raises the throughput ceiling
+    /// on bulk streaming pulls before HTTP/2 backpressure kicks in.
+    /// @p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
+    /// Default is `1024` (1 MiB).
+    void set_market_data_stream_window_size_kb(std::size_t kb) {
+        thetadatadx_config_set_market_data_stream_window_size_kb(handle_.get(), kb);
+    }
+
+    /// Read the current per-stream HTTP/2 flow-control window (KB) for the
+    /// market-data gRPC channel.
+    ///
+    /// Returns the configured KB value, or `0` on a null handle (matching the
+    /// C ABI's `-1` failure mapping at the boundary).
+    std::size_t get_market_data_stream_window_size_kb() const {
+        std::size_t out{};
+        thetadatadx_config_get_market_data_stream_window_size_kb(handle_.get(), &out);
+        return out;
+    }
+
+    /// Set the initial connection-level HTTP/2 flow-control window, in KB, for
+    /// the market-data gRPC channel. A larger window raises the throughput
+    /// ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+    /// @p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
+    /// Default is `8192` (8 MiB).
+    void set_market_data_connection_window_size_kb(std::size_t kb) {
+        thetadatadx_config_set_market_data_connection_window_size_kb(handle_.get(), kb);
+    }
+
+    /// Read the current connection-level HTTP/2 flow-control window (KB) for
+    /// the market-data gRPC channel.
+    ///
+    /// Returns the configured KB value, or `0` on a null handle (matching the
+    /// C ABI's `-1` failure mapping at the boundary).
+    std::size_t get_market_data_connection_window_size_kb() const {
+        std::size_t out{};
+        thetadatadx_config_get_market_data_connection_window_size_kb(handle_.get(), &out);
+        return out;
+    }
+
     ///
     std::uint64_t get_retry_initial_delay_ms() const {
         std::uint64_t out{};

--- a/thetadatadx-cpp/include/config_accessors.hpp.inc
+++ b/thetadatadx-cpp/include/config_accessors.hpp.inc
@@ -367,7 +367,7 @@
     /// market-data gRPC channel. A larger window raises the throughput ceiling
     /// on bulk streaming pulls before HTTP/2 backpressure kicks in.
     /// @p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
-    /// Default is `1024` (1 MiB).
+    /// Default is `8192` (8 MiB).
     void set_market_data_stream_window_size_kb(std::size_t kb) {
         thetadatadx_config_set_market_data_stream_window_size_kb(handle_.get(), kb);
     }
@@ -387,7 +387,7 @@
     /// the market-data gRPC channel. A larger window raises the throughput
     /// ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
     /// @p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
-    /// Default is `8192` (8 MiB).
+    /// Default is `16384` (16 MiB).
     void set_market_data_connection_window_size_kb(std::size_t kb) {
         thetadatadx_config_set_market_data_connection_window_size_kb(handle_.get(), kb);
     }

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -2000,6 +2000,48 @@ void thetadatadx_config_set_request_timeout_secs(ThetaDataDxConfig* config, uint
  */
 int32_t thetadatadx_config_get_request_timeout_secs(const ThetaDataDxConfig* config, uint64_t* out);
 
+/**
+ * Set the initial per-stream HTTP/2 flow-control window, in KB, for the
+ * market-data gRPC channel.
+ *
+ * A larger window raises the throughput ceiling on bulk streaming pulls
+ * before HTTP/2 backpressure kicks in.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param kb Window size in KB; clamped into [64, 2097151] KB at
+ *           validate/connect time. Default 1024 (1 MiB).
+ */
+void thetadatadx_config_set_market_data_stream_window_size_kb(ThetaDataDxConfig* config, size_t kb);
+
+/**
+ * Read the current per-stream HTTP/2 flow-control window (KB) for the
+ * market-data gRPC channel.
+ * @param config Config handle to read.
+ * @param out_kb Receives the configured KB value on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
+int32_t thetadatadx_config_get_market_data_stream_window_size_kb(const ThetaDataDxConfig* config, size_t* out_kb);
+
+/**
+ * Set the initial connection-level HTTP/2 flow-control window, in KB, for
+ * the market-data gRPC channel.
+ *
+ * A larger window raises the throughput ceiling on bulk streaming pulls
+ * before HTTP/2 backpressure kicks in.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param kb Window size in KB; clamped into [64, 2097151] KB at
+ *           validate/connect time. Default 8192 (8 MiB).
+ */
+void thetadatadx_config_set_market_data_connection_window_size_kb(ThetaDataDxConfig* config, size_t kb);
+
+/**
+ * Read the current connection-level HTTP/2 flow-control window (KB) for
+ * the market-data gRPC channel.
+ * @param config Config handle to read.
+ * @param out_kb Receives the configured KB value on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
+int32_t thetadatadx_config_get_market_data_connection_window_size_kb(const ThetaDataDxConfig* config, size_t* out_kb);
+
 /* ── MarketDataClient ── */
 
 /** Connect a market-data client to ThetaData servers.

--- a/thetadatadx-cpp/include/thetadatadx.h
+++ b/thetadatadx-cpp/include/thetadatadx.h
@@ -2005,7 +2005,7 @@ int32_t thetadatadx_config_get_request_timeout_secs(const ThetaDataDxConfig* con
  * before HTTP/2 backpressure kicks in.
  * @param config Config handle to mutate; no-op when NULL.
  * @param kb Window size in KB; clamped into [64, 2097151] KB at
- *           validate/connect time. Default 1024 (1 MiB).
+ *           validate/connect time. Default 8192 (8 MiB).
  */
 void thetadatadx_config_set_market_data_stream_window_size_kb(ThetaDataDxConfig* config, size_t kb);
 
@@ -2026,7 +2026,7 @@ int32_t thetadatadx_config_get_market_data_stream_window_size_kb(const ThetaData
  * before HTTP/2 backpressure kicks in.
  * @param config Config handle to mutate; no-op when NULL.
  * @param kb Window size in KB; clamped into [64, 2097151] KB at
- *           validate/connect time. Default 8192 (8 MiB).
+ *           validate/connect time. Default 16384 (16 MiB).
  */
 void thetadatadx_config_set_market_data_connection_window_size_kb(ThetaDataDxConfig* config, size_t kb);
 

--- a/thetadatadx-ffi/src/config_accessors.rs
+++ b/thetadatadx-ffi/src/config_accessors.rs
@@ -1000,6 +1000,89 @@ pub unsafe extern "C" fn thetadatadx_config_get_request_timeout_secs(
     })
 }
 
+/// Set the initial per-stream HTTP/2 flow-control window, in KB, for the
+/// market-data gRPC channel on a config handle. A larger window raises the
+/// throughput ceiling on bulk streaming pulls before HTTP/2 backpressure
+/// kicks in. Default `1024` (1 MiB); `DirectConfig` validation (and the
+/// connect path) clamps the applied value into `[64, 2_097_151]` KB.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_market_data_stream_window_size_kb(
+    config: *mut ThetaDataDxConfig,
+    kb: usize,
+) {
+    ffi_boundary!((), {
+        let config = require_config_mut!(config);
+        config.inner.market_data.stream_window_size_kb = kb;
+    })
+}
+
+/// Read the current per-stream HTTP/2 flow-control window (KB) for the
+/// market-data gRPC channel (default `1024`).
+///
+/// Writes the configured value into `*out_kb`. Returns `0` on success,
+/// `-1` if either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_market_data_stream_window_size_kb(
+    config: *const ThetaDataDxConfig,
+    out_kb: *mut usize,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_kb.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        // SAFETY: out_kb null-checked above; caller pins the storage for the call duration.
+        unsafe {
+            *out_kb = config.inner.market_data.stream_window_size_kb;
+        }
+        0
+    })
+}
+
+/// Set the initial connection-level HTTP/2 flow-control window, in KB, for
+/// the market-data gRPC channel on a config handle. A larger window raises
+/// the throughput ceiling on bulk streaming pulls before HTTP/2
+/// backpressure kicks in. Default `8192` (8 MiB); `DirectConfig`
+/// validation (and the connect path) clamps the applied value into
+/// `[64, 2_097_151]` KB.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_set_market_data_connection_window_size_kb(
+    config: *mut ThetaDataDxConfig,
+    kb: usize,
+) {
+    ffi_boundary!((), {
+        let config = require_config_mut!(config);
+        config.inner.market_data.connection_window_size_kb = kb;
+    })
+}
+
+/// Read the current connection-level HTTP/2 flow-control window (KB) for
+/// the market-data gRPC channel (default `8192`).
+///
+/// Writes the configured value into `*out_kb`. Returns `0` on success,
+/// `-1` if either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_market_data_connection_window_size_kb(
+    config: *const ThetaDataDxConfig,
+    out_kb: *mut usize,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_kb.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        // SAFETY: out_kb null-checked above; caller pins the storage for the call duration.
+        unsafe {
+            *out_kb = config.inner.market_data.connection_window_size_kb;
+        }
+        0
+    })
+}
+
 /// Read the current `retry.initial_delay` setting (ms). Returns `0` on
 /// success, `-1` if either pointer is null.
 #[no_mangle]

--- a/thetadatadx-ffi/src/config_accessors.rs
+++ b/thetadatadx-ffi/src/config_accessors.rs
@@ -1003,7 +1003,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_request_timeout_secs(
 /// Set the initial per-stream HTTP/2 flow-control window, in KB, for the
 /// market-data gRPC channel on a config handle. A larger window raises the
 /// throughput ceiling on bulk streaming pulls before HTTP/2 backpressure
-/// kicks in. Default `1024` (1 MiB); `DirectConfig` validation (and the
+/// kicks in. Default `8192` (8 MiB); `DirectConfig` validation (and the
 /// connect path) clamps the applied value into `[64, 2_097_151]` KB.
 #[no_mangle]
 pub unsafe extern "C" fn thetadatadx_config_set_market_data_stream_window_size_kb(
@@ -1017,7 +1017,7 @@ pub unsafe extern "C" fn thetadatadx_config_set_market_data_stream_window_size_k
 }
 
 /// Read the current per-stream HTTP/2 flow-control window (KB) for the
-/// market-data gRPC channel (default `1024`).
+/// market-data gRPC channel (default `8192`).
 ///
 /// Writes the configured value into `*out_kb`. Returns `0` on success,
 /// `-1` if either pointer is null.
@@ -1044,7 +1044,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_market_data_stream_window_size_k
 /// Set the initial connection-level HTTP/2 flow-control window, in KB, for
 /// the market-data gRPC channel on a config handle. A larger window raises
 /// the throughput ceiling on bulk streaming pulls before HTTP/2
-/// backpressure kicks in. Default `8192` (8 MiB); `DirectConfig`
+/// backpressure kicks in. Default `16384` (16 MiB); `DirectConfig`
 /// validation (and the connect path) clamps the applied value into
 /// `[64, 2_097_151]` KB.
 #[no_mangle]
@@ -1059,7 +1059,7 @@ pub unsafe extern "C" fn thetadatadx_config_set_market_data_connection_window_si
 }
 
 /// Read the current connection-level HTTP/2 flow-control window (KB) for
-/// the market-data gRPC channel (default `8192`).
+/// the market-data gRPC channel (default `16384`).
 ///
 /// Writes the configured value into `*out_kb`. Returns `0` on success,
 /// `-1` if either pointer is null.

--- a/thetadatadx-py/examples/chain_quote_bench.py
+++ b/thetadatadx-py/examples/chain_quote_bench.py
@@ -1,0 +1,210 @@
+"""Full-chain option quote streaming benchmark.
+
+Pulls an entire option chain's quote history over the streaming market-data
+endpoint and reports TTFB, throughput, and an approximate in-memory decoded
+volume so the effect of the h2 flow-control window sizes can be measured
+against the live backend.
+
+Ported from `thetadatadx-rs/examples/chain_quote_bench.rs` -- see that file
+for the semantics this mirrors.
+
+Usage:
+    python chain_quote_bench.py [symbol] [expiration] [date] [interval]
+
+Args (all optional):
+  symbol      option root (default SPXW)
+  expiration  contract expiration YYYYMMDD (default 20260710)
+  date        history date YYYYMMDD (default = expiration, i.e. a 0DTE pull)
+  interval    tick | 1s | 1m | ... (default tick)
+
+The h2 windows are set on the config before connect via
+STREAM_WINDOW_SIZE_KB / CONNECTION_WINDOW_SIZE_KB below -- edit those
+constants and rerun to benchmark different values (both are clamped into
+[64, 2_097_151] KB by `validate`, which `MarketDataClient.__init__` runs).
+This binding has no post-connect (validated) config read-back, so the
+constants themselves are printed as the "effective" values every run.
+
+Credentials are loaded from $CREDS (default ./creds.txt).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+from thetadatadx import Config, Credentials, MarketDataClient
+
+USAGE = """\
+usage: chain_quote_bench.py [symbol] [expiration] [date] [interval]
+       defaults: SPXW 20260710 <expiration> tick
+       date defaults to <expiration> (a 0DTE full-chain pull)
+       h2 windows come from the STREAM_WINDOW_SIZE_KB / CONNECTION_WINDOW_SIZE_KB
+       constants in this file; edit and rerun to test different values
+       credentials from $CREDS (default ./creds.txt)"""
+
+# h2 flow-control windows applied to Config's `market_data_stream_window_size_kb`
+# / `market_data_connection_window_size_kb` properties before connect. Edit
+# and rerun to benchmark different values; `validate` clamps both into
+# [64, 2_097_151] KB at connect.
+STREAM_WINDOW_SIZE_KB = 8_192
+# STREAM_WINDOW_SIZE_KB = 64
+CONNECTION_WINDOW_SIZE_KB = 32_768
+# CONNECTION_WINDOW_SIZE_KB = 64
+
+MIB = 1024.0 * 1024.0
+
+# Decoded in-memory size of a single parsed quote row. The `.stream()`
+# callback only exposes a list of rows, so decoded volume is approximated as
+# `rows * QUOTE_TICK_SIZE` -- an in-memory figure, not wire bytes. Mirrors
+# `std::mem::size_of::<QuoteTick>()` in the Rust example (measured 128 bytes:
+# `#[repr(C, align(64))]`, 13 fields) so figures are comparable across
+# bindings.
+QUOTE_TICK_SIZE = 128
+
+
+def arg_or(args: list[str], idx: int, default: str) -> str:
+    return args[idx] if idx < len(args) else default
+
+
+def human_bytes(n: int) -> str:
+    f = float(n)
+    gib = MIB * 1024.0
+    if f >= gib:
+        return f"{f / gib:.2f} GiB"
+    return f"{f / MIB:.2f} MiB"
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if any(a in ("-h", "--help") for a in args):
+        print(USAGE)
+        return
+    if len(args) > 4:
+        print(USAGE, file=sys.stderr)
+        sys.exit(2)
+
+    symbol = arg_or(args, 0, "SPXW")
+    expiration = arg_or(args, 1, "20260710")
+    date = arg_or(args, 2, expiration)
+    interval = arg_or(args, 3, "tick")
+
+    creds_path = os.environ.get("CREDS", "creds.txt")
+    try:
+        creds = Credentials.from_file(creds_path)
+    except Exception as e:  # noqa: BLE001 -- mirrors the Rust example's blanket `Err(e)`
+        print(f"creds load failed ({creds_path}): {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # production() supplies the defaults; the benchmark constants override
+    # the h2 window knobs before connect, which clamps the applied values
+    # into [64, 2_097_151] KB via validate.
+    config = Config.production()
+    config.market_data_stream_window_size_kb = STREAM_WINDOW_SIZE_KB
+    config.market_data_connection_window_size_kb = CONNECTION_WINDOW_SIZE_KB
+
+    connect_start = time.monotonic()
+    try:
+        client = MarketDataClient(creds, config)
+    except Exception as e:  # noqa: BLE001
+        print(f"connect failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    connect_elapsed = time.monotonic() - connect_start
+
+    # Effective h2 window sizes, so every run is self-documenting. No
+    # post-connect (validated) config read-back exists on this binding, so
+    # the constants are printed as-is; validate clamps both into
+    # [64, 2_097_151] KB at connect.
+    stream_window_size_kb = config.market_data_stream_window_size_kb
+    connection_window_size_kb = config.market_data_connection_window_size_kb
+    print(
+        f"[bench] effective h2 windows: stream={stream_window_size_kb} KB, "
+        f"connection={connection_window_size_kb} KB",
+        file=sys.stderr,
+    )
+    print(
+        f"[bench] streaming option_history_quote {symbol} exp={expiration} date={date} "
+        f"interval={interval} strike=* right=both (no deadline)",
+        file=sys.stderr,
+    )
+
+    rows = 0
+    chunks = 0
+    ttfb: float | None = None
+    last_log = time.monotonic()
+
+    # Dispatch clock: started immediately before dispatching the stream call
+    # so TTFB excludes connect/auth and measures backend-to-first-chunk latency.
+    dispatch = time.monotonic()
+
+    def on_chunk(chunk: list) -> None:
+        nonlocal rows, chunks, ttfb, last_log
+        if ttfb is None:
+            ttfb = time.monotonic() - dispatch
+        rows += len(chunk)
+        chunks += 1
+        # Lightweight liveness so a 10-minute pull is not silent.
+        now = time.monotonic()
+        if now - last_log >= 10.0:
+            last_log = now
+            secs = max(now - dispatch, sys.float_info.epsilon)
+            approx_mib = (rows * QUOTE_TICK_SIZE) / MIB
+            print(
+                f"[bench] +{secs:6.0f}s rows={rows} chunks={chunks} "
+                f"~{approx_mib:.2f} MiB in-mem ({approx_mib / secs:.2f} MiB/s)",
+                file=sys.stderr,
+            )
+
+    # A full-day 0DTE pull can run 6-15 minutes; the config default
+    # request_timeout_secs (300 s) would kill it, so opt out of any deadline
+    # with timeout_ms=0 (normalized to "no deadline" by effective_deadline).
+    try:
+        (
+            client.option_history_quote_builder(symbol, expiration)
+            .strike("*")
+            .right("both")
+            .date(date)
+            .interval(interval)
+            .timeout_ms(0)
+            .stream(on_chunk)
+        )
+    except Exception as e:  # noqa: BLE001
+        total = time.monotonic() - dispatch
+        print(f"stream failed after {total:.1f}s: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    total = time.monotonic() - dispatch
+    secs = max(total, sys.float_info.epsilon)
+    ttfb_secs = ttfb if ttfb is not None else 0.0
+    # Approximate decoded VOLUME (in-memory, not wire): the `.stream()`
+    # callback exposes only parsed rows, so multiply the row count by the
+    # decoded row size. This is a lower bound on RSS (ignores per-row heap)
+    # and is unrelated to the compressed bytes that crossed the h2 window.
+    approx_decoded = rows * QUOTE_TICK_SIZE
+
+    # Greppable key=value block on stdout; progress/logs stay on stderr.
+    print(f"symbol={symbol}")
+    print(f"expiration={expiration}")
+    print(f"date={date}")
+    print(f"interval={interval}")
+    print(f"stream_window_size_kb={stream_window_size_kb}")
+    print(f"connection_window_size_kb={connection_window_size_kb}")
+    print(f"connect_auth_secs={connect_elapsed:.3f}")
+    print(f"ttfb_secs={ttfb_secs:.3f}")
+    print(f"total_secs={secs:.3f}")
+    print(f"rows={rows}")
+    print(f"chunks={chunks}")
+    print(f"rows_per_sec={rows / secs:.1f}")
+    print(f"quote_tick_size_bytes={QUOTE_TICK_SIZE}")
+    print(f"approx_decoded_bytes={approx_decoded}")
+    print(f"approx_decoded={human_bytes(approx_decoded)}")
+    print(f"approx_decoded_bytes_per_sec={approx_decoded / secs:.0f}")
+    print(f"approx_rate_mib_per_sec={approx_decoded / secs / MIB:.2f}")
+    print(
+        f"# approx_decoded* is in-memory volume = rows x QUOTE_TICK_SIZE "
+        f"({QUOTE_TICK_SIZE} B); not wire bytes"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -206,9 +206,9 @@ class Config:
     request_timeout_secs: int
     """Default per-request deadline, in seconds, for market-data queries. Bounds every request that did not set its own deadline, so a live-but-silent stream resolves to a timeout instead of blocking forever. ``0`` no longer disables the default: it is floored to the ``300``-second default at request time. The default is ``300`` (5 minutes)."""
     market_data_stream_window_size_kb: int
-    """Initial per-stream HTTP/2 flow-control window (KB) for the market-data gRPC channel. A larger window raises the throughput ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in. The value is clamped into ``[64, 2_097_151]`` KB at validate/connect time. The default is ``1024`` (1 MiB)."""
+    """Initial per-stream HTTP/2 flow-control window (KB) for the market-data gRPC channel. A larger window raises the throughput ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in. The value is clamped into ``[64, 2_097_151]`` KB at validate/connect time. The default is ``8192`` (8 MiB)."""
     market_data_connection_window_size_kb: int
-    """Initial connection-level HTTP/2 flow-control window (KB) for the market-data gRPC channel. A larger window raises the throughput ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in. The value is clamped into ``[64, 2_097_151]`` KB at validate/connect time. The default is ``8192`` (8 MiB)."""
+    """Initial connection-level HTTP/2 flow-control window (KB) for the market-data gRPC channel. A larger window raises the throughput ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in. The value is clamped into ``[64, 2_097_151]`` KB at validate/connect time. The default is ``16384`` (16 MiB)."""
     reconnect_policy: str
     """Active reconnect policy name: ``"auto"``, ``"manual"``, or ``"custom"`` (the last reported when a :attr:`reconnect_callback` is installed)."""
     reconnect_max_attempts: int

--- a/thetadatadx-py/python/thetadatadx/__init__.pyi
+++ b/thetadatadx-py/python/thetadatadx/__init__.pyi
@@ -205,6 +205,10 @@ class Config:
     """Byte ceiling above which a buffered (non-``.stream()``) historical response logs a warning pointing the caller at the streaming surface. ``0`` disables the warning; the default is ``100 * 1024 * 1024`` (100 MiB). The data is still delivered."""
     request_timeout_secs: int
     """Default per-request deadline, in seconds, for market-data queries. Bounds every request that did not set its own deadline, so a live-but-silent stream resolves to a timeout instead of blocking forever. ``0`` no longer disables the default: it is floored to the ``300``-second default at request time. The default is ``300`` (5 minutes)."""
+    market_data_stream_window_size_kb: int
+    """Initial per-stream HTTP/2 flow-control window (KB) for the market-data gRPC channel. A larger window raises the throughput ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in. The value is clamped into ``[64, 2_097_151]`` KB at validate/connect time. The default is ``1024`` (1 MiB)."""
+    market_data_connection_window_size_kb: int
+    """Initial connection-level HTTP/2 flow-control window (KB) for the market-data gRPC channel. A larger window raises the throughput ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in. The value is clamped into ``[64, 2_097_151]`` KB at validate/connect time. The default is ``8192`` (8 MiB)."""
     reconnect_policy: str
     """Active reconnect policy name: ``"auto"``, ``"manual"``, or ``"custom"`` (the last reported when a :attr:`reconnect_callback` is installed)."""
     reconnect_max_attempts: int

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -458,7 +458,7 @@ impl Config {
     /// market-data gRPC channel. A larger window raises the throughput ceiling
     /// on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
     /// is clamped into ``[64, 2_097_151]`` KB at validate/connect time.
-    /// Default is ``1024`` (1 MiB).
+    /// Default is ``8192`` (8 MiB).
     ///
     /// Examples
     /// --------
@@ -471,7 +471,7 @@ impl Config {
     }
 
     /// Current per-stream HTTP/2 flow-control window (KB) for the market-data
-    /// gRPC channel (default ``1024``).
+    /// gRPC channel (default ``8192``).
     #[getter]
     fn get_market_data_stream_window_size_kb(&self) -> usize {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -482,7 +482,7 @@ impl Config {
     /// the market-data gRPC channel. A larger window raises the throughput
     /// ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
     /// The value is clamped into ``[64, 2_097_151]`` KB at validate/connect
-    /// time. Default is ``8192`` (8 MiB).
+    /// time. Default is ``16384`` (16 MiB).
     ///
     /// Examples
     /// --------
@@ -495,7 +495,7 @@ impl Config {
     }
 
     /// Current connection-level HTTP/2 flow-control window (KB) for the
-    /// market-data gRPC channel (default ``8192``).
+    /// market-data gRPC channel (default ``16384``).
     #[getter]
     fn get_market_data_connection_window_size_kb(&self) -> usize {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/thetadatadx-py/src/_generated/config_accessors.rs
+++ b/thetadatadx-py/src/_generated/config_accessors.rs
@@ -454,6 +454,54 @@ impl Config {
         guard.market_data.request_timeout_secs
     }
 
+    /// Set the initial per-stream HTTP/2 flow-control window (in KB) for the
+    /// market-data gRPC channel. A larger window raises the throughput ceiling
+    /// on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
+    /// is clamped into ``[64, 2_097_151]`` KB at validate/connect time.
+    /// Default is ``1024`` (1 MiB).
+    ///
+    /// Examples
+    /// --------
+    ///     cfg = Config.production()
+    ///     cfg.market_data_stream_window_size_kb = 4096
+    #[setter]
+    fn set_market_data_stream_window_size_kb(&self, kb: usize) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.market_data.stream_window_size_kb = kb;
+    }
+
+    /// Current per-stream HTTP/2 flow-control window (KB) for the market-data
+    /// gRPC channel (default ``1024``).
+    #[getter]
+    fn get_market_data_stream_window_size_kb(&self) -> usize {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.market_data.stream_window_size_kb
+    }
+
+    /// Set the initial connection-level HTTP/2 flow-control window (in KB) for
+    /// the market-data gRPC channel. A larger window raises the throughput
+    /// ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+    /// The value is clamped into ``[64, 2_097_151]`` KB at validate/connect
+    /// time. Default is ``8192`` (8 MiB).
+    ///
+    /// Examples
+    /// --------
+    ///     cfg = Config.production()
+    ///     cfg.market_data_connection_window_size_kb = 16384
+    #[setter]
+    fn set_market_data_connection_window_size_kb(&self, kb: usize) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.market_data.connection_window_size_kb = kb;
+    }
+
+    /// Current connection-level HTTP/2 flow-control window (KB) for the
+    /// market-data gRPC channel (default ``8192``).
+    #[getter]
+    fn get_market_data_connection_window_size_kb(&self) -> usize {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.market_data.connection_window_size_kb
+    }
+
     /// Current ``retry.initial_delay`` value in ms.
     #[getter]
     fn get_retry_initial_delay_ms(&self) -> u64 {

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -1424,6 +1424,157 @@ Current market-data `request_timeout_secs` setting in seconds
 default at request time rather than disabling the deadline.
 """
 
+[[accessor]]
+symbol = "thetadatadx_config_set_market_data_stream_window_size_kb"
+kind = "set"
+param = "kb"
+abi_type = "usize"
+path = "market_data.stream_window_size_kb"
+doc = """
+Set the initial per-stream HTTP/2 flow-control window, in KB, for the
+market-data gRPC channel on a config handle. A larger window raises the
+throughput ceiling on bulk streaming pulls before HTTP/2 backpressure
+kicks in. Default `1024` (1 MiB); `DirectConfig` validation (and the
+connect path) clamps the applied value into `[64, 2_097_151]` KB.
+"""
+cpp_doc = """
+Set the initial per-stream HTTP/2 flow-control window, in KB, for the
+market-data gRPC channel. A larger window raises the throughput ceiling
+on bulk streaming pulls before HTTP/2 backpressure kicks in.
+@p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
+Default is `1024` (1 MiB).
+"""
+py_doc = """
+Set the initial per-stream HTTP/2 flow-control window (in KB) for the
+market-data gRPC channel. A larger window raises the throughput ceiling
+on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
+is clamped into ``[64, 2_097_151]`` KB at validate/connect time.
+Default is ``1024`` (1 MiB).
+
+Examples
+--------
+    cfg = Config.production()
+    cfg.market_data_stream_window_size_kb = 4096
+"""
+ts_doc = """
+Set the initial per-stream HTTP/2 flow-control window (in KB) for the
+market-data gRPC channel. A larger window raises the throughput ceiling
+on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
+is clamped into `[64, 2_097_151]` KB at validate/connect time. Default
+`1024n` (1 MiB). KB are taken as a `BigInt` for parity with the other
+byte/KB-denominated knobs.
+"""
+py_param = "kb"
+ts_param = "kb"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_market_data_stream_window_size_kb"
+kind = "get"
+param = "out_kb"
+abi_type = "usize"
+path = "market_data.stream_window_size_kb"
+out_safety = """
+        // SAFETY: out_kb null-checked above; caller pins the storage for the call duration.
+"""
+doc = """
+Read the current per-stream HTTP/2 flow-control window (KB) for the
+market-data gRPC channel (default `1024`).
+
+Writes the configured value into `*out_kb`. Returns `0` on success,
+`-1` if either pointer is null.
+"""
+cpp_doc = """
+Read the current per-stream HTTP/2 flow-control window (KB) for the
+market-data gRPC channel.
+
+Returns the configured KB value, or `0` on a null handle (matching the
+C ABI's `-1` failure mapping at the boundary).
+"""
+py_doc = """
+Current per-stream HTTP/2 flow-control window (KB) for the market-data
+gRPC channel (default ``1024``).
+"""
+ts_doc = """
+Current per-stream HTTP/2 flow-control window (KB) for the market-data
+gRPC channel (default `1024n`, returned as a `BigInt`).
+"""
+
+[[accessor]]
+symbol = "thetadatadx_config_set_market_data_connection_window_size_kb"
+kind = "set"
+param = "kb"
+abi_type = "usize"
+path = "market_data.connection_window_size_kb"
+doc = """
+Set the initial connection-level HTTP/2 flow-control window, in KB, for
+the market-data gRPC channel on a config handle. A larger window raises
+the throughput ceiling on bulk streaming pulls before HTTP/2
+backpressure kicks in. Default `8192` (8 MiB); `DirectConfig`
+validation (and the connect path) clamps the applied value into
+`[64, 2_097_151]` KB.
+"""
+cpp_doc = """
+Set the initial connection-level HTTP/2 flow-control window, in KB, for
+the market-data gRPC channel. A larger window raises the throughput
+ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+@p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
+Default is `8192` (8 MiB).
+"""
+py_doc = """
+Set the initial connection-level HTTP/2 flow-control window (in KB) for
+the market-data gRPC channel. A larger window raises the throughput
+ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+The value is clamped into ``[64, 2_097_151]`` KB at validate/connect
+time. Default is ``8192`` (8 MiB).
+
+Examples
+--------
+    cfg = Config.production()
+    cfg.market_data_connection_window_size_kb = 16384
+"""
+ts_doc = """
+Set the initial connection-level HTTP/2 flow-control window (in KB) for
+the market-data gRPC channel. A larger window raises the throughput
+ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+The value is clamped into `[64, 2_097_151]` KB at validate/connect
+time. Default `8192n` (8 MiB). KB are taken as a `BigInt` for parity
+with the other byte/KB-denominated knobs.
+"""
+py_param = "kb"
+ts_param = "kb"
+
+[[accessor]]
+symbol = "thetadatadx_config_get_market_data_connection_window_size_kb"
+kind = "get"
+param = "out_kb"
+abi_type = "usize"
+path = "market_data.connection_window_size_kb"
+out_safety = """
+        // SAFETY: out_kb null-checked above; caller pins the storage for the call duration.
+"""
+doc = """
+Read the current connection-level HTTP/2 flow-control window (KB) for
+the market-data gRPC channel (default `8192`).
+
+Writes the configured value into `*out_kb`. Returns `0` on success,
+`-1` if either pointer is null.
+"""
+cpp_doc = """
+Read the current connection-level HTTP/2 flow-control window (KB) for
+the market-data gRPC channel.
+
+Returns the configured KB value, or `0` on a null handle (matching the
+C ABI's `-1` failure mapping at the boundary).
+"""
+py_doc = """
+Current connection-level HTTP/2 flow-control window (KB) for the
+market-data gRPC channel (default ``8192``).
+"""
+ts_doc = """
+Current connection-level HTTP/2 flow-control window (KB) for the
+market-data gRPC channel (default `8192n`, returned as a `BigInt`).
+"""
+
 
 # ── retry Duration getters (ms) ────────────────────────────────────
 #

--- a/thetadatadx-rs/config_surface.toml
+++ b/thetadatadx-rs/config_surface.toml
@@ -1434,7 +1434,7 @@ doc = """
 Set the initial per-stream HTTP/2 flow-control window, in KB, for the
 market-data gRPC channel on a config handle. A larger window raises the
 throughput ceiling on bulk streaming pulls before HTTP/2 backpressure
-kicks in. Default `1024` (1 MiB); `DirectConfig` validation (and the
+kicks in. Default `8192` (8 MiB); `DirectConfig` validation (and the
 connect path) clamps the applied value into `[64, 2_097_151]` KB.
 """
 cpp_doc = """
@@ -1442,14 +1442,14 @@ Set the initial per-stream HTTP/2 flow-control window, in KB, for the
 market-data gRPC channel. A larger window raises the throughput ceiling
 on bulk streaming pulls before HTTP/2 backpressure kicks in.
 @p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
-Default is `1024` (1 MiB).
+Default is `8192` (8 MiB).
 """
 py_doc = """
 Set the initial per-stream HTTP/2 flow-control window (in KB) for the
 market-data gRPC channel. A larger window raises the throughput ceiling
 on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
 is clamped into ``[64, 2_097_151]`` KB at validate/connect time.
-Default is ``1024`` (1 MiB).
+Default is ``8192`` (8 MiB).
 
 Examples
 --------
@@ -1461,7 +1461,7 @@ Set the initial per-stream HTTP/2 flow-control window (in KB) for the
 market-data gRPC channel. A larger window raises the throughput ceiling
 on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
 is clamped into `[64, 2_097_151]` KB at validate/connect time. Default
-`1024n` (1 MiB). KB are taken as a `BigInt` for parity with the other
+`8192n` (8 MiB). KB are taken as a `BigInt` for parity with the other
 byte/KB-denominated knobs.
 """
 py_param = "kb"
@@ -1478,7 +1478,7 @@ out_safety = """
 """
 doc = """
 Read the current per-stream HTTP/2 flow-control window (KB) for the
-market-data gRPC channel (default `1024`).
+market-data gRPC channel (default `8192`).
 
 Writes the configured value into `*out_kb`. Returns `0` on success,
 `-1` if either pointer is null.
@@ -1492,11 +1492,11 @@ C ABI's `-1` failure mapping at the boundary).
 """
 py_doc = """
 Current per-stream HTTP/2 flow-control window (KB) for the market-data
-gRPC channel (default ``1024``).
+gRPC channel (default ``8192``).
 """
 ts_doc = """
 Current per-stream HTTP/2 flow-control window (KB) for the market-data
-gRPC channel (default `1024n`, returned as a `BigInt`).
+gRPC channel (default `8192n`, returned as a `BigInt`).
 """
 
 [[accessor]]
@@ -1509,7 +1509,7 @@ doc = """
 Set the initial connection-level HTTP/2 flow-control window, in KB, for
 the market-data gRPC channel on a config handle. A larger window raises
 the throughput ceiling on bulk streaming pulls before HTTP/2
-backpressure kicks in. Default `8192` (8 MiB); `DirectConfig`
+backpressure kicks in. Default `16384` (16 MiB); `DirectConfig`
 validation (and the connect path) clamps the applied value into
 `[64, 2_097_151]` KB.
 """
@@ -1518,14 +1518,14 @@ Set the initial connection-level HTTP/2 flow-control window, in KB, for
 the market-data gRPC channel. A larger window raises the throughput
 ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
 @p kb is clamped into `[64, 2_097_151]` KB at validate/connect time.
-Default is `8192` (8 MiB).
+Default is `16384` (16 MiB).
 """
 py_doc = """
 Set the initial connection-level HTTP/2 flow-control window (in KB) for
 the market-data gRPC channel. A larger window raises the throughput
 ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
 The value is clamped into ``[64, 2_097_151]`` KB at validate/connect
-time. Default is ``8192`` (8 MiB).
+time. Default is ``16384`` (16 MiB).
 
 Examples
 --------
@@ -1537,7 +1537,7 @@ Set the initial connection-level HTTP/2 flow-control window (in KB) for
 the market-data gRPC channel. A larger window raises the throughput
 ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
 The value is clamped into `[64, 2_097_151]` KB at validate/connect
-time. Default `8192n` (8 MiB). KB are taken as a `BigInt` for parity
+time. Default `16384n` (16 MiB). KB are taken as a `BigInt` for parity
 with the other byte/KB-denominated knobs.
 """
 py_param = "kb"
@@ -1554,7 +1554,7 @@ out_safety = """
 """
 doc = """
 Read the current connection-level HTTP/2 flow-control window (KB) for
-the market-data gRPC channel (default `8192`).
+the market-data gRPC channel (default `16384`).
 
 Writes the configured value into `*out_kb`. Returns `0` on success,
 `-1` if either pointer is null.
@@ -1568,11 +1568,11 @@ C ABI's `-1` failure mapping at the boundary).
 """
 py_doc = """
 Current connection-level HTTP/2 flow-control window (KB) for the
-market-data gRPC channel (default ``8192``).
+market-data gRPC channel (default ``16384``).
 """
 ts_doc = """
 Current connection-level HTTP/2 flow-control window (KB) for the
-market-data gRPC channel (default `8192n`, returned as a `BigInt`).
+market-data gRPC channel (default `16384n`, returned as a `BigInt`).
 """
 
 

--- a/thetadatadx-rs/examples/chain_quote_bench.rs
+++ b/thetadatadx-rs/examples/chain_quote_bench.rs
@@ -10,7 +10,7 @@
 //!         [symbol] [expiration] [date] [interval]
 //!
 //! Args (all optional):
-//!   symbol      option root (default SPX)
+//!   symbol      option root (default SPXW)
 //!   expiration  contract expiration YYYYMMDD (default 20260710)
 //!   date        history date YYYYMMDD (default = expiration, i.e. a 0DTE pull)
 //!   interval    tick | 1s | 1m | ... (default tick)
@@ -32,7 +32,7 @@ use thetadatadx::{Credentials, DirectConfig, MarketDataClient, QuoteTick};
 
 const USAGE: &str = "\
 usage: chain_quote_bench [symbol] [expiration] [date] [interval]
-       defaults: SPX 20260710 <expiration> tick
+       defaults: SPXW 20260710 <expiration> tick
        date defaults to <expiration> (a 0DTE full-chain pull)
        h2 windows come from the STREAM_WINDOW_SIZE_KB / CONNECTION_WINDOW_SIZE_KB
        constants in this file; edit and rebuild to test different values

--- a/thetadatadx-rs/examples/chain_quote_bench.rs
+++ b/thetadatadx-rs/examples/chain_quote_bench.rs
@@ -1,6 +1,6 @@
 //! Full-chain option quote streaming benchmark.
 //!
-//! Pulls an entire option chain's quote history over the streaming MDDS
+//! Pulls an entire option chain's quote history over the streaming market-data
 //! endpoint and reports TTFB, throughput, and an approximate in-memory decoded
 //! volume so the effect of the h2 flow-control window sizes can be measured
 //! against the live backend.

--- a/thetadatadx-rs/examples/chain_quote_bench.rs
+++ b/thetadatadx-rs/examples/chain_quote_bench.rs
@@ -1,0 +1,232 @@
+//! Full-chain option quote streaming benchmark.
+//!
+//! Pulls an entire option chain's quote history over the streaming MDDS
+//! endpoint and reports TTFB, throughput, and an approximate in-memory decoded
+//! volume so the effect of the h2 flow-control window sizes can be measured
+//! against the live backend.
+//!
+//! Usage:
+//!     cargo run --release --example chain_quote_bench -- \
+//!         [symbol] [expiration] [date] [interval]
+//!
+//! Args (all optional):
+//!   symbol      option root (default SPX)
+//!   expiration  contract expiration YYYYMMDD (default 20260710)
+//!   date        history date YYYYMMDD (default = expiration, i.e. a 0DTE pull)
+//!   interval    tick | 1s | 1m | ... (default tick)
+//!
+//! The h2 windows are set on the config before connect via
+//! [`STREAM_WINDOW_SIZE_KB`] / [`CONNECTION_WINDOW_SIZE_KB`] — edit those
+//! constants and rebuild to benchmark different values (both are clamped
+//! into `[64, 2_097_151]` KB by `DirectConfig::validate`, which
+//! `MarketDataClient::connect` runs). The effective (validated) values are
+//! printed on every run.
+//!
+//! Credentials are loaded from `$CREDS` (default `./creds.txt`).
+
+use std::process::ExitCode;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use thetadatadx::{Credentials, DirectConfig, MarketDataClient, QuoteTick};
+
+const USAGE: &str = "\
+usage: chain_quote_bench [symbol] [expiration] [date] [interval]
+       defaults: SPX 20260710 <expiration> tick
+       date defaults to <expiration> (a 0DTE full-chain pull)
+       h2 windows come from the STREAM_WINDOW_SIZE_KB / CONNECTION_WINDOW_SIZE_KB
+       constants in this file; edit and rebuild to test different values
+       credentials from $CREDS (default ./creds.txt)";
+
+/// h2 flow-control windows applied to `market_data.stream_window_size_kb` /
+/// `.connection_window_size_kb` before connect. Edit and rebuild to benchmark
+/// different values; `DirectConfig::validate` clamps both into
+/// `[64, 2_097_151]` KB at connect.
+const STREAM_WINDOW_SIZE_KB: usize = 8_192;
+// const STREAM_WINDOW_SIZE_KB: usize = 64;
+const CONNECTION_WINDOW_SIZE_KB: usize = 32_768;
+// const CONNECTION_WINDOW_SIZE_KB: usize = 64;
+
+const MIB: f64 = 1024.0 * 1024.0;
+
+/// Decoded in-memory size of a single parsed quote row. The `.stream()`
+/// callback only exposes `&[QuoteTick]`, so decoded volume is approximated as
+/// `rows * size_of::<QuoteTick>()` — an in-memory figure, not wire bytes.
+const QUOTE_TICK_SIZE: usize = std::mem::size_of::<QuoteTick>();
+
+/// Per-chunk state shared between the stream handler and the post-run report.
+/// The handler is invoked once per chunk under the crate's internal mutex, so
+/// a single `Mutex` here is uncontended.
+struct Progress {
+    rows: u64,
+    chunks: u64,
+    ttfb: Option<Duration>,
+    last_log: Instant,
+}
+
+fn arg_or(args: &[String], idx: usize, default: &str) -> String {
+    args.get(idx)
+        .map(String::as_str)
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn human_bytes(n: u64) -> String {
+    let f = n as f64;
+    const GIB: f64 = MIB * 1024.0;
+    if f >= GIB {
+        format!("{:.2} GiB", f / GIB)
+    } else {
+        format!("{:.2} MiB", f / MIB)
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> ExitCode {
+    // Pin ring as the single rustls `CryptoProvider` via the standard
+    // `install_default` path — the workspace compiles rustls with only the
+    // `ring` provider, so this seats it before the first TLS handshake.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        println!("{USAGE}");
+        return ExitCode::SUCCESS;
+    }
+    if args.len() > 5 {
+        eprintln!("{USAGE}");
+        return ExitCode::from(2);
+    }
+
+    let symbol = arg_or(&args, 1, "SPXW");
+    let expiration = arg_or(&args, 2, "20260710");
+    let date = arg_or(&args, 3, &expiration);
+    let interval = arg_or(&args, 4, "tick");
+
+    let creds_path = std::env::var("CREDS").unwrap_or_else(|_| "creds.txt".to_string());
+    let creds = match Credentials::from_file(&creds_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("creds load failed ({creds_path}): {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // `production()` supplies the defaults; the benchmark constants override
+    // the h2 window knobs before connect, which clamps the applied values
+    // into [64, 2_097_151] KB via `validate`.
+    let mut config = DirectConfig::production();
+    config.market_data.stream_window_size_kb = STREAM_WINDOW_SIZE_KB;
+    config.market_data.connection_window_size_kb = CONNECTION_WINDOW_SIZE_KB;
+
+    let connect_start = Instant::now();
+    let client = match MarketDataClient::connect(&creds, config).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("connect failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let connect_elapsed = connect_start.elapsed();
+
+    // Effective (validated) h2 window sizes, so every run is self-documenting.
+    let stream_window_size_kb = client.config().market_data.stream_window_size_kb;
+    let connection_window_size_kb = client.config().market_data.connection_window_size_kb;
+    eprintln!(
+        "[bench] effective h2 windows: stream={stream_window_size_kb} KB, connection={connection_window_size_kb} KB"
+    );
+    eprintln!(
+        "[bench] streaming option_history_quote {symbol} exp={expiration} date={date} \
+         interval={interval} strike=* right=both (no deadline)"
+    );
+
+    let progress = Arc::new(Mutex::new(Progress {
+        rows: 0,
+        chunks: 0,
+        ttfb: None,
+        last_log: Instant::now(),
+    }));
+
+    // Dispatch clock: started immediately before awaiting the stream so TTFB
+    // excludes connect/auth and measures backend-to-first-chunk latency.
+    let dispatch = Instant::now();
+    let handler_progress = progress.clone();
+    // A full-day 0DTE pull can run 6-15 minutes; the config default
+    // `request_timeout_secs` (300 s) would kill it, so opt out of any deadline
+    // with `Duration::ZERO` (normalized to "no deadline" by `effective_deadline`).
+    let stream_result = client
+        .option_history_quote_stream(&symbol, &expiration)
+        .date(&date)
+        .strike("*")
+        .right("both")
+        .interval(&interval)
+        .with_deadline(Duration::ZERO)
+        .stream(move |ticks| {
+            let mut p = handler_progress.lock().expect("progress mutex poisoned");
+            if p.ttfb.is_none() {
+                p.ttfb = Some(dispatch.elapsed());
+            }
+            p.rows += ticks.len() as u64;
+            p.chunks += 1;
+            // Lightweight liveness so a 10-minute pull is not silent.
+            if p.last_log.elapsed() >= Duration::from_secs(10) {
+                p.last_log = Instant::now();
+                let secs = dispatch.elapsed().as_secs_f64().max(f64::EPSILON);
+                let approx_mib = (p.rows * QUOTE_TICK_SIZE as u64) as f64 / MIB;
+                eprintln!(
+                    "[bench] +{secs:6.0}s rows={} chunks={} ~{approx_mib:.2} MiB in-mem ({:.2} MiB/s)",
+                    p.rows,
+                    p.chunks,
+                    approx_mib / secs,
+                );
+            }
+        })
+        .await;
+    let total = dispatch.elapsed();
+
+    if let Err(e) = stream_result {
+        eprintln!("stream failed after {:.1}s: {e}", total.as_secs_f64());
+        return ExitCode::FAILURE;
+    }
+
+    let (rows, chunks, ttfb) = {
+        let p = progress.lock().expect("progress mutex poisoned");
+        (p.rows, p.chunks, p.ttfb.unwrap_or_default())
+    };
+    let secs = total.as_secs_f64().max(f64::EPSILON);
+    // Approximate decoded VOLUME (in-memory, not wire): the public `.stream()`
+    // callback exposes only parsed `&[QuoteTick]`, so multiply the row count by
+    // the decoded row size. This is a lower bound on RSS (ignores per-row heap)
+    // and is unrelated to the compressed bytes that crossed the h2 window.
+    let approx_decoded = rows * QUOTE_TICK_SIZE as u64;
+
+    // Greppable key=value block on stdout; progress/logs stay on stderr.
+    println!("symbol={symbol}");
+    println!("expiration={expiration}");
+    println!("date={date}");
+    println!("interval={interval}");
+    println!("stream_window_size_kb={stream_window_size_kb}");
+    println!("connection_window_size_kb={connection_window_size_kb}");
+    println!("connect_auth_secs={:.3}", connect_elapsed.as_secs_f64());
+    println!("ttfb_secs={:.3}", ttfb.as_secs_f64());
+    println!("total_secs={secs:.3}");
+    println!("rows={rows}");
+    println!("chunks={chunks}");
+    println!("rows_per_sec={:.1}", rows as f64 / secs);
+    println!("quote_tick_size_bytes={QUOTE_TICK_SIZE}");
+    println!("approx_decoded_bytes={approx_decoded}");
+    println!("approx_decoded={}", human_bytes(approx_decoded));
+    println!(
+        "approx_decoded_bytes_per_sec={:.0}",
+        approx_decoded as f64 / secs
+    );
+    println!(
+        "approx_rate_mib_per_sec={:.2}",
+        approx_decoded as f64 / secs / MIB
+    );
+    println!(
+        "# approx_decoded* is in-memory volume = rows x size_of::<QuoteTick>() ({QUOTE_TICK_SIZE} B); not wire bytes"
+    );
+
+    ExitCode::SUCCESS
+}

--- a/thetadatadx-rs/src/config/mdds.rs
+++ b/thetadatadx-rs/src/config/mdds.rs
@@ -69,15 +69,16 @@ pub struct MarketDataConfig {
     /// gRPC flow control: initial stream window size in KB.
     ///
     /// Sets the per-stream HTTP/2 flow-control window on every market-data
-    /// channel. Default 64 KB matches the HTTP/2 spec default;
-    /// validation clamps to `[64, 1024]`.
-    pub window_size_kb: usize,
+    /// channel. Default 1024 KB (1 MiB) — well above the 64 KiB HTTP/2 spec
+    /// window, which throttles bulk pulls; validation clamps to
+    /// `[64, 2_097_151]`.
+    pub stream_window_size_kb: usize,
 
     /// gRPC flow control: initial connection window size in KB.
     ///
     /// Sets the connection-level HTTP/2 flow-control window on every
-    /// Market-data channel. Default 64 KB; validation clamps to `[64, 1024]`.
-    /// Increase for high-throughput bulk queries.
+    /// market-data channel. Default 8192 KB (8 MiB); validation clamps to
+    /// `[64, 2_097_151]`. Increase for high-throughput bulk queries.
     pub connection_window_size_kb: usize,
 
     /// TCP connect timeout for the market-data channel, in seconds.
@@ -177,8 +178,8 @@ impl MarketDataConfig {
             max_message_size: 4 * 1024 * 1024,
             keepalive_secs: 30,
             keepalive_timeout_secs: 10,
-            window_size_kb: 64,
-            connection_window_size_kb: 64,
+            stream_window_size_kb: 1_024,
+            connection_window_size_kb: 8_192,
             connect_timeout_secs: 10,
             // 5 min — bounds a server that holds the stream open while
             // sending no chunks (h2 keepalive only catches a fully dead

--- a/thetadatadx-rs/src/config/mdds.rs
+++ b/thetadatadx-rs/src/config/mdds.rs
@@ -69,7 +69,7 @@ pub struct MarketDataConfig {
     /// gRPC flow control: initial stream window size in KB.
     ///
     /// Sets the per-stream HTTP/2 flow-control window on every market-data
-    /// channel. Default 1024 KB (1 MiB) — well above the 64 KiB HTTP/2 spec
+    /// channel. Default 8192 KB (8 MiB) — well above the 64 KiB HTTP/2 spec
     /// window, which throttles bulk pulls; validation clamps to
     /// `[64, 2_097_151]`.
     pub stream_window_size_kb: usize,
@@ -77,7 +77,7 @@ pub struct MarketDataConfig {
     /// gRPC flow control: initial connection window size in KB.
     ///
     /// Sets the connection-level HTTP/2 flow-control window on every
-    /// market-data channel. Default 8192 KB (8 MiB); validation clamps to
+    /// market-data channel. Default 16384 KB (16 MiB); validation clamps to
     /// `[64, 2_097_151]`. Increase for high-throughput bulk queries.
     pub connection_window_size_kb: usize,
 
@@ -178,8 +178,8 @@ impl MarketDataConfig {
             max_message_size: 4 * 1024 * 1024,
             keepalive_secs: 30,
             keepalive_timeout_secs: 10,
-            stream_window_size_kb: 1_024,
-            connection_window_size_kb: 8_192,
+            stream_window_size_kb: 8_192,
+            connection_window_size_kb: 16_384,
             connect_timeout_secs: 10,
             // 5 min — bounds a server that holds the stream open while
             // sending no chunks (h2 keepalive only catches a fully dead

--- a/thetadatadx-rs/src/config/mod.rs
+++ b/thetadatadx-rs/src/config/mod.rs
@@ -749,7 +749,7 @@ impl DirectConfig {
     /// Validate configuration values and reject out-of-range tuning knobs.
     ///
     /// Returns the configuration with market-data HTTP/2 window sizes clamped
-    /// into `[64, 1024]` KB on success. Returns
+    /// into `[64, 2_097_151]` KB on success. Returns
     /// [`Error::Config`] when any wired streaming
     /// knob (`timeout_ms`, `connect_timeout_ms`, `ping_interval_ms`)
     /// falls outside its documented range — silent rounding would
@@ -1341,8 +1341,8 @@ mod config_file {
         /// ring_size = 131072
         ///
         /// [grpc]
-        /// stream_window_size_kb = 1024
-        /// connection_window_size_kb = 8192
+        /// stream_window_size_kb = 8192
+        /// connection_window_size_kb = 16384
         /// ```
         ///
         /// # Errors
@@ -2093,7 +2093,8 @@ mod tests {
     fn validate_preserves_in_range_values() {
         let config = DirectConfig::production_defaults();
         let validated = config.validate().expect("production defaults validate");
-        assert_eq!(validated.market_data.stream_window_size_kb, 1_024);
+        assert_eq!(validated.market_data.stream_window_size_kb, 8_192);
+        assert_eq!(validated.market_data.connection_window_size_kb, 16_384);
         assert_eq!(validated.streaming.timeout_ms, 10_000);
         assert_eq!(validated.streaming.ping_interval_ms, 100);
         assert_eq!(validated.streaming.connect_timeout_ms, 2_000);

--- a/thetadatadx-rs/src/config/mod.rs
+++ b/thetadatadx-rs/src/config/mod.rs
@@ -991,9 +991,14 @@ impl DirectConfig {
         if let Err(e) = crate::fpss::ring::check_ring_size(self.streaming.ring_size) {
             return Err(Error::config_invalid("streaming.ring_size", e.to_string()));
         }
-        self.market_data.window_size_kb = self.market_data.window_size_kb.clamp(64, 1_024);
-        self.market_data.connection_window_size_kb =
-            self.market_data.connection_window_size_kb.clamp(64, 1_024);
+        // h2 caps a flow-control window at 2^31 - 1 bytes, so 2_097_151 KB
+        // (the largest whole-KB value under that ceiling) is the upper bound.
+        self.market_data.stream_window_size_kb =
+            self.market_data.stream_window_size_kb.clamp(64, 2_097_151);
+        self.market_data.connection_window_size_kb = self
+            .market_data
+            .connection_window_size_kb
+            .clamp(64, 2_097_151);
         // The market-data channel needs a routable port. A `0` port is never a
         // valid dial target, so reject it up front rather than at the connect
         // attempt.
@@ -1241,7 +1246,7 @@ mod config_file {
     #[derive(Debug, Deserialize)]
     #[serde(default, deny_unknown_fields)]
     struct GrpcSection {
-        window_size_kb: usize,
+        stream_window_size_kb: usize,
         connection_window_size_kb: usize,
         /// Max inbound message size, in MB. `None` (key absent) leaves the
         /// `[market_data].max_message_size` byte value in force; an explicit
@@ -1256,7 +1261,7 @@ mod config_file {
         fn default() -> Self {
             let prod = DirectConfig::production_defaults();
             Self {
-                window_size_kb: prod.market_data.window_size_kb,
+                stream_window_size_kb: prod.market_data.stream_window_size_kb,
                 connection_window_size_kb: prod.market_data.connection_window_size_kb,
                 // Absent by default so `[market_data].max_message_size`
                 // remains the single source of truth unless the operator
@@ -1336,8 +1341,8 @@ mod config_file {
         /// ring_size = 131072
         ///
         /// [grpc]
-        /// window_size_kb = 64
-        /// connection_window_size_kb = 64
+        /// stream_window_size_kb = 1024
+        /// connection_window_size_kb = 8192
         /// ```
         ///
         /// # Errors
@@ -1417,7 +1422,7 @@ mod config_file {
             out.market_data.max_message_size = max_message_size;
             out.market_data.keepalive_secs = cf.market_data.keepalive_time_secs;
             out.market_data.keepalive_timeout_secs = cf.market_data.keepalive_timeout_secs;
-            out.market_data.window_size_kb = cf.grpc.window_size_kb;
+            out.market_data.stream_window_size_kb = cf.grpc.stream_window_size_kb;
             out.market_data.connection_window_size_kb = cf.grpc.connection_window_size_kb;
             // mdds.connect_timeout_secs is not yet TOML-surfaced; keep production default.
 
@@ -1767,11 +1772,11 @@ mod tests {
         fn grpc_section_sets_window_sizes() {
             let toml = r#"
                 [grpc]
-                window_size_kb = 128
+                stream_window_size_kb = 128
                 connection_window_size_kb = 256
             "#;
             let config = DirectConfig::from_toml_str(toml).unwrap();
-            assert_eq!(config.market_data.window_size_kb, 128);
+            assert_eq!(config.market_data.stream_window_size_kb, 128);
             assert_eq!(config.market_data.connection_window_size_kb, 256);
         }
 
@@ -1937,8 +1942,8 @@ mod tests {
                 prod.market_data.max_message_size
             );
             assert_eq!(
-                config.market_data.window_size_kb,
-                prod.market_data.window_size_kb
+                config.market_data.stream_window_size_kb,
+                prod.market_data.stream_window_size_kb
             );
             assert_eq!(
                 config.market_data.connection_window_size_kb,
@@ -2075,12 +2080,12 @@ mod tests {
     #[test]
     fn validate_clamps_market_data_window_sizes_into_range() {
         let mut config = DirectConfig::production_defaults();
-        config.market_data.window_size_kb = 2_048;
+        config.market_data.stream_window_size_kb = 3_000_000;
         config.market_data.connection_window_size_kb = 32;
         let config = config
             .validate()
             .expect("market-data window sizes are clamped");
-        assert_eq!(config.market_data.window_size_kb, 1_024);
+        assert_eq!(config.market_data.stream_window_size_kb, 2_097_151);
         assert_eq!(config.market_data.connection_window_size_kb, 64);
     }
 
@@ -2088,7 +2093,7 @@ mod tests {
     fn validate_preserves_in_range_values() {
         let config = DirectConfig::production_defaults();
         let validated = config.validate().expect("production defaults validate");
-        assert_eq!(validated.market_data.window_size_kb, 64);
+        assert_eq!(validated.market_data.stream_window_size_kb, 1_024);
         assert_eq!(validated.streaming.timeout_ms, 10_000);
         assert_eq!(validated.streaming.ping_interval_ms, 100);
         assert_eq!(validated.streaming.connect_timeout_ms, 2_000);

--- a/thetadatadx-rs/src/grpc/channel.rs
+++ b/thetadatadx-rs/src/grpc/channel.rs
@@ -50,15 +50,15 @@ const USER_AGENT_PREFIX: &str = "thetadatadx-grpc";
 
 /// HTTP/2 session tuning threaded from `DirectConfig::mdds` —
 /// flow-control windows and keepalive cadence. The short channel
-/// constructors use [`ChannelTuning::default`] (the HTTP/2 spec
-/// windows, 30 s / 10 s keepalive — the values production config
-/// defaults to); `MarketDataClient::connect` threads the operator's
-/// configured values through [`Channel::connect_tls_tuned`] /
-/// [`Channel::connect_h2c_tuned`].
+/// constructors use [`ChannelTuning::default`] (the 64 KiB HTTP/2 spec
+/// windows, 30 s / 10 s keepalive — a deliberately untuned connection,
+/// below the larger production-config defaults); `MarketDataClient::connect`
+/// threads the operator's configured values through
+/// [`Channel::connect_tls_tuned`] / [`Channel::connect_h2c_tuned`].
 #[derive(Debug, Clone, Copy)]
 pub struct ChannelTuning {
     /// Initial per-stream flow-control window, in bytes. Mirrors
-    /// `MarketDataConfig::window_size_kb`.
+    /// `MarketDataConfig::stream_window_size_kb`.
     pub initial_stream_window_size: u32,
     /// Initial connection-level flow-control window, in bytes.
     /// Mirrors `MarketDataConfig::connection_window_size_kb`.
@@ -75,8 +75,9 @@ pub struct ChannelTuning {
 impl Default for ChannelTuning {
     fn default() -> Self {
         Self {
-            // HTTP/2 spec initial windows (64 KiB) — the same wire
-            // shape the production config defaults to.
+            // HTTP/2 spec initial windows (64 KiB) — a deliberately
+            // untuned connection for the short constructors, below the
+            // larger production-config defaults.
             initial_stream_window_size: 64 * 1024,
             initial_connection_window_size: 64 * 1024,
             keepalive_interval: Duration::from_secs(30),

--- a/thetadatadx-rs/src/mdds/client.rs
+++ b/thetadatadx-rs/src/mdds/client.rs
@@ -567,12 +567,15 @@ async fn open_channel_pool(
     let connect_timeout = Duration::from_secs(config.market_data.connect_timeout_secs);
     let max_message_size = config.market_data.max_message_size;
     // HTTP/2 session tuning from the operator's config: flow-control
-    // windows (`window_size_kb` / `connection_window_size_kb`, already
-    // clamped to [64, 1024] KB by `DirectConfig::validate`) and the
+    // windows (`stream_window_size_kb` / `connection_window_size_kb`, already
+    // clamped to [64, 2_097_151] KB by `DirectConfig::validate`) and the
     // keepalive cadence (`keepalive_secs` / `keepalive_timeout_secs`).
     let tuning = ChannelTuning {
         initial_stream_window_size: u32::try_from(
-            config.market_data.window_size_kb.saturating_mul(1024),
+            config
+                .market_data
+                .stream_window_size_kb
+                .saturating_mul(1024),
         )
         .unwrap_or(u32::MAX),
         initial_connection_window_size: u32::try_from(

--- a/thetadatadx-ts/examples/chain_quote_bench.ts
+++ b/thetadatadx-ts/examples/chain_quote_bench.ts
@@ -8,7 +8,7 @@
 // sizes can be measured against the live backend.
 //
 // Run with:
-//     npx tsx examples/chain_quote_bench.ts -- [symbol] [expiration] [date] [interval]
+//     npx tsx examples/chain_quote_bench.ts [symbol] [expiration] [date] [interval]
 //
 // Args (all optional):
 //   symbol      option root (default SPXW)
@@ -38,10 +38,10 @@ const USAGE = `usage: chain_quote_bench.ts [symbol] [expiration] [date] [interva
 // / `setMarketDataConnectionWindowSizeKb` before connect. Edit and rerun to
 // benchmark different values; validate/connect clamps both into
 // [64, 2_097_151] KB.
-// const STREAM_WINDOW_SIZE_KB = 8_192;
-const STREAM_WINDOW_SIZE_KB = 64;
-// const CONNECTION_WINDOW_SIZE_KB = 32_768;
-const CONNECTION_WINDOW_SIZE_KB = 64;
+const STREAM_WINDOW_SIZE_KB = 8_192;
+// const STREAM_WINDOW_SIZE_KB = 64;
+const CONNECTION_WINDOW_SIZE_KB = 32_768;
+// const CONNECTION_WINDOW_SIZE_KB = 64;
 
 const MIB = 1024.0 * 1024.0;
 

--- a/thetadatadx-ts/examples/chain_quote_bench.ts
+++ b/thetadatadx-ts/examples/chain_quote_bench.ts
@@ -1,0 +1,211 @@
+// Full-chain option quote streaming benchmark -- ported from
+// `thetadatadx-rs/examples/chain_quote_bench.rs` (see that file for the
+// semantics this mirrors).
+//
+// Pulls an entire option chain's quote history over the streaming
+// market-data endpoint and reports TTFB, throughput, and an approximate
+// in-memory decoded volume so the effect of the h2 flow-control window
+// sizes can be measured against the live backend.
+//
+// Run with:
+//     npx tsx examples/chain_quote_bench.ts -- [symbol] [expiration] [date] [interval]
+//
+// Args (all optional):
+//   symbol      option root (default SPXW)
+//   expiration  contract expiration YYYYMMDD (default 20260710)
+//   date        history date YYYYMMDD (default = expiration, i.e. a 0DTE pull)
+//   interval    tick | 1s | 1m | ... (default tick)
+//
+// The h2 windows are set on the config before connect via
+// STREAM_WINDOW_SIZE_KB / CONNECTION_WINDOW_SIZE_KB below -- edit those
+// constants and rerun to benchmark different values (both are clamped into
+// [64, 2_097_151] KB at connect). This binding has no post-connect
+// (validated) config read-back, so the constants themselves are printed as
+// the "effective" values every run.
+//
+// Credentials are loaded from $CREDS (default ./creds.txt).
+
+import { Config, Credentials, MarketDataClient } from "thetadatadx-ts";
+
+const USAGE = `usage: chain_quote_bench.ts [symbol] [expiration] [date] [interval]
+       defaults: SPXW 20260710 <expiration> tick
+       date defaults to <expiration> (a 0DTE full-chain pull)
+       h2 windows come from the STREAM_WINDOW_SIZE_KB / CONNECTION_WINDOW_SIZE_KB
+       constants in this file; edit and rerun to test different values
+       credentials from $CREDS (default ./creds.txt)`;
+
+// h2 flow-control windows applied to Config's `setMarketDataStreamWindowSizeKb`
+// / `setMarketDataConnectionWindowSizeKb` before connect. Edit and rerun to
+// benchmark different values; validate/connect clamps both into
+// [64, 2_097_151] KB.
+// const STREAM_WINDOW_SIZE_KB = 8_192;
+const STREAM_WINDOW_SIZE_KB = 64;
+// const CONNECTION_WINDOW_SIZE_KB = 32_768;
+const CONNECTION_WINDOW_SIZE_KB = 64;
+
+const MIB = 1024.0 * 1024.0;
+
+// Decoded in-memory size of a single parsed quote row. The streaming
+// callback only exposes `QuoteTick[]`, so decoded volume is approximated as
+// `rows * QUOTE_TICK_SIZE` -- an in-memory figure, not wire bytes. Mirrors
+// `std::mem::size_of::<QuoteTick>()` in the Rust example (measured 128
+// bytes: `#[repr(C, align(64))]`, 13 fields) so figures are comparable
+// across bindings.
+const QUOTE_TICK_SIZE = 128;
+
+function argOr(args: string[], idx: number, fallback: string): string {
+  return args[idx] ?? fallback;
+}
+
+function humanBytes(n: number): string {
+  const gib = MIB * 1024.0;
+  if (n >= gib) {
+    return `${(n / gib).toFixed(2)} GiB`;
+  }
+  return `${(n / MIB).toFixed(2)} MiB`;
+}
+
+function nowSecs(): bigint {
+  return process.hrtime.bigint();
+}
+
+function secsSince(start: bigint): number {
+  return Number(nowSecs() - start) / 1e9;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.some((a) => a === "-h" || a === "--help")) {
+    console.log(USAGE);
+    return;
+  }
+  if (args.length > 4) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+
+  const symbol = argOr(args, 0, "SPXW");
+  const expiration = argOr(args, 1, "20260710");
+  const date = argOr(args, 2, expiration);
+  const interval = argOr(args, 3, "tick");
+
+  const credsPath = process.env.CREDS ?? "creds.txt";
+  let creds: Credentials;
+  try {
+    creds = Credentials.fromFile(credsPath);
+  } catch (e) {
+    console.error(`creds load failed (${credsPath}): ${e}`);
+    process.exit(1);
+  }
+
+  // production() supplies the defaults; the benchmark constants override the
+  // h2 window knobs before connect, which clamps the applied values into
+  // [64, 2_097_151] KB via validate.
+  const config = Config.production();
+  config.setMarketDataStreamWindowSizeKb(BigInt(STREAM_WINDOW_SIZE_KB));
+  config.setMarketDataConnectionWindowSizeKb(BigInt(CONNECTION_WINDOW_SIZE_KB));
+
+  const connectStart = nowSecs();
+  let client: MarketDataClient;
+  try {
+    client = await MarketDataClient.connect(creds, config);
+  } catch (e) {
+    console.error(`connect failed: ${e}`);
+    process.exit(1);
+  }
+  const connectAuthSecs = secsSince(connectStart);
+
+  // Effective h2 window sizes, so every run is self-documenting. No
+  // post-connect (validated) config read-back exists on this binding, so
+  // the constants are printed as-is; validate clamps both into
+  // [64, 2_097_151] KB at connect.
+  const streamWindowSizeKb = STREAM_WINDOW_SIZE_KB;
+  const connectionWindowSizeKb = CONNECTION_WINDOW_SIZE_KB;
+  console.error(
+    `[bench] effective h2 windows: stream=${streamWindowSizeKb} KB, ` +
+      `connection=${connectionWindowSizeKb} KB`,
+  );
+  console.error(
+    `[bench] streaming option_history_quote ${symbol} exp=${expiration} date=${date} ` +
+      `interval=${interval} strike=* right=both (no deadline)`,
+  );
+
+  let rows = 0;
+  let chunks = 0;
+  let ttfbSecs: number | null = null;
+  let lastLog = nowSecs();
+
+  // Dispatch clock: started immediately before dispatching the stream call
+  // so TTFB excludes connect/auth and measures backend-to-first-chunk latency.
+  const dispatch = nowSecs();
+
+  // A full-day 0DTE pull can run 6-15 minutes; the config default
+  // requestTimeoutSecs (300 s) would kill it, so opt out of any deadline
+  // with timeoutMs: 0 (documented as "no deadline").
+  try {
+    await client.optionHistoryQuoteStream(
+      symbol,
+      expiration,
+      { strike: "*", right: "both", date, interval, timeoutMs: 0 },
+      (chunk) => {
+        const now = nowSecs();
+        if (ttfbSecs === null) {
+          ttfbSecs = secsSince(dispatch);
+        }
+        rows += chunk.length;
+        chunks += 1;
+        // Lightweight liveness so a 10-minute pull is not silent.
+        if (secsSince(lastLog) >= 10.0) {
+          lastLog = now;
+          const secs = Math.max(secsSince(dispatch), Number.EPSILON);
+          const approxMib = (rows * QUOTE_TICK_SIZE) / MIB;
+          console.error(
+            `[bench] +${secs.toFixed(0).padStart(6, " ")}s rows=${rows} chunks=${chunks} ` +
+              `~${approxMib.toFixed(2)} MiB in-mem (${(approxMib / secs).toFixed(2)} MiB/s)`,
+          );
+        }
+      },
+    );
+  } catch (e) {
+    const total = secsSince(dispatch);
+    console.error(`stream failed after ${total.toFixed(1)}s: ${e}`);
+    process.exit(1);
+  }
+
+  const total = secsSince(dispatch);
+  const secs = Math.max(total, Number.EPSILON);
+  const finalTtfbSecs = ttfbSecs ?? 0.0;
+  // Approximate decoded VOLUME (in-memory, not wire): the streaming callback
+  // exposes only parsed rows, so multiply the row count by the decoded row
+  // size. This is a lower bound on RSS (ignores per-row heap) and is
+  // unrelated to the compressed bytes that crossed the h2 window.
+  const approxDecoded = rows * QUOTE_TICK_SIZE;
+
+  // Greppable key=value block on stdout; progress/logs stay on stderr.
+  console.log(`symbol=${symbol}`);
+  console.log(`expiration=${expiration}`);
+  console.log(`date=${date}`);
+  console.log(`interval=${interval}`);
+  console.log(`stream_window_size_kb=${streamWindowSizeKb}`);
+  console.log(`connection_window_size_kb=${connectionWindowSizeKb}`);
+  console.log(`connect_auth_secs=${connectAuthSecs.toFixed(3)}`);
+  console.log(`ttfb_secs=${finalTtfbSecs.toFixed(3)}`);
+  console.log(`total_secs=${secs.toFixed(3)}`);
+  console.log(`rows=${rows}`);
+  console.log(`chunks=${chunks}`);
+  console.log(`rows_per_sec=${(rows / secs).toFixed(1)}`);
+  console.log(`quote_tick_size_bytes=${QUOTE_TICK_SIZE}`);
+  console.log(`approx_decoded_bytes=${approxDecoded}`);
+  console.log(`approx_decoded=${humanBytes(approxDecoded)}`);
+  console.log(`approx_decoded_bytes_per_sec=${(approxDecoded / secs).toFixed(0)}`);
+  console.log(`approx_rate_mib_per_sec=${(approxDecoded / secs / MIB).toFixed(2)}`);
+  console.log(
+    `# approx_decoded* is in-memory volume = rows x QUOTE_TICK_SIZE ` +
+      `(${QUOTE_TICK_SIZE} B); not wire bytes`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -478,6 +478,34 @@ export declare class Config {
    * default at request time rather than disabling the deadline.
    */
   get requestTimeoutSecs(): bigint
+  /**
+   * Set the initial per-stream HTTP/2 flow-control window (in KB) for the
+   * market-data gRPC channel. A larger window raises the throughput ceiling
+   * on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
+   * is clamped into `[64, 2_097_151]` KB at validate/connect time. Default
+   * `1024n` (1 MiB). KB are taken as a `BigInt` for parity with the other
+   * byte/KB-denominated knobs.
+   */
+  setMarketDataStreamWindowSizeKb(kb: bigint): void
+  /**
+   * Current per-stream HTTP/2 flow-control window (KB) for the market-data
+   * gRPC channel (default `1024n`, returned as a `BigInt`).
+   */
+  get marketDataStreamWindowSizeKb(): bigint
+  /**
+   * Set the initial connection-level HTTP/2 flow-control window (in KB) for
+   * the market-data gRPC channel. A larger window raises the throughput
+   * ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+   * The value is clamped into `[64, 2_097_151]` KB at validate/connect
+   * time. Default `8192n` (8 MiB). KB are taken as a `BigInt` for parity
+   * with the other byte/KB-denominated knobs.
+   */
+  setMarketDataConnectionWindowSizeKb(kb: bigint): void
+  /**
+   * Current connection-level HTTP/2 flow-control window (KB) for the
+   * market-data gRPC channel (default `8192n`, returned as a `BigInt`).
+   */
+  get marketDataConnectionWindowSizeKb(): bigint
   /** Current `retry.initial_delay` value (ms, returned as BigInt). */
   get retryInitialDelayMs(): bigint
   /** Current `retry.max_delay` value (ms, returned as BigInt). */

--- a/thetadatadx-ts/index.d.ts
+++ b/thetadatadx-ts/index.d.ts
@@ -483,13 +483,13 @@ export declare class Config {
    * market-data gRPC channel. A larger window raises the throughput ceiling
    * on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
    * is clamped into `[64, 2_097_151]` KB at validate/connect time. Default
-   * `1024n` (1 MiB). KB are taken as a `BigInt` for parity with the other
+   * `8192n` (8 MiB). KB are taken as a `BigInt` for parity with the other
    * byte/KB-denominated knobs.
    */
   setMarketDataStreamWindowSizeKb(kb: bigint): void
   /**
    * Current per-stream HTTP/2 flow-control window (KB) for the market-data
-   * gRPC channel (default `1024n`, returned as a `BigInt`).
+   * gRPC channel (default `8192n`, returned as a `BigInt`).
    */
   get marketDataStreamWindowSizeKb(): bigint
   /**
@@ -497,13 +497,13 @@ export declare class Config {
    * the market-data gRPC channel. A larger window raises the throughput
    * ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
    * The value is clamped into `[64, 2_097_151]` KB at validate/connect
-   * time. Default `8192n` (8 MiB). KB are taken as a `BigInt` for parity
+   * time. Default `16384n` (16 MiB). KB are taken as a `BigInt` for parity
    * with the other byte/KB-denominated knobs.
    */
   setMarketDataConnectionWindowSizeKb(kb: bigint): void
   /**
    * Current connection-level HTTP/2 flow-control window (KB) for the
-   * market-data gRPC channel (default `8192n`, returned as a `BigInt`).
+   * market-data gRPC channel (default `16384n`, returned as a `BigInt`).
    */
   get marketDataConnectionWindowSizeKb(): bigint
   /** Current `retry.initial_delay` value (ms, returned as BigInt). */

--- a/thetadatadx-ts/index.js
+++ b/thetadatadx-ts/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-android-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-ts-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-ts-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-ts-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-ts-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-ts-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-ts-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-ts-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-ts-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-ts-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-ts-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-ts-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-ts-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-ts-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-ts-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-ts-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-ts-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-ts-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-ts-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-ts-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -672,6 +672,66 @@ impl Config {
         Ok(napi::bindgen_prelude::BigInt::from(guard.market_data.request_timeout_secs))
     }
 
+    /// Set the initial per-stream HTTP/2 flow-control window (in KB) for the
+    /// market-data gRPC channel. A larger window raises the throughput ceiling
+    /// on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
+    /// is clamped into `[64, 2_097_151]` KB at validate/connect time. Default
+    /// `1024n` (1 MiB). KB are taken as a `BigInt` for parity with the other
+    /// byte/KB-denominated knobs.
+    #[napi(js_name = "setMarketDataStreamWindowSizeKb")]
+    pub fn set_market_data_stream_window_size_kb(&self, kb: napi::bindgen_prelude::BigInt) -> napi::Result<()> {
+        let value = bigint_to_u64("setMarketDataStreamWindowSizeKb", &kb)?;
+        let value = usize::try_from(value)
+            .map_err(|_| napi::Error::from_reason("value exceeds usize on this platform"))?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.market_data.stream_window_size_kb = value;
+        Ok(())
+    }
+
+    /// Current per-stream HTTP/2 flow-control window (KB) for the market-data
+    /// gRPC channel (default `1024n`, returned as a `BigInt`).
+    #[napi(getter, js_name = "marketDataStreamWindowSizeKb")]
+    pub fn market_data_stream_window_size_kb(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(napi::bindgen_prelude::BigInt::from(guard.market_data.stream_window_size_kb as u64))
+    }
+
+    /// Set the initial connection-level HTTP/2 flow-control window (in KB) for
+    /// the market-data gRPC channel. A larger window raises the throughput
+    /// ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
+    /// The value is clamped into `[64, 2_097_151]` KB at validate/connect
+    /// time. Default `8192n` (8 MiB). KB are taken as a `BigInt` for parity
+    /// with the other byte/KB-denominated knobs.
+    #[napi(js_name = "setMarketDataConnectionWindowSizeKb")]
+    pub fn set_market_data_connection_window_size_kb(&self, kb: napi::bindgen_prelude::BigInt) -> napi::Result<()> {
+        let value = bigint_to_u64("setMarketDataConnectionWindowSizeKb", &kb)?;
+        let value = usize::try_from(value)
+            .map_err(|_| napi::Error::from_reason("value exceeds usize on this platform"))?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.market_data.connection_window_size_kb = value;
+        Ok(())
+    }
+
+    /// Current connection-level HTTP/2 flow-control window (KB) for the
+    /// market-data gRPC channel (default `8192n`, returned as a `BigInt`).
+    #[napi(getter, js_name = "marketDataConnectionWindowSizeKb")]
+    pub fn market_data_connection_window_size_kb(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(napi::bindgen_prelude::BigInt::from(guard.market_data.connection_window_size_kb as u64))
+    }
+
     /// Current `retry.initial_delay` value (ms, returned as BigInt).
     #[napi(getter, js_name = "retryInitialDelayMs")]
     pub fn retry_initial_delay_ms(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {

--- a/thetadatadx-ts/src/_generated/config_accessors.rs
+++ b/thetadatadx-ts/src/_generated/config_accessors.rs
@@ -676,7 +676,7 @@ impl Config {
     /// market-data gRPC channel. A larger window raises the throughput ceiling
     /// on bulk streaming pulls before HTTP/2 backpressure kicks in. The value
     /// is clamped into `[64, 2_097_151]` KB at validate/connect time. Default
-    /// `1024n` (1 MiB). KB are taken as a `BigInt` for parity with the other
+    /// `8192n` (8 MiB). KB are taken as a `BigInt` for parity with the other
     /// byte/KB-denominated knobs.
     #[napi(js_name = "setMarketDataStreamWindowSizeKb")]
     pub fn set_market_data_stream_window_size_kb(&self, kb: napi::bindgen_prelude::BigInt) -> napi::Result<()> {
@@ -692,7 +692,7 @@ impl Config {
     }
 
     /// Current per-stream HTTP/2 flow-control window (KB) for the market-data
-    /// gRPC channel (default `1024n`, returned as a `BigInt`).
+    /// gRPC channel (default `8192n`, returned as a `BigInt`).
     #[napi(getter, js_name = "marketDataStreamWindowSizeKb")]
     pub fn market_data_stream_window_size_kb(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
         let guard = self
@@ -706,7 +706,7 @@ impl Config {
     /// the market-data gRPC channel. A larger window raises the throughput
     /// ceiling on bulk streaming pulls before HTTP/2 backpressure kicks in.
     /// The value is clamped into `[64, 2_097_151]` KB at validate/connect
-    /// time. Default `8192n` (8 MiB). KB are taken as a `BigInt` for parity
+    /// time. Default `16384n` (16 MiB). KB are taken as a `BigInt` for parity
     /// with the other byte/KB-denominated knobs.
     #[napi(js_name = "setMarketDataConnectionWindowSizeKb")]
     pub fn set_market_data_connection_window_size_kb(&self, kb: napi::bindgen_prelude::BigInt) -> napi::Result<()> {
@@ -722,7 +722,7 @@ impl Config {
     }
 
     /// Current connection-level HTTP/2 flow-control window (KB) for the
-    /// market-data gRPC channel (default `8192n`, returned as a `BigInt`).
+    /// market-data gRPC channel (default `16384n`, returned as a `BigInt`).
     #[napi(getter, js_name = "marketDataConnectionWindowSizeKb")]
     pub fn market_data_connection_window_size_kb(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
         let guard = self


### PR DESCRIPTION
## Summary

This change makes it possible for clients to adjust the above values to better utilize the h2 grpc connection.
The provided benchmarks show 40%-60% improvement depending on settings. 

## Changes
- exposes h2 stream_window_size and connection_window_size to client libraries
- raised default settings
- renamed existing `window_size` to `connection_window_size` for clarity


## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Updated `CHANGELOG.md` (if user-facing change)
- [ ] Updated documentation (if public API changed)
- [x] FFI/SDK bindings updated (if core API changed)

## Testing
Provided examples for Rust, Python and JS
`cargo run --release --example chain_quote_bench`
`python examples/chain_quote_bench.py`
`npx tsx examples/chain_quote_bench.ts`
