### PR TITLE
fix(deps): bump js-yaml to 4.3.0 in thetadatadx-ts

### DIFF
--- a/thetadatadx-ts/package-lock.json
+++ b/thetadatadx-ts/package-lock.json
@@ -2168,9 +2168,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
js-yaml 4.2.0 lets a long merge-key (`<<`) chain force quadratic CPU consumption while parsing (CVE-2026-59869); 4.3.0 fixes it. It is a transitive dev dependency via @napi-rs/cli, whose `^4.2.0` range already permits 4.3.0, so this is a lockfile-only bump with no manifest or runtime change. Dev-scope only (the napi build CLI), not shipped in the published package.