### PR TITLE
fix: binding error-surface hardening and 0.4.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - 2026-08-03
+## [0.4.0] - 2026-08-08
 
 ### Removed
 
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **The public API surface is tightened to what the SDK exposes for use.** Internal modules that were reachable by path (`auth` beyond `Credentials`, `backoff` beyond `JitterMode`, `util`) and a few internal decode helpers are now crate-private or hidden from the documented surface. The user-facing types stay exported at the crate root exactly as before (`Credentials`, `JitterMode`), so ordinary code is unaffected; only code that reached into the `auth` or `backoff` module path directly switches to those root re-exports.
-- **Multi-day option-chain pulls now fan the date shard axis out by call/put.** A both-rights chain (`right = "both"`, `strike = "*"`) pulled over a date range shorter than the request pool cut one shard per day and left the rest of the pool idle; it now also splits each date band into a call band and a put band, so more lanes run at once and the pull finishes sooner. The merged rows are exactly the single stream's, in the SDK's canonical chain order (ascending expiration, strike, right). The `ShardBand::Date` band (surfaced only through `Error::PartialShardFetch`) gains a `right` field; code that matches or builds it updates for the new field.
+- **Multi-day option-chain pulls now fan the date shard axis out by call/put.** A both-rights chain (`right = "both"`, `strike = "*"`) pulled over a date range shorter than the request pool cut one shard per day and left the rest of the pool idle; it now also splits each date band into a call band and a put band, so more lanes run at once and the pull finishes sooner. A tick chain is served one day per band, so its date bands split by right only while the resulting call and put single-day bands still fit the request pool. The merged rows are exactly the single stream's, in the SDK's canonical chain order (ascending expiration, strike, right). The `ShardBand::Date` band (surfaced only through `Error::PartialShardFetch`) gains a `right` field; code that matches or builds it updates for the new field.
 
 - **TypeScript date and time arguments take a wire-format string only, not a JS `Date`.** A calendar date (`startDate`, `endDate`, `expiration`) or an intraday time (`startTime`, `endTime`, `timeOfDay`) was accepted either as the `"YYYYMMDD"` / `"HH:MM:SS"` wire string or as a JS `Date`. A `Date` is an instant, not a calendar day, so the SDK rendered it in UTC and shifted the requested day for a caller in a non-UTC zone (`new Date(2024, 0, 1)` in Central Europe queried `20231231`). These parameters now accept the wire-format string exclusively. This is a breaking change to the TypeScript surface; format a `Date` yourself before passing it.
 
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Per-call `timeout_ms = 0` disables the deadline on every endpoint family.** On the Python and TypeScript list endpoints (`option_list_expirations`, `stock_list_symbols`, and the like) a zero `timeout_ms` / `timeoutMs` raced the call against a zero-duration timer and failed immediately, while the history and snapshot endpoints read zero as "no deadline" (matching `with_deadline(Duration::ZERO)`). Zero now means "no per-call deadline" uniformly; any other value runs under the configured request timeout.
 
-- **The TypeScript numeric config setters reject an out-of-range value instead of silently wrapping it.** napi decoded these arguments with V8 `ToUint32`, so `setMaxConcurrentRequests(-1n)` wrapped to `4294967295` and drove a multi-billion-entry pool allocation, `1.5` truncated to `1`, and `2**32` wrapped to `0`. The setters now take the value as a number and reject a non-finite, negative, fractional, or over-`u32` input with `InvalidParameterError`; the port setters keep their `0..=65535` range check on top.
+- **The TypeScript numeric config setters reject an out-of-range value instead of silently wrapping it.** napi decoded these arguments with V8 `ToUint32`, so `setMaxConcurrentRequests(-1)` wrapped to `4294967295` and drove a multi-billion-entry pool allocation, `1.5` truncated to `1`, and `2**32` wrapped to `0`. The setters now take the value as a number and reject a non-finite, negative, fractional, or over-`u32` input with `InvalidParameterError`; the port setters keep their `0..=65535` range check on top.
 
 - **A rejected BigInt config value names its actual cause.** A negative or over-`u64` BigInt passed to a `*Ms` config setter reported "magnitude must fit in u64", which is wrong for a negative value — the magnitude fits, the sign does not. The message now names the cause (a negative sign or an over-`u64` magnitude). The error stays a plain `Error`, matching the built-in `OverflowError` the Python binding raises for the same input.
 
@@ -164,7 +164,8 @@ The SDK ships under per-language package names: `thetadatadx-rs` (crates.io), `t
 - The streaming login wipes the account password from memory the moment the login frame is sent, so the cleartext password is not retained in released heap or a buffered protocol frame after authentication, on the first connect and every reconnect.
 - Authentication errors carry only the HTTP status and never the upstream response body, the auth client does not follow redirects, and session UUIDs are redacted from `Debug` output.
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.4.0
 [0.3.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.3.0
 [0.2.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.2.0
 [0.1.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.1.0

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - 2026-08-03
+## [0.4.0] - 2026-08-08
 
 ### Removed
 
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **The public API surface is tightened to what the SDK exposes for use.** Internal modules that were reachable by path (`auth` beyond `Credentials`, `backoff` beyond `JitterMode`, `util`) and a few internal decode helpers are now crate-private or hidden from the documented surface. The user-facing types stay exported at the crate root exactly as before (`Credentials`, `JitterMode`), so ordinary code is unaffected; only code that reached into the `auth` or `backoff` module path directly switches to those root re-exports.
-- **Multi-day option-chain pulls now fan the date shard axis out by call/put.** A both-rights chain (`right = "both"`, `strike = "*"`) pulled over a date range shorter than the request pool cut one shard per day and left the rest of the pool idle; it now also splits each date band into a call band and a put band, so more lanes run at once and the pull finishes sooner. The merged rows are exactly the single stream's, in the SDK's canonical chain order (ascending expiration, strike, right). The `ShardBand::Date` band (surfaced only through `Error::PartialShardFetch`) gains a `right` field; code that matches or builds it updates for the new field.
+- **Multi-day option-chain pulls now fan the date shard axis out by call/put.** A both-rights chain (`right = "both"`, `strike = "*"`) pulled over a date range shorter than the request pool cut one shard per day and left the rest of the pool idle; it now also splits each date band into a call band and a put band, so more lanes run at once and the pull finishes sooner. A tick chain is served one day per band, so its date bands split by right only while the resulting call and put single-day bands still fit the request pool. The merged rows are exactly the single stream's, in the SDK's canonical chain order (ascending expiration, strike, right). The `ShardBand::Date` band (surfaced only through `Error::PartialShardFetch`) gains a `right` field; code that matches or builds it updates for the new field.
 
 - **TypeScript date and time arguments take a wire-format string only, not a JS `Date`.** A calendar date (`startDate`, `endDate`, `expiration`) or an intraday time (`startTime`, `endTime`, `timeOfDay`) was accepted either as the `"YYYYMMDD"` / `"HH:MM:SS"` wire string or as a JS `Date`. A `Date` is an instant, not a calendar day, so the SDK rendered it in UTC and shifted the requested day for a caller in a non-UTC zone (`new Date(2024, 0, 1)` in Central Europe queried `20231231`). These parameters now accept the wire-format string exclusively. This is a breaking change to the TypeScript surface; format a `Date` yourself before passing it.
 
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Per-call `timeout_ms = 0` disables the deadline on every endpoint family.** On the Python and TypeScript list endpoints (`option_list_expirations`, `stock_list_symbols`, and the like) a zero `timeout_ms` / `timeoutMs` raced the call against a zero-duration timer and failed immediately, while the history and snapshot endpoints read zero as "no deadline" (matching `with_deadline(Duration::ZERO)`). Zero now means "no per-call deadline" uniformly; any other value runs under the configured request timeout.
 
-- **The TypeScript numeric config setters reject an out-of-range value instead of silently wrapping it.** napi decoded these arguments with V8 `ToUint32`, so `setMaxConcurrentRequests(-1n)` wrapped to `4294967295` and drove a multi-billion-entry pool allocation, `1.5` truncated to `1`, and `2**32` wrapped to `0`. The setters now take the value as a number and reject a non-finite, negative, fractional, or over-`u32` input with `InvalidParameterError`; the port setters keep their `0..=65535` range check on top.
+- **The TypeScript numeric config setters reject an out-of-range value instead of silently wrapping it.** napi decoded these arguments with V8 `ToUint32`, so `setMaxConcurrentRequests(-1)` wrapped to `4294967295` and drove a multi-billion-entry pool allocation, `1.5` truncated to `1`, and `2**32` wrapped to `0`. The setters now take the value as a number and reject a non-finite, negative, fractional, or over-`u32` input with `InvalidParameterError`; the port setters keep their `0..=65535` range check on top.
 
 - **A rejected BigInt config value names its actual cause.** A negative or over-`u64` BigInt passed to a `*Ms` config setter reported "magnitude must fit in u64", which is wrong for a negative value — the magnitude fits, the sign does not. The message now names the cause (a negative sign or an over-`u64` magnitude). The error stays a plain `Error`, matching the built-in `OverflowError` the Python binding raises for the same input.
 
@@ -164,7 +164,8 @@ The SDK ships under per-language package names: `thetadatadx-rs` (crates.io), `t
 - The streaming login wipes the account password from memory the moment the login frame is sent, so the cleartext password is not retained in released heap or a buffered protocol frame after authentication, on the first connect and every reconnect.
 - Authentication errors carry only the HTTP status and never the upstream response body, the auth client does not follow redirects, and session UUIDs are redacted from `Debug` output.
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.4.0
 [0.3.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.3.0
 [0.2.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.2.0
 [0.1.0]: https://github.com/userFRM/ThetaDataDx/releases/tag/v0.1.0

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx-docs",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx-docs",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "dependencies": {
         "highlight.js": "11.11.1"
       },

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-docs",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "ThetaDataDx documentation site",

--- a/thetadatadx-cpp/include/thetadatadx.hpp
+++ b/thetadatadx-cpp/include/thetadatadx.hpp
@@ -1164,6 +1164,10 @@ public:
      *  failure the existing `callback_` is left untouched so the
      *  still-live registration keeps pointing at valid storage. */
     void set_callback(std::function<void(const StreamEvent&)> fn) {
+        if (!fn) {
+            throw InvalidParameterError(
+                "set_callback requires a callable target; an empty std::function was passed");
+        }
         auto staged = std::make_unique<std::function<void(const StreamEvent&)>>(std::move(fn));
         int rc = thetadatadx_streaming_set_callback(handle_.get(), &StreamingClient::callback_shim, staged.get());
         if (rc < 0) {
@@ -1201,11 +1205,13 @@ public:
         return handle_ ? thetadatadx_streaming_ring_capacity(handle_.get()) : 0;
     }
 
-    /** Cumulative count of user-callback failures contained by the
-     *  per-invocation isolation boundary since the current stream
-     *  started. If the callback aborts on a given event, the failure is
-     *  contained, recorded here, and does not stop event delivery — the
-     *  next event continues normally. Returns 0 when no callback has been
+    /** Cumulative count of user-callback failures contained by the core's
+     *  per-invocation isolation boundary since the current stream started,
+     *  so one aborting event never stops delivery — the next continues.
+     *  Note the C++ boundary: an exception thrown from your callback is
+     *  caught at the C ABI shim (unwinding across C is undefined behavior)
+     *  and swallowed there, so it does NOT increment this count — handle
+     *  errors inside the callback. Returns 0 when no callback has been
      *  installed yet. Safe to call from any thread without blocking. */
     uint64_t panic_count() const {
         return handle_ ? thetadatadx_streaming_panic_count(handle_.get()) : 0;

--- a/thetadatadx-ffi/src/streaming.rs
+++ b/thetadatadx-ffi/src/streaming.rs
@@ -753,7 +753,10 @@ unsafe fn coerce_subscription(
                 THETADATADX_SUB_KIND_OPEN_INTEREST => SubscriptionKind::OpenInterest,
                 THETADATADX_SUB_KIND_MARKET_VALUE => SubscriptionKind::MarketValue,
                 other => {
-                    set_error(&format!("invalid kind {other}"));
+                    set_error_with_code(
+                        &format!("invalid kind {other}"),
+                        crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                    );
                     return None;
                 }
             };
@@ -809,15 +812,24 @@ unsafe fn coerce_subscription(
                 THETADATADX_SUB_KIND_TRADE => FullSubscriptionKind::Trades,
                 THETADATADX_SUB_KIND_OPEN_INTEREST => FullSubscriptionKind::OpenInterest,
                 THETADATADX_SUB_KIND_QUOTE => {
-                    set_error("full-stream Quote is not a valid subscription");
+                    set_error_with_code(
+                        "full-stream Quote is not a valid subscription",
+                        crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                    );
                     return None;
                 }
                 THETADATADX_SUB_KIND_MARKET_VALUE => {
-                    set_error("full-stream MarketValue is not a valid subscription");
+                    set_error_with_code(
+                        "full-stream MarketValue is not a valid subscription",
+                        crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                    );
                     return None;
                 }
                 other => {
-                    set_error(&format!("invalid kind {other}"));
+                    set_error_with_code(
+                        &format!("invalid kind {other}"),
+                        crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                    );
                     return None;
                 }
             };
@@ -827,16 +839,20 @@ unsafe fn coerce_subscription(
                 "OPTION" => thetadatadx::SecType::Option,
                 "INDEX" => thetadatadx::SecType::Index,
                 other => {
-                    set_error(&format!(
-                        "invalid sec_type {other:?} (expected STOCK, OPTION, INDEX)"
-                    ));
+                    set_error_with_code(
+                        &format!("invalid sec_type {other:?} (expected STOCK, OPTION, INDEX)"),
+                        crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+                    );
                     return None;
                 }
             };
             Some(Subscription::Full { sec_type, kind })
         }
         other => {
-            set_error(&format!("invalid scope {other}"));
+            set_error_with_code(
+                &format!("invalid scope {other}"),
+                crate::error::THETADATADX_ERR_INVALID_PARAMETER,
+            );
             None
         }
     }

--- a/thetadatadx-py/src/lib.rs
+++ b/thetadatadx-py/src/lib.rs
@@ -117,7 +117,14 @@ where
     // this call would wait on. Neither can make progress, so reject it fast
     // with the same guidance the core reentrancy guard gives.
     if in_delivery_handler_thread() {
-        return Err(to_py_err(tick::Error::HandlerReentrancy));
+        // Same type as `to_py_err(HandlerReentrancy)` (base `ThetaDataError`), but
+        // the core's "use a second client" advice is wrong for this thread-scoped guard.
+        return Err(crate::errors::ThetaDataError::new_err(
+            "a synchronous market-data call was made from inside a Python streaming \
+             delivery handler, which would deadlock; issue the request from a \
+             background thread instead (a second client on the delivery thread is \
+             rejected the same way)",
+        ));
     }
     py.detach(|| {
         // VOCAB-OK: tokio Runtime::block_on in PyO3 bridge, not PyO3 allow_threads GIL-hold pattern

--- a/thetadatadx-rs/src/fpss/ring.rs
+++ b/thetadatadx-rs/src/fpss/ring.rs
@@ -504,23 +504,25 @@ mod tests {
     fn backoff_escalates_to_park_after_idle_window_then_resets_on_progress() {
         // Backoff spins while the idle run is short, parks once it crosses
         // the threshold, and returns to spinning after a delivered event.
-        let strat = AdaptiveWaitStrategy::from_mode(WaitMode::Backoff, Duration::from_millis(5));
+        // ponytail: 200 ms park (not 5) so a spin descheduled under load can't
+        // cross the spin/park boundary — the tight 5 ms window flaked ~1/1178.
+        let strat = AdaptiveWaitStrategy::from_mode(WaitMode::Backoff, Duration::from_millis(200));
         let mut w = DrainWaiter::new(strat);
 
         // Pre-threshold: the first empty spins, it does not park.
         let t0 = Instant::now();
         w.on_empty();
         assert!(
-            t0.elapsed() < Duration::from_millis(5),
+            t0.elapsed() < Duration::from_millis(100),
             "a fresh idle run must spin, not park"
         );
 
-        // Let the idle run cross the threshold; the next empty parks.
+        // Let the idle run cross the threshold; the next empty parks (~200 ms).
         thread::sleep(BACKOFF_IDLE_THRESHOLD);
         let t1 = Instant::now();
         w.on_empty();
         assert!(
-            t1.elapsed() >= Duration::from_millis(4),
+            t1.elapsed() >= Duration::from_millis(100),
             "past the idle window, an empty must park"
         );
 
@@ -529,7 +531,7 @@ mod tests {
         let t2 = Instant::now();
         w.on_empty();
         assert!(
-            t2.elapsed() < Duration::from_millis(5),
+            t2.elapsed() < Duration::from_millis(100),
             "after progress, the idle run restarts and spins"
         );
     }

--- a/thetadatadx-rs/src/mdds/shard.rs
+++ b/thetadatadx-rs/src/mdds/shard.rs
@@ -1196,8 +1196,9 @@ pub(crate) type ShardStreamFuture<'a> =
 /// `parsed_endpoint!`) holds no request permit while this runs — each
 /// band future acquires its own, which is what keeps the fan-out
 /// deadlock-free at any pool size (worst case the bands serialize).
-/// Every completion event re-polls the remaining set; the set is capped
-/// by the pool size, so the sweep is noise next to a chunk decode.
+/// Every completion event re-polls the remaining set; the set is bounded
+/// by the band count (in-flight requests stay capped by the pool), so the
+/// sweep is noise next to a chunk decode.
 ///
 /// Mirrors [`join_shards`]: a band the server holds no rows for errors
 /// gRPC `NotFound`, which folds to an empty contribution; only when
@@ -1942,13 +1943,29 @@ mod tests {
             Some("both")
         );
 
-        // A date band never carries a right and never touches contract_spec.
+        // A date band with no right override leaves contract_spec as issued.
         let mut q3 = query();
         let band = &date_band;
         shard_apply_field!(q3, band, contract_spec);
         assert_eq!(
             q3.contract_spec.as_ref().unwrap().right.as_deref(),
             Some("both")
+        );
+
+        // A right-carrying date band (call/put split of a multi-day both-rights
+        // chain) must rewrite contract_spec.right on the wire, like a time band.
+        let put_date_band = ShardBand::Date {
+            start_date: "20260101".into(),
+            end_date: "20260131".into(),
+            right: Some("put".into()),
+        };
+        let mut q4 = query();
+        let band = &put_date_band;
+        shard_apply_field!(q4, band, contract_spec);
+        assert_eq!(
+            q4.contract_spec.as_ref().unwrap().right.as_deref(),
+            Some("put"),
+            "a right-carrying date band must rewrite contract_spec.right on the wire"
         );
     }
 

--- a/thetadatadx-ts/src/lib.rs
+++ b/thetadatadx-ts/src/lib.rs
@@ -537,7 +537,9 @@ pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
     Ok(validate_nonneg_whole(
         "timeoutMs",
         timeout_ms,
-        u64::MAX as f64,
+        // MAX_SAFE_INTEGER: largest f64 with an exact u64. A u64::MAX bound
+        // rounds to 2^64 as f64, so 2**64 would pass it and saturate on the cast.
+        9_007_199_254_740_991.0,
         Some("millisecond"),
     )? as u64)
 }


### PR DESCRIPTION
Correctness and consistency pass across the bindings, plus 0.4.0 changelog finalization, before cutting the release.

- **node:** \`timeoutMs\` is bounded at \`Number.MAX_SAFE_INTEGER\`, closing a saturation where \`2**64\` passed a \`u64::MAX\` bound and cast to \`u64::MAX\`.
- **ffi / cpp:** every malformed subscription argument (scope, kind, full-stream \`sec_type\`) now sets the typed \`INVALID_PARAMETER\` code, so the C++ wrapper raises \`InvalidParameterError\` consistently; \`set_callback\` rejects an empty \`std::function\` instead of silently swallowing every event; the \`panic_count\` doc states the C++ shim swallows callback exceptions.
- **py:** the \`HandlerReentrancy\` error gives binding-correct guidance (issue from a background thread) rather than the core's "second client" advice, which the thread-scoped Python guard rejects too.
- **core:** the shard-apply test covers a right-carrying \`Date\` band and the stale "a date band never carries a right" comment is corrected; the backoff spin/park timing test is stabilized against CPU-load flakiness.
- **docs:** the 0.4.0 changelog is finalized (date, links, example, a tick right-split clause), mirrored into the docs-site copy, and the docs-site package is bumped to 0.4.0.

Local gates green: workspace clippy, core (1504), ffi (99), TypeScript (283, \`index.d.ts\` byte-identical), Python (37 rust), C/C++ header syntax, surface-drift, docs-consistency, version-sync, parity.